### PR TITLE
Makefile: Create debugging target

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -167,6 +167,11 @@ endif
 all: $(BUILD) $(GFXBUILD) $(DEPSDIR) $(ROMFS_T3XFILES) $(T3XHFILES)
 	@$(MAKE) --no-print-directory -C $(BUILD) -f $(CURDIR)/Makefile
 
+# Debug target
+debug: CFLAGS += -g -DENABLE_DEBUG
+debug: CXXFLAGS += -g -DENABLE_DEBUG
+debug: all
+
 $(BUILD):
 	@mkdir -p $@
 

--- a/README.md
+++ b/README.md
@@ -14,6 +14,8 @@ First, in the code folder, use ```make```. This should generate a ```basecode.ip
 
 Then, in the root folder, use ```make``` to build ```OoT3D_Randomizer.3dsx```.
 
+To enable extra debugging features, follow the above instructions, but type ```make debug``` instead of ```make``` in the relevant steps.
+
 ## Installation
 
 On your SD card, copy the built ```basecode.ips``` to ```/luma/titles/0004000000033500/```. Also copy ```OoT3D_Randomizer.3dsx``` to ```/3ds/```.

--- a/code/Makefile
+++ b/code/Makefile
@@ -140,6 +140,11 @@ endif
 #---------------------------------------------------------------------------------
 all: $(BUILD)
 
+# Debug target
+debug: CFLAGS += -g -DENABLE_DEBUG
+debug: CXXFLAGS += -g -DENABLE_DEBUG
+debug: all
+
 $(BUILD):
 	@python3 custom_messages.py
 	@[ -d $@ ] || mkdir -p $@

--- a/code/src/savefile.c
+++ b/code/src/savefile.c
@@ -2,27 +2,25 @@
 #include "settings.h"
 
 void SaveFile_Init() {
-
-    u8 debug = 0;
-    if (debug) {
-      gSaveContext.equipment  |= 0xFFFF;  //Swords, shields, tunics, boots
-      gSaveContext.upgrades   |= 0x109;   //bomb bag, quiver, strength
-      gSaveContext.questItems |= 0x3FFC0; //songs
-      gSaveContext.items[SLOT_OCARINA]  = ITEM_OCARINA_FAIRY;
-      gSaveContext.items[SLOT_HOOKSHOT] = ITEM_LONGSHOT;
-      gSaveContext.items[SLOT_HAMMER]   = ITEM_HAMMER;
-      gSaveContext.items[SLOT_FARORES_WIND] = ITEM_FARORES_WIND;
-      gSaveContext.items[SLOT_DINS_FIRE] = ITEM_DINS_FIRE;
-      gSaveContext.items[SLOT_BOMB] = ITEM_BOMB;
-      gSaveContext.items[SLOT_BOW] = ITEM_BOW;
-      gSaveContext.items[SLOT_ARROW_FIRE] = ITEM_ARROW_FIRE;
-      gSaveContext.magicAcquired = 1;
-      gSaveContext.magicLevel = 2;
-      gSaveContext.magic = 48;
-      gSaveContext.dungeonKeys[6] = 8;
-      gSaveContext.ammo[2] = 20; //bombs
-      gSaveContext.ammo[3] = 20; //arrows
-    }
+#ifdef ENABLE_DEBUG
+    gSaveContext.equipment  |= 0xFFFF;  //Swords, shields, tunics, boots
+    gSaveContext.upgrades   |= 0x109;   //bomb bag, quiver, strength
+    gSaveContext.questItems |= 0x3FFC0; //songs
+    gSaveContext.items[SLOT_OCARINA]  = ITEM_OCARINA_FAIRY;
+    gSaveContext.items[SLOT_HOOKSHOT] = ITEM_LONGSHOT;
+    gSaveContext.items[SLOT_HAMMER]   = ITEM_HAMMER;
+    gSaveContext.items[SLOT_FARORES_WIND] = ITEM_FARORES_WIND;
+    gSaveContext.items[SLOT_DINS_FIRE] = ITEM_DINS_FIRE;
+    gSaveContext.items[SLOT_BOMB] = ITEM_BOMB;
+    gSaveContext.items[SLOT_BOW] = ITEM_BOW;
+    gSaveContext.items[SLOT_ARROW_FIRE] = ITEM_ARROW_FIRE;
+    gSaveContext.magicAcquired = 1;
+    gSaveContext.magicLevel = 2;
+    gSaveContext.magic = 48;
+    gSaveContext.dungeonKeys[6] = 8;
+    gSaveContext.ammo[2] = 20; //bombs
+    gSaveContext.ammo[3] = 20; //arrows
+#endif
 
     //things to always set
     gSaveContext.cutsceneIndex = 0;          //no intro cutscene


### PR DESCRIPTION
Allows debug mode to be enabled on the command line by simply typing: `make debug`

Which makes it easier to enable debugging code in the future if more than one spot needs it.