### PR TITLE
item_location: Convert some vectors into arrays

### DIFF
--- a/source/item_location.cpp
+++ b/source/item_location.cpp
@@ -488,7 +488,7 @@ ItemLocation Twinrova                                     = ItemLocation(0xFF, I
 ItemLocation BongoBongo                                   = ItemLocation(0xFF, ITEMLOCATIONTYPE_TEMPLE_REWARD, 0xFF, "Bongo Bongo",                                      {});
 
 //key requirements for placing randomized keys and other items in dungeons
-std::vector<ItemLocationKeyPairing> DekuTreeKeyRequirements = {
+const std::array<ItemLocationKeyPairing, 10> DekuTreeKeyRequirements{{
   ItemLocationKeyPairing(&DekuTree_MapChest,               0),
   ItemLocationKeyPairing(&DekuTree_CompassChest,           0),
   ItemLocationKeyPairing(&DekuTree_CompassRoomSideChest,   0),
@@ -499,8 +499,8 @@ std::vector<ItemLocationKeyPairing> DekuTreeKeyRequirements = {
   ItemLocationKeyPairing(&DekuTree_GS_BasementVines,       0),
   ItemLocationKeyPairing(&DekuTree_GS_BasementGate,        0),
   ItemLocationKeyPairing(&DekuTree_GS_BasementBackRoom,    0),
-};
-std::vector<ItemLocationKeyPairing> DodongosCavernKeyRequirements = {
+}};
+const std::array<ItemLocationKeyPairing, 11> DodongosCavernKeyRequirements{{
   ItemLocationKeyPairing(&DodongosCavern_MapChest,                     0),
   ItemLocationKeyPairing(&DodongosCavern_CompassChest,                 0),
   ItemLocationKeyPairing(&DodongosCavern_GS_SideRoomNearLowerLizalfos, 0),
@@ -512,8 +512,8 @@ std::vector<ItemLocationKeyPairing> DodongosCavernKeyRequirements = {
   ItemLocationKeyPairing(&DodongosCavern_GS_AlcoveAboveStairs,         0),
   ItemLocationKeyPairing(&DodongosCavern_BossRoomChest,                0),
   ItemLocationKeyPairing(&DodongosCavern_GS_BackRoom,                  0),
-};
-std::vector<ItemLocationKeyPairing> JabuJabusBellyKeyRequirements = {
+}};
+const std::array<ItemLocationKeyPairing, 7> JabuJabusBellyKeyRequirements{{
   ItemLocationKeyPairing(&JabuJabusBelly_BoomerangChest,        0),
   ItemLocationKeyPairing(&JabuJabusBelly_MapChest,              0),
   ItemLocationKeyPairing(&JabuJabusBelly_CompassChest,          0),
@@ -521,8 +521,8 @@ std::vector<ItemLocationKeyPairing> JabuJabusBellyKeyRequirements = {
   ItemLocationKeyPairing(&JabuJabusBelly_GS_LobbyBasementLower, 0),
   ItemLocationKeyPairing(&JabuJabusBelly_GS_LobbyBasementUpper, 0),
   ItemLocationKeyPairing(&JabuJabusBelly_GS_NearBoss,           0),
-};
-std::vector<ItemLocationKeyPairing> ForestTempleKeyRequirements = {
+}};
+const std::array<ItemLocationKeyPairing, 18> ForestTempleKeyRequirements{{
   ItemLocationKeyPairing(&ForestTemple_FirstRoomChest,             0),
   ItemLocationKeyPairing(&ForestTemple_FirstStalfosChest,          0),
   ItemLocationKeyPairing(&ForestTemple_GS_FirstRoom,               0),
@@ -541,8 +541,8 @@ std::vector<ItemLocationKeyPairing> ForestTempleKeyRequirements = {
   ItemLocationKeyPairing(&ForestTemple_FallingCeilingRoomChest,    5),
   ItemLocationKeyPairing(&ForestTemple_BasementChest,              5),
   ItemLocationKeyPairing(&ForestTemple_GS_Basement,                5),
-};
-std::vector<ItemLocationKeyPairing> FireTempleKeyRequirements = {
+}};
+const std::array<ItemLocationKeyPairing, 19> FireTempleKeyRequirements{{
   ItemLocationKeyPairing(&FireTemple_NearBossChest,                 0),
   ItemLocationKeyPairing(&FireTemple_FlareDancerChest,              0),
   ItemLocationKeyPairing(&FireTemple_BossKeyChest,                  0),
@@ -562,8 +562,8 @@ std::vector<ItemLocationKeyPairing> FireTempleKeyRequirements = {
   ItemLocationKeyPairing(&FireTemple_GS_ScarecrowTop,               6),
   ItemLocationKeyPairing(&FireTemple_HighestGoronChest,             7),
   ItemLocationKeyPairing(&FireTemple_MegatonHammerChest,            7),
-};
-std::vector<ItemLocationKeyPairing> WaterTempleKeyRequirements = {
+}};
+const std::array<ItemLocationKeyPairing, 15> WaterTempleKeyRequirements{{
   ItemLocationKeyPairing(&WaterTemple_MapChest,               0),
   ItemLocationKeyPairing(&WaterTemple_CompassChest,           0),
   ItemLocationKeyPairing(&WaterTemple_TorchesChest,           0),
@@ -579,8 +579,8 @@ std::vector<ItemLocationKeyPairing> WaterTempleKeyRequirements = {
   ItemLocationKeyPairing(&WaterTemple_RiverChest,             5),
   ItemLocationKeyPairing(&WaterTemple_GS_River,               5),
   ItemLocationKeyPairing(&WaterTemple_BossKeyChest,           5), //FIX WHEN ADDING MORPHA HC
-};
-std::vector<ItemLocationKeyPairing> SpiritTempleKeyRequirements = {
+}};
+const std::array<ItemLocationKeyPairing, 25> SpiritTempleKeyRequirements{{
   ItemLocationKeyPairing(&SpiritTemple_ChildBridgeChest,           0),
   ItemLocationKeyPairing(&SpiritTemple_ChildEarlyTorchesChest,     0),
   ItemLocationKeyPairing(&SpiritTemple_GS_MetalFence,              0),
@@ -606,8 +606,8 @@ std::vector<ItemLocationKeyPairing> SpiritTempleKeyRequirements = {
   ItemLocationKeyPairing(&SpiritTemple_HallwayRightInvisibleChest, 4),
   ItemLocationKeyPairing(&SpiritTemple_BossKeyChest,               5),
   ItemLocationKeyPairing(&SpiritTemple_TopmostChest,               5),
-};
-std::vector<ItemLocationKeyPairing> ShadowTempleKeyRequirements = {
+}};
+const std::array<ItemLocationKeyPairing, 22> ShadowTempleKeyRequirements = {
   ItemLocationKeyPairing(&ShadowTemple_MapChest,                      0),
   ItemLocationKeyPairing(&ShadowTemple_HoverBootsChest,               0),
   ItemLocationKeyPairing(&ShadowTemple_CompassChest,                  0),
@@ -631,7 +631,7 @@ std::vector<ItemLocationKeyPairing> ShadowTempleKeyRequirements = {
   ItemLocationKeyPairing(&ShadowTemple_InvisibleFloormasterChest,     4),
   ItemLocationKeyPairing(&ShadowTemple_GS_TripleGiantPot,             4),
 };
-std::vector<ItemLocationKeyPairing> BottomOfTheWellKeyRequirements = {
+const std::array<ItemLocationKeyPairing, 17> BottomOfTheWellKeyRequirements{{
   ItemLocationKeyPairing(&BottomOfTheWell_FrontLeftFakeWallChest,   0),
   ItemLocationKeyPairing(&BottomOfTheWell_FrontCenterBombableChest, 0),
   ItemLocationKeyPairing(&BottomOfTheWell_RightBottomFakeWallChest, 0),
@@ -649,8 +649,8 @@ std::vector<ItemLocationKeyPairing> BottomOfTheWellKeyRequirements = {
   ItemLocationKeyPairing(&BottomOfTheWell_GS_WestInnerRoom,         3),
   ItemLocationKeyPairing(&BottomOfTheWell_GS_EastInnerRoom,         3),
   ItemLocationKeyPairing(&BottomOfTheWell_GS_LikeLikeCage,          3),
-};
-std::vector<ItemLocationKeyPairing> IceCavernKeyRequirements = {
+}};
+const std::array<ItemLocationKeyPairing, 7> IceCavernKeyRequirements = {
   ItemLocationKeyPairing(&IceCavern_MapChest,              0),
   ItemLocationKeyPairing(&IceCavern_CompassChest,          0),
   ItemLocationKeyPairing(&IceCavern_IronBootsChest,        0),
@@ -659,7 +659,7 @@ std::vector<ItemLocationKeyPairing> IceCavernKeyRequirements = {
   ItemLocationKeyPairing(&IceCavern_GS_HeartPieceRoom,     0),
   ItemLocationKeyPairing(&IceCavern_GS_PushBlockRoom,      0),
 };
-std::vector<ItemLocationKeyPairing> GerudoTrainingGroundsKeyRequirements = {
+const std::array<ItemLocationKeyPairing, 22> GerudoTrainingGroundsKeyRequirements = {
   ItemLocationKeyPairing(&GerudoTrainingGrounds_LobbyLeftChest,             0),
   ItemLocationKeyPairing(&GerudoTrainingGrounds_LobbyRightChest,            0),
   ItemLocationKeyPairing(&GerudoTrainingGrounds_StalfosChest,               0),
@@ -683,7 +683,7 @@ std::vector<ItemLocationKeyPairing> GerudoTrainingGroundsKeyRequirements = {
   ItemLocationKeyPairing(&GerudoTrainingGrounds_MazePathThirdChest,         7),
   ItemLocationKeyPairing(&GerudoTrainingGrounds_MazePathFinalChest,         9),
 };
-std::vector<ItemLocationKeyPairing> GanonsCastleKeyRequirements = {
+const std::array<ItemLocationKeyPairing, 15> GanonsCastleKeyRequirements{{
   ItemLocationKeyPairing(&GanonsCastle_ForestTrialChest,                0),
   ItemLocationKeyPairing(&GanonsCastle_WaterTrialLeftChest,             0),
   ItemLocationKeyPairing(&GanonsCastle_WaterTrialRightChest,            0),
@@ -699,9 +699,9 @@ std::vector<ItemLocationKeyPairing> GanonsCastleKeyRequirements = {
   ItemLocationKeyPairing(&GanonsCastle_LightTrialThirdRightChest,       0),
   ItemLocationKeyPairing(&GanonsCastle_LightTrialInvisibleEnemiesChest, 0),
   ItemLocationKeyPairing(&GanonsCastle_LightTrialLullabyChest,          1),
-};
+}};
 
-std::vector<ItemLocation *> allLocations = {
+const std::array<ItemLocation*, 334> allLocations{
   &KF_KokiriSwordChest,
   &KF_MidoTopLeftChest,
   &KF_MidoTopRightChest,

--- a/source/item_location.hpp
+++ b/source/item_location.hpp
@@ -1,9 +1,12 @@
 #pragma once
-#include <functional>
-#include <vector>
-#include <unistd.h>
+
+#include <array>
 #include <cstdio>
+#include <functional>
 #include <string>
+#include <unistd.h>
+#include <vector>
+
 #include "../code/include/z3D/z3D.h"
 #include "../code/src/item_override.h"
 #include "item_list.hpp"
@@ -62,7 +65,7 @@ public:
 
 class ItemLocationKeyPairing {
 public:
-  ItemLocationKeyPairing(ItemLocation* loc_, u8 keysRequired_)
+  constexpr ItemLocationKeyPairing(ItemLocation* loc_, u8 keysRequired_)
   : loc(loc_), keysRequired(keysRequired_) {}
 
   ItemLocation* loc;
@@ -565,17 +568,17 @@ extern ItemLocation Twinrova;
 extern ItemLocation Morpha;
 extern ItemLocation BongoBongo;
 
-extern std::vector<ItemLocationKeyPairing> DekuTreeKeyRequirements;
-extern std::vector<ItemLocationKeyPairing> DodongosCavernKeyRequirements;
-extern std::vector<ItemLocationKeyPairing> JabuJabusBellyKeyRequirements;
-extern std::vector<ItemLocationKeyPairing> ForestTempleKeyRequirements;
-extern std::vector<ItemLocationKeyPairing> FireTempleKeyRequirements;
-extern std::vector<ItemLocationKeyPairing> WaterTempleKeyRequirements;
-extern std::vector<ItemLocationKeyPairing> SpiritTempleKeyRequirements;
-extern std::vector<ItemLocationKeyPairing> ShadowTempleKeyRequirements;
-extern std::vector<ItemLocationKeyPairing> BottomOfTheWellKeyRequirements;
-extern std::vector<ItemLocationKeyPairing> IceCavernKeyRequirements;
-extern std::vector<ItemLocationKeyPairing> GerudoTrainingGroundsKeyRequirements;
-extern std::vector<ItemLocationKeyPairing> GanonsCastleKeyRequirements;
+extern const std::array<ItemLocationKeyPairing, 10> DekuTreeKeyRequirements;
+extern const std::array<ItemLocationKeyPairing, 11> DodongosCavernKeyRequirements;
+extern const std::array<ItemLocationKeyPairing, 7>  JabuJabusBellyKeyRequirements;
+extern const std::array<ItemLocationKeyPairing, 18> ForestTempleKeyRequirements;
+extern const std::array<ItemLocationKeyPairing, 19> FireTempleKeyRequirements;
+extern const std::array<ItemLocationKeyPairing, 15> WaterTempleKeyRequirements;
+extern const std::array<ItemLocationKeyPairing, 25> SpiritTempleKeyRequirements;
+extern const std::array<ItemLocationKeyPairing, 22> ShadowTempleKeyRequirements;
+extern const std::array<ItemLocationKeyPairing, 17> BottomOfTheWellKeyRequirements;
+extern const std::array<ItemLocationKeyPairing, 7>  IceCavernKeyRequirements;
+extern const std::array<ItemLocationKeyPairing, 22> GerudoTrainingGroundsKeyRequirements;
+extern const std::array<ItemLocationKeyPairing, 15> GanonsCastleKeyRequirements;
 
-extern std::vector<ItemLocation *> allLocations;
+extern const std::array<ItemLocation*, 334> allLocations;

--- a/source/playthrough.cpp
+++ b/source/playthrough.cpp
@@ -23,13 +23,12 @@ void erase_if(std::vector<T>& vector, Predicate pred) {
 }
 
 namespace Playthrough {
-
     //static int debug = 0;
 
     static u32 totalItemsPlaced = 0;
     static std::vector<ItemLocation *> AccessibleLocationPool;
 
-    void PlaceItemInLocation(Item* item, ItemLocation* loc, std::set<ItemOverride, ItemOverride_Compare>& overrides, bool applyEffectImmediately = true) {
+    static void PlaceItemInLocation(Item* item, ItemLocation* loc, std::set<ItemOverride, ItemOverride_Compare>& overrides, bool applyEffectImmediately = true) {
         // put item in the override table
         ItemOverride override;
         override.key.all = 0;
@@ -40,7 +39,11 @@ namespace Playthrough {
 
         overrides.insert(override);
 
-        PlacementLog_Msg("\n"); PlacementLog_Msg(item->getName()); PlacementLog_Msg(" placed at "); PlacementLog_Msg(loc->getName()); PlacementLog_Msg("\n\n");
+        PlacementLog_Msg("\n");
+        PlacementLog_Msg(item->getName());
+        PlacementLog_Msg(" placed at ");
+        PlacementLog_Msg(loc->getName());
+        PlacementLog_Msg("\n\n");
 
         if (applyEffectImmediately) {
           item->applyEffect();
@@ -51,6 +54,32 @@ namespace Playthrough {
         totalItemsPlaced++;
         printf("\x1b[10;10HPlacing Items");
         printf("\x1b[11;10H%lu\n", totalItemsPlaced);
+    }
+
+    template <typename Container>
+    static void RandomizeDungeonKeys(const Container& KeyRequirements, Item* smallKeyItem, u8 maxKeys, std::set<ItemOverride, ItemOverride_Compare>& overrides) {
+      for (size_t i = 0; i < maxKeys; i++) {
+        std::vector<ItemLocation *> dungeonPool;
+        for (const ItemLocationKeyPairing& ilkp : KeyRequirements) {
+          if (ilkp.keysRequired <= i && ilkp.loc->placedItem.name == "No Item") {
+            dungeonPool.push_back(ilkp.loc);
+          }
+        }
+        const u32 locIdx = Random() % dungeonPool.size();
+        PlaceItemInLocation(smallKeyItem, dungeonPool[locIdx], overrides, false);
+      }
+    }
+
+    template <typename Container>
+    static void RandomizeDungeonItem(const Container& dungeonLocations, Item* item, std::set<ItemOverride, ItemOverride_Compare>& overrides) {
+      std::vector<ItemLocation *> dungeonPool;
+      for (const ItemLocationKeyPairing& ilkp : dungeonLocations) {
+        if (ilkp.loc->placedItem.name == "No Item") {
+          dungeonPool.push_back(ilkp.loc);
+        }
+      }
+      const u32 locIdx = Random() % dungeonPool.size();
+      PlaceItemInLocation(item, dungeonPool[locIdx], overrides, false);
     }
 
     void UpdateToDAccess(Exit* exit, u8 age, ExitPairing::Time ToD) {
@@ -237,58 +266,8 @@ namespace Playthrough {
         return 1;
     }
 
-    static void Playthrough_Init(u32 seed, std::set<ItemOverride, ItemOverride_Compare>& overrides) {
-        Random_Init(seed); //seed goes here
-        Settings::UpdateSettings();
-        Settings::PrintSettings();
-        Logic::UpdateHelpers();
-        totalItemsPlaced = 0;
-        GenerateItemPool();
-        UpdateSetItems();
-        PlaceSetItems(overrides);
-        AccessibleLocations_Init(overrides);
-    }
-
-    int Fill(int settings, u32 seed, std::set<ItemOverride, ItemOverride_Compare>& overrides) {
-        (void)settings;
-
-        Playthrough_Init(seed, overrides);
-        /*
-        while (not all locations accessible)
-          - Determine which items can be placed for advancement
-          - Choose randomly from that list for placement
-          - Update accessibility and items that can be used for advancement
-          - Otherwise place a random item
-
-        */
-        while ((!ItemPool.empty() || !AdvancementItemPool.empty()) && !AccessibleLocationPool.empty()) {
-            int ret;
-            if (!AdvancementItemPool.empty()) {
-              ret = PlaceAdvancementItem(overrides);
-            } else {
-              ret = PlaceRandomItem(overrides);
-            }
-
-            if (ret < 0) {
-                return ret;
-            }
-
-            if (ItemPool.empty() && !AccessibleLocationPool.empty()) {
-              AddGreenRupee();
-            }
-
-        }
-        //printf("Items Placed: %lu\n", totalItemsPlaced);
-        bool rv = SpoilerLog_Write();
-        if (rv) printf("Wrote Spoiler Log\n");
-        else    printf("failed to write log\n");
-
-        rv = PlacementLog_Write();
-        return 1;
-    }
-
     //Check for specific preset items in locations
-    void PlaceSetItems(std::set<ItemOverride, ItemOverride_Compare>& overrides) {
+    static void PlaceSetItems(std::set<ItemOverride, ItemOverride_Compare>& overrides) {
       const bool NO_EFFECT = false;
 
       PlaceItemInLocation(&A_ZeldasLetter,    &HC_ZeldasLetter, overrides, NO_EFFECT);
@@ -579,28 +558,53 @@ namespace Playthrough {
       }
     }
 
-    void RandomizeDungeonKeys(std::vector<ItemLocationKeyPairing> KeyRequirements, Item* smallKeyItem, u8 maxKeys, std::set<ItemOverride, ItemOverride_Compare>& overrides) {
-      for (int i = 0; i < maxKeys; i++) {
-        std::vector<ItemLocation *> dungeonPool = {};
-        for (ItemLocationKeyPairing ilkp : KeyRequirements) {
-          if (ilkp.keysRequired <= i && ilkp.loc->placedItem.name == "No Item") {
-            dungeonPool.push_back(ilkp.loc);
-          }
-        }
-        u8 locIdx = Random() % dungeonPool.size();
-        PlaceItemInLocation(smallKeyItem, dungeonPool[locIdx], overrides, false);
-      }
+    static void Playthrough_Init(u32 seed, std::set<ItemOverride, ItemOverride_Compare>& overrides) {
+        Random_Init(seed); //seed goes here
+        Settings::UpdateSettings();
+        Settings::PrintSettings();
+        Logic::UpdateHelpers();
+        totalItemsPlaced = 0;
+        GenerateItemPool();
+        UpdateSetItems();
+        PlaceSetItems(overrides);
+        AccessibleLocations_Init(overrides);
     }
 
-    void RandomizeDungeonItem(std::vector<ItemLocationKeyPairing> dungeonLocations, Item* item, std::set<ItemOverride, ItemOverride_Compare>& overrides) {
-      std::vector<ItemLocation *> dungeonPool = {};
-      for (ItemLocationKeyPairing ilkp : dungeonLocations) {
-        if (ilkp.loc->placedItem.name == "No Item") {
-          dungeonPool.push_back(ilkp.loc);
-        }
-      }
-      u8 locIdx = Random() % dungeonPool.size();
-      PlaceItemInLocation(item, dungeonPool[locIdx], overrides, false);
-    }
+    int Fill(int settings, u32 seed, std::set<ItemOverride, ItemOverride_Compare>& overrides) {
+        (void)settings;
 
+        Playthrough_Init(seed, overrides);
+        /*
+        while (not all locations accessible)
+          - Determine which items can be placed for advancement
+          - Choose randomly from that list for placement
+          - Update accessibility and items that can be used for advancement
+          - Otherwise place a random item
+
+        */
+        while ((!ItemPool.empty() || !AdvancementItemPool.empty()) && !AccessibleLocationPool.empty()) {
+            int ret;
+            if (!AdvancementItemPool.empty()) {
+              ret = PlaceAdvancementItem(overrides);
+            } else {
+              ret = PlaceRandomItem(overrides);
+            }
+
+            if (ret < 0) {
+                return ret;
+            }
+
+            if (ItemPool.empty() && !AccessibleLocationPool.empty()) {
+              AddGreenRupee();
+            }
+
+        }
+        //printf("Items Placed: %lu\n", totalItemsPlaced);
+        bool rv = SpoilerLog_Write();
+        if (rv) printf("Wrote Spoiler Log\n");
+        else    printf("failed to write log\n");
+
+        rv = PlacementLog_Write();
+        return 1;
+    }
 }

--- a/source/playthrough.hpp
+++ b/source/playthrough.hpp
@@ -17,7 +17,4 @@ namespace Playthrough {
     };
 
     int  Fill(int settings, u32 seed, std::set<ItemOverride, ItemOverride_Compare>& overrides);
-    void PlaceSetItems(std::set<ItemOverride, ItemOverride_Compare>& overrides);
-    void RandomizeDungeonKeys(std::vector<ItemLocationKeyPairing> KeyRequirements, Item* smallKeyItem, u8 maxKeys, std::set<ItemOverride, ItemOverride_Compare>& overrides);
-    void RandomizeDungeonItem(std::vector<ItemLocationKeyPairing> KeyRequirements, Item* item, std::set<ItemOverride, ItemOverride_Compare>& overrides);
 }


### PR DESCRIPTION
Gets rid of a few unnecessary allocations and places everything in lookup tables in the executable rather than the heap.