### PR TITLE
App:Now read basecode and exheader from romfs

### DIFF
--- a/source/menu.hpp
+++ b/source/menu.hpp
@@ -7,6 +7,7 @@
 #define GENERATE_MODE 2
 #define LOAD_PRESET 3
 #define SAVE_PRESET 4
+#define POST_GENERATE 5
 #define MAX_SETTINGS_ON_SCREEN 13
 #define TOP_WIDTH 50
 #define BOTTOM_WIDTH 40
@@ -16,9 +17,11 @@ void ModeChangeInit();
 void UpdateMainMenu(u32 kDown);
 void UpdateSubMenu(u32 kDown);
 void UpdatePresetsMenu(u32 kdown);
+void UpdateGenerateMenu(u32 kDown);
 void PrintMainMenu();
 void PrintSubMenu();
 void PrintPresetsMenu();
+void PrintGenerateMenu();
 void ClearDescription();
 void PrintOptionDescrption();
 bool CreatePresetDirectories();

--- a/source/patch.hpp
+++ b/source/patch.hpp
@@ -7,7 +7,8 @@
 #include "../code/src/settings.h"
 #include "../code/src/item_override.h"
 
-
 #define V_TO_P(addr) (addr - 0x100000)
+#define PATCH_CONSOLE 0
+#define PATCH_CITRA 1
 
 bool WritePatch();

--- a/source/playthrough.cpp
+++ b/source/playthrough.cpp
@@ -32,18 +32,19 @@ namespace Playthrough {
 
         if (Settings::GenerateSpoilerLog) {
           //write logs
-          printf("\x1b[9;10H");
+          printf("\x1b[9;10HWriting Spoiler Log...");
           if (SpoilerLog_Write()) {
-            printf("Wrote spoiler log");
+            printf("Done");
           } else {
-            printf("Failed to write spoiler log");
+            printf("Failed");
           }
 
-          printf("\x1b[10;10H");
+
+          printf("\x1b[10;10HWriting Placement Log...");
           if (PlacementLog_Write()) {
-            printf("Wrote placement log\n");
+            printf("Done\n");
           } else {
-            printf("Failed to write placement log\n");
+            printf("Failed\n");
           }
         } else {
           playthroughLocations = {};

--- a/source/settings.cpp
+++ b/source/settings.cpp
@@ -301,9 +301,10 @@ namespace Settings {
 
   //declared here, set in fill.cpp
   u32 LinksPocketRewardBitMask = 0;
-
-  //declared here, set in fill.cpp
   std::array<u32, 9> rDungeonRewardOverrides{};
+
+  //declared here, set in menu.cpp
+  u8 PlayOption;
 
   //Fills a SettingsContext struct which is sent to the patch
   SettingsContext FillContext() {

--- a/source/settings.hpp
+++ b/source/settings.hpp
@@ -291,6 +291,8 @@ namespace Settings {
   extern u32 LinksPocketRewardBitMask;
   extern std::array<u32, 9> rDungeonRewardOverrides;
 
+  extern u8 PlayOption;
+
   extern std::vector<Option *> excludeLocationsOptions;
   extern std::vector<Option *> detailedLogicOptions;
 


### PR DESCRIPTION
- Now the app reads basecode.ips and exheader.bin from the romfs folder. This allows the user to not worry about dealing with these files. 
- The App will prompt the user for whether they're playing on Citra or 3ds. This determines which exheader they get copied.