### PR TITLE
spoiler_log: Make use of std::string_view

### DIFF
--- a/source/item_list.hpp
+++ b/source/item_list.hpp
@@ -43,8 +43,8 @@ public:
         return val;
     }
 
-    const char * getName() const {
-      return name.c_str();
+    std::string_view getName() const {
+      return name;
     }
 
     std::string name;

--- a/source/item_location.hpp
+++ b/source/item_location.hpp
@@ -44,8 +44,8 @@ public:
       return used;
     }
 
-    const char * getName() const {
-      return name.c_str();
+    std::string_view getName() const {
+      return name;
     }
 
 private:

--- a/source/playthrough.cpp
+++ b/source/playthrough.cpp
@@ -160,7 +160,10 @@ namespace Playthrough {
 
                 //If the exit is accessible, but not in the exit pool, add it
                 if (exit->HasAccess() && !exit->addedToPool) {
-                  PlacementLog_Msg("NEW EXIT FOUND: "); PlacementLog_Msg(exit->regionName.c_str()); PlacementLog_Msg("\n");
+                  PlacementLog_Msg("NEW EXIT FOUND: ");
+                  PlacementLog_Msg(exit->regionName);
+                  PlacementLog_Msg("\n");
+
                   Exits::ExitPool.push_back(exit);
                   exit->addedToPool = true;
                 }
@@ -173,7 +176,9 @@ namespace Playthrough {
               ItemLocation *location = locPair.location;
 
               if (locPair.ConditionsMet() && !location->addedToPool) {
-                PlacementLog_Msg("NEW LOCATION FOUND: "); PlacementLog_Msg(location->getName());
+                PlacementLog_Msg("NEW LOCATION FOUND: ");
+                PlacementLog_Msg(location->getName());
+
                 location->addedToPool = true;
 
                 if (location->placedItem.name == "No Item") {
@@ -226,7 +231,7 @@ namespace Playthrough {
         Exits::ExitPool.push_back(&Exits::Root);
       } else if (Settings::Logic == LOGIC_NONE) {
         Exits::ExitPool.clear();
-        AccessibleLocationPool = allLocations;
+        AccessibleLocationPool.assign(allLocations.begin(), allLocations.end());
       }
 
       AccessibleLocations_Update(overrides);

--- a/source/spoiler_log.cpp
+++ b/source/spoiler_log.cpp
@@ -2,69 +2,92 @@
 #include "item_location.hpp"
 #include "item_list.hpp"
 #include "settings.hpp"
-#include <stdio.h>
-#include <stdlib.h>
-#include <string.h>
+
 #include <3ds.h>
-#include <set>
+#include <cstdio>
+#include <cstdlib>
 #include <cstring>
-#include <vector>
+#include <set>
 #include <string>
+#include <vector>
 
-int LONGEST_LINE = 53;
-
-Result res = 0;
+namespace {
 FS_Archive sdmcArchive = 0;
 Handle spoilerlog;
 Handle placementlog;
-u32 bytesWritten = 0;
-u32 totalRW = 0;
 
-std::string logtxt = "";
-std::string placementtxt = "";
+std::string logtxt;
+std::string placementtxt;
+}
 
-void SpoilerLog_SaveLocation(const char *loc, const char *item) {
+static void SpoilerLog_SaveLocation(std::string_view loc, std::string_view item) {
   logtxt += loc;
   logtxt += ": ";
 
-  //formatting for spoiler log (there's probably an easier way to do this)
-  u8 remainingSpaces = LONGEST_LINE - (strlen(loc));
-  for (u8 i = 0; i < remainingSpaces; i++) {
-    logtxt += " ";
-  }
+  // Formatting for spoiler log
+  constexpr u32 LONGEST_LINE = 53;
+  const auto remainingSpaces = LONGEST_LINE - loc.size();
+  logtxt.append(remainingSpaces, ' ');
 
   logtxt += item;
-  logtxt += "\n";
+  logtxt += '\n';
+}
+
+static auto GetSeedPath() {
+  return "/3ds/" + Settings::seed + "-spoilerlog.txt";
 }
 
 bool SpoilerLog_Write() {
-
   logtxt += "Seed: " + Settings::seed + "\n\n";
 
-  for (auto loc = allLocations.begin(); loc != allLocations.end(); loc++) {
-    SpoilerLog_SaveLocation((*loc)->getName(), (*loc)->placedItem.getName());
+  for (const auto* location : allLocations) {
+    SpoilerLog_SaveLocation(location->getName(), location->placedItem.getName());
   }
 
-  //Open SD archive
-  if (!R_SUCCEEDED(res = FSUSER_OpenArchive(&sdmcArchive, ARCHIVE_SDMC, fsMakePath(PATH_EMPTY, "")))) return false;
-  //Open spoilerlog.txt
-  if (!R_SUCCEEDED(res = FSUSER_OpenFile(&spoilerlog, sdmcArchive, fsMakePath(PATH_ASCII, ("/3ds/"+Settings::seed+"-spoilerlog.txt").c_str()), FS_OPEN_WRITE | FS_OPEN_CREATE, 0))) return false;
-  //write to spoilerlog.txt
-  if (!R_SUCCEEDED(res = FSFILE_Write(spoilerlog, &bytesWritten, totalRW, logtxt.c_str(), strlen(logtxt.c_str()), FS_WRITE_FLUSH))) return false;
+  Result res = 0;
+  u32 bytesWritten = 0;
+
+  // Open SD archive
+  if (!R_SUCCEEDED(res = FSUSER_OpenArchive(&sdmcArchive, ARCHIVE_SDMC, fsMakePath(PATH_EMPTY, "")))) {
+    return false;
+  }
+
+  // Open spoilerlog.txt
+  if (!R_SUCCEEDED(res = FSUSER_OpenFile(&spoilerlog, sdmcArchive, fsMakePath(PATH_ASCII, GetSeedPath().c_str()), FS_OPEN_WRITE | FS_OPEN_CREATE, 0))) {
+    return false;
+  }
+
+  // Write to spoilerlog.txt
+  if (!R_SUCCEEDED(res = FSFILE_Write(spoilerlog, &bytesWritten, 0, logtxt.c_str(), strlen(logtxt.c_str()), FS_WRITE_FLUSH))) {
+    return false;
+  }
+
   return true;
 }
 
-void PlacementLog_Msg(const char *msg) {
+void PlacementLog_Msg(std::string_view msg) {
   placementtxt += msg;
 }
 
 bool PlacementLog_Write() {
+  Result res = 0;
+  u32 bytesWritten = 0;
 
   //Open SD archive
-  if (!R_SUCCEEDED(res = FSUSER_OpenArchive(&sdmcArchive, ARCHIVE_SDMC, fsMakePath(PATH_EMPTY, "")))) return false;
+  if (!R_SUCCEEDED(res = FSUSER_OpenArchive(&sdmcArchive, ARCHIVE_SDMC, fsMakePath(PATH_EMPTY, "")))) {
+    return false;
+  }
+
   //Open placementlog.txt
-  if (!R_SUCCEEDED(res = FSUSER_OpenFile(&placementlog, sdmcArchive, fsMakePath(PATH_ASCII, ("/3ds/"+Settings::seed+"-placementlog.txt").c_str()), FS_OPEN_WRITE | FS_OPEN_CREATE, 0))) return false;
+  const auto seed_path = "/3ds/" + Settings::seed + "-placementlog.txt";
+  if (!R_SUCCEEDED(res = FSUSER_OpenFile(&placementlog, sdmcArchive, fsMakePath(PATH_ASCII, GetSeedPath().c_str()), FS_OPEN_WRITE | FS_OPEN_CREATE, 0))) {
+    return false;
+  }
+
   //write to placementlog.txt
-  if (!R_SUCCEEDED(res = FSFILE_Write(placementlog, &bytesWritten, totalRW, placementtxt.c_str(), strlen(placementtxt.c_str()), FS_WRITE_FLUSH))) return false;
+  if (!R_SUCCEEDED(res = FSFILE_Write(placementlog, &bytesWritten, 0, placementtxt.c_str(), placementtxt.size(), FS_WRITE_FLUSH))) {
+    return false;
+  }
+
   return true;
 }

--- a/source/spoiler_log.hpp
+++ b/source/spoiler_log.hpp
@@ -1,7 +1,8 @@
 #pragma once
-#include "item_location.hpp"
 
-extern void SpoilerLog_SaveLocation(const char *loc, const char *item);
-extern bool SpoilerLog_Write();
-extern void PlacementLog_Msg(const char *msg);
-extern bool PlacementLog_Write();
+#include <string_view>
+
+bool SpoilerLog_Write();
+
+void PlacementLog_Msg(std::string_view msg);
+bool PlacementLog_Write();


### PR DESCRIPTION
Same behavior, minus the need to call .c_str() or take the lengths of strings that we already know the length of.

Makes writing out the spoiler log a little more convenient and a tiny bit faster.