### PR TITLE
settings: Make use of std::variant with Option

### DIFF
--- a/source/menu.cpp
+++ b/source/menu.cpp
@@ -107,44 +107,51 @@ void MenuUpdate(u32 kDown) {
 }
 
 void UpdateMainMenu(u32 kDown) {
-	if (kDown & KEY_DUP)
-      menuIdx--;
+  if ((kDown & KEY_DUP) != 0) {
+    menuIdx--;
+  }
 
-	if (kDown & KEY_DDOWN)
-			menuIdx++;
+  if ((kDown & KEY_DDOWN) != 0) {
+    menuIdx++;
+  }
 
-  //bounds checking
-  if (menuIdx == 0xFF) menuIdx = Settings::mainMenu.size() - 1;
-  if (menuIdx == Settings::mainMenu.size()) menuIdx = 0;
+  // Bounds checking
+  if (menuIdx == Settings::mainMenu.size()) {
+    menuIdx = 0;
+  } else if (menuIdx == 0xFF) {
+    menuIdx = static_cast<u8>(Settings::mainMenu.size() - 1);
+  }
 
 	currentMenu = Settings::mainMenu[menuIdx];
 }
 
 void UpdateSubMenu(u32 kDown) {
-	if (kDown & KEY_DUP)
+  if ((kDown & KEY_DUP) != 0) {
     settingIdx--;
+  }
 
-	if (kDown & KEY_DDOWN)
-		settingIdx++;
+  if ((kDown & KEY_DDOWN) != 0)  {
+    settingIdx++;
+  }
 
-  //bounds checking
-  if (settingIdx == 0xFF) settingIdx = currentMenu->settingsList.size() - 1;
-  if (settingIdx == currentMenu->settingsList.size()) settingIdx = 0;
+  // Bounds checking
+  if (settingIdx == currentMenu->settingsList.size()) {
+    settingIdx = 0;
+  } else if (settingIdx == 0xFF) {
+    settingIdx = static_cast<u8>(currentMenu->settingsList.size() - 1);
+  }
 
-	currentSetting = currentMenu->settingsList[settingIdx];
+  currentSetting = currentMenu->settingsList[settingIdx];
 
-	if (kDown & KEY_DRIGHT) {
-		currentSetting->selectedOption++;
-	}
-	if (kDown & KEY_DLEFT) {
-		currentSetting->selectedOption--;
-	}
+  if ((kDown & KEY_DRIGHT) != 0) {
+    currentSetting->NextOptionIndex();
+  }
+  if ((kDown & KEY_DLEFT) != 0) {
+    currentSetting->PrevOptionIndex();
+  }
 
-  //bounds checking
-  if (currentSetting->selectedOption == 0xFF)
-    currentSetting->selectedOption = currentSetting->options.size() - 1;
-  if (currentSetting->selectedOption == currentSetting->options.size())
-    currentSetting->selectedOption = 0;
+  // Bounds checking
+  currentSetting->SanitizeSelectedOptionIndex();
 }
 
 void PrintMainMenu() {
@@ -188,11 +195,11 @@ void PrintSubMenu() {
     //make the current setting green
 		if (settingIdx == i + settingBound) {
 			printf("\x1b[%d;%dH\x1b[32m>", row,  1);
-			printf("\x1b[%d;%dH%s:",       row,  2, setting->name.c_str());
-			printf("\x1b[%d;%dH%s\x1b[0m", row, 26, setting->options[setting->selectedOption].c_str());
+			printf("\x1b[%d;%dH%s:",       row,  2, setting->GetName().data());
+			printf("\x1b[%d;%dH%s\x1b[0m", row, 26, setting->GetSelectedOption().data());
 		} else {
-			printf("\x1b[%d;%dH%s:",       row,  2, setting->name.c_str());
-			printf("\x1b[%d;%dH%s",        row, 26, setting->options[setting->selectedOption].c_str());
+			printf("\x1b[%d;%dH%s:",       row,  2, setting->GetName().data());
+			printf("\x1b[%d;%dH%s",        row, 26, setting->GetSelectedOption().data());
 		}
 
 		setting->SetVariable();

--- a/source/settings.hpp
+++ b/source/settings.hpp
@@ -1,37 +1,61 @@
 #pragma once
-#include <stdlib.h>
+
 #include <3ds.h>
+#include <cstdlib>
 #include <string>
+#include <variant>
 #include <vector>
 #include "../code/src/settings.h"
 
 class Option {
-  public:
+public:
     Option(u8* var_, std::string name_, std::vector<std::string> options_, u8 defaultOption_ = 0)
-          :   varu8(var_),       name(std::move(name_)),   options(std::move(options_)), selectedOption(defaultOption_) {
-        type == "u8";
-        *varu8 = selectedOption;
+          : var(var_),           name(std::move(name_)),   options(std::move(options_)), selectedOption(defaultOption_) {
+        SetVariable();
     }
 
     Option(bool* var_, std::string name_, std::vector<std::string> options_, u8 defaultOption_ = 0)
-          :varBool(var_), name(std::move(name_)),  options(std::move(options_)), selectedOption(defaultOption_) {
-        type = "bool";
-        *varBool = selectedOption ? true : false;
+          : var(var_), name(std::move(name_)),  options(std::move(options_)), selectedOption(defaultOption_) {
+        SetVariable();
     }
-    u8* varu8;
-    bool* varBool;
-    std::string name;
-    std::vector<std::string> options;
-    u8 selectedOption;
-    std::string type;
+
+    std::string_view GetName() const {
+        return name;
+    }
+
+    std::string_view GetSelectedOption() const {
+        return options[selectedOption];
+    }
+
+    void NextOptionIndex() {
+        ++selectedOption;
+    }
+
+    void PrevOptionIndex() {
+        --selectedOption;
+    }
+
+    void SanitizeSelectedOptionIndex() {
+        if (selectedOption == options.size()) {
+            selectedOption = 0;
+        } else if (selectedOption == 0xFF) {
+            selectedOption = static_cast<u8>(options.size() - 1);
+        }
+    }
 
     void SetVariable() {
-      if (type == "bool") {
-        *varBool = selectedOption ? true : false;
+      if (std::holds_alternative<bool*>(var)) {
+        *std::get<bool*>(var) = selectedOption != 0;
       } else {
-        *varu8 = selectedOption;
+        *std::get<u8*>(var) = selectedOption;
       }
     }
+
+private:
+  std::variant<bool*, u8*> var;
+  std::string name;
+  std::vector<std::string> options;
+  u8 selectedOption;
 };
 
 class Menu {


### PR DESCRIPTION
Allows an interface to be built around the Option class and also shrinks the total size of an Option instance down, considering std::variant keeps track of which type is active for us, so we don't need any of the tracking variables anymore.