### PR TITLE
general: Use std::move where applicable

### DIFF
--- a/source/item_list.hpp
+++ b/source/item_list.hpp
@@ -25,7 +25,12 @@ enum ItemType {
 class Item {
 public:
     Item(std::string name_, ItemType type_, int getItemId_, bool progressive_, bool advancement_, std::function<void()> effect_)
-        : name(name_), type(type_), getItemId(getItemId_), progressive(progressive_), advancement(advancement_), effect(std::move(effect_)) {}
+        : name(std::move(name_)),
+          type(type_),
+          getItemId(getItemId_),
+          progressive(progressive_),
+          advancement(advancement_),
+          effect(std::move(effect_)) {}
 
     void applyEffect() {
         effect();
@@ -39,7 +44,7 @@ public:
         return val;
     }
 
-    const char * getName() {
+    const char * getName() const {
       return name.c_str();
     }
 

--- a/source/item_location.hpp
+++ b/source/item_location.hpp
@@ -19,10 +19,7 @@ enum ItemLocationType {
 class ItemLocation {
 public:
     ItemLocation(u8 scene_, ItemLocationType type_, u8 flag_, std::string name_)
-        : scene(scene_), type(type_), flag(flag_), name(name_) {
-          placedItem = NoItem;
-          used = false;
-        }
+        : scene(scene_), type(type_), flag(flag_), name(std::move(name_)) {}
 
     ItemOverride_Key key() const {
         ItemOverride_Key key;
@@ -52,7 +49,7 @@ private:
     u8 scene;
     ItemLocationType type;
     u8 flag;
-    bool used;
+    bool used = false;
 
 public:
     std::string name;

--- a/source/item_location.hpp
+++ b/source/item_location.hpp
@@ -39,7 +39,7 @@ public:
       return used;
     }
 
-    const char * getName() {
+    const char * getName() const {
       return name.c_str();
     }
 

--- a/source/location_access.hpp
+++ b/source/location_access.hpp
@@ -20,8 +20,8 @@ public:
 
 class ExitPairing {
 public:         //This exit, the conditions needed to access the exit, whether this exit can be accessed at only day/night or both
-    ExitPairing(Exit* exit_, std::function<bool()> ConditionsMet_, std::string ToD = "Both")
-              : exit(std::move(exit_)), ConditionsMet(std::move(ConditionsMet_)) {}
+    ExitPairing(Exit* exit_, std::function<bool()> ConditionsMet_, std::string ToD_ = "Both")
+              : exit(std::move(exit_)), ConditionsMet(std::move(ConditionsMet_)), ToD(std::move(ToD_)) {}
     Exit* exit;
     std::function<bool()> ConditionsMet;
     std::string ToD;

--- a/source/location_access.hpp
+++ b/source/location_access.hpp
@@ -79,17 +79,16 @@ public:
       return events();
     }
 
-    bool CanPlantBean() {
+    bool CanPlantBean() const {
       return (Logic::MagicBean || Logic::MagicBeanPack) && BothAges();
     }
 
-    bool BothAges() {
+    bool BothAges() const {
       return (dayChild || nightChild) && (dayAdult || nightAdult);
     }
 
     //checks to see if all locations and exits are accessible
     bool AllAccountedFor() {
-
       for (auto loc = locations.begin(); loc != locations.end(); loc++) {
         if (!loc->location->isUsed())
           return false;

--- a/source/location_access.hpp
+++ b/source/location_access.hpp
@@ -13,7 +13,7 @@ class Exit;
 class ItemLocationPairing {
 public:
     ItemLocationPairing(ItemLocation* location_, std::function<bool()> ConditionsMet_)
-                        : location(location_), ConditionsMet(ConditionsMet_) {}
+                        : location(location_), ConditionsMet(std::move(ConditionsMet_)) {}
     ItemLocation* location;
     std::function<bool()> ConditionsMet;
 };
@@ -21,7 +21,7 @@ public:
 class ExitPairing {
 public:         //This exit, the conditions needed to access the exit, whether this exit can be accessed at only day/night or both
     ExitPairing(Exit* exit_, std::function<bool()> ConditionsMet_, std::string ToD = "Both")
-              : exit(exit_), ConditionsMet(ConditionsMet_) {}
+              : exit(std::move(exit_)), ConditionsMet(std::move(ConditionsMet_)) {}
     Exit* exit;
     std::function<bool()> ConditionsMet;
     std::string ToD;
@@ -30,7 +30,7 @@ public:         //This exit, the conditions needed to access the exit, whether t
 class AdvancementPairing {
 public:
     AdvancementPairing(Item item_, std::function<bool()> ConditionsMet_, u8 count_ = 1)
-                      :item(item_), ConditionsMet(ConditionsMet_), count(count_) {}
+                      :item(std::move(item_)), ConditionsMet(std::move(ConditionsMet_)), count(count_) {}
     Item item;
     std::function<bool()> ConditionsMet;
     u8 count;
@@ -39,14 +39,14 @@ public:
 class Exit {
 public:
     Exit(std::string regionName_, std::string scene_, std::string hint_, bool timePass_, std::function<bool()> events_, std::vector<ItemLocationPairing> locations_, std::vector<ExitPairing> exits_, std::vector<AdvancementPairing> advancementNeeds_ = {})
-        : regionName(regionName_),      scene(scene_),       hint(hint_), timePass(timePass_),          events(events_),             locations(locations_),         exits(exits_),   advancementNeeds(advancementNeeds_){
-          accountedForChild = false;
-          accountedForAdult = false;
-          dayChild   = false;
-          nightChild = false;
-          dayAdult   = false;
-          nightAdult = false;
-        }
+        : regionName(std::move(regionName_)),
+          scene(std::move(scene_)),
+          hint(std::move(hint_)),
+          timePass(timePass_),
+          events(std::move(events_)),
+          locations(std::move(locations_)),
+          exits(std::move(exits_)),
+          advancementNeeds(std::move(advancementNeeds_)) {}
 
     std::string regionName;
     std::string scene;
@@ -57,12 +57,12 @@ public:
     std::vector<ExitPairing> exits;
     std::vector<AdvancementPairing> advancementNeeds;
 
-    bool accountedForChild;
-    bool accountedForAdult;
-    bool dayChild;
-    bool nightChild;
-    bool dayAdult;
-    bool nightAdult;
+    bool accountedForChild = false;
+    bool accountedForAdult = false;
+    bool dayChild = false;
+    bool nightChild = false;
+    bool dayAdult = false;
+    bool nightAdult = false;
 
     bool UpdateEvents() {
 


### PR DESCRIPTION
Churns memory a little bit less and makes compiling it a tiny bit faster, since no code needs to be generated for numerous would-be copies in location_access.cpp.

Also adds a missing initializer for time of day within ExitPairing's constructor.