### PR TITLE
Logic:Temporary Fix for Freestanding Keys

### DIFF
--- a/code/src/savefile.c
+++ b/code/src/savefile.c
@@ -14,10 +14,12 @@ void SaveFile_Init() {
     gSaveContext.items[SLOT_BOMB] = ITEM_BOMB;
     gSaveContext.items[SLOT_BOW] = ITEM_BOW;
     gSaveContext.items[SLOT_ARROW_FIRE] = ITEM_ARROW_FIRE;
+    gSaveContext.items[SLOT_HOVER_BOOTS] = ITEM_BOOTS_HOVER;
     gSaveContext.magicAcquired = 1;
     gSaveContext.magicLevel = 2;
     gSaveContext.magic = 48;
     gSaveContext.dungeonKeys[6] = 8;
+    gSaveContext.dungeonKeys[7] = 5;
     gSaveContext.ammo[2] = 20; //bombs
     gSaveContext.ammo[3] = 20; //arrows
 #endif

--- a/source/item_list.cpp
+++ b/source/item_list.cpp
@@ -12,6 +12,8 @@ bool none = false;
 Item NoItem = Item("No Item", ITEMTYPE_ITEM,   GI_RUPEE_GREEN,   false, &none);
 Item I_Triforce = Item("Triforce", ITEMTYPE_ITEM, GI_RUPEE_RED_LOSE, false, &none);
 
+Item GenericSmallKey = Item("Small Key", ITEMTYPE_SMALLKEY, GI_KEY_SMALL, true, &none);
+
 //Specific Advancement Items         // name              type           getItemId          advancement logic variable
 Item I_KokiriSword              = Item("Kokiri Sword",    ITEMTYPE_ITEM, GI_SWORD_KOKIRI,   true,  &KokiriSword);
 Item I_BiggoronSword            = Item("Biggoron Sword",  ITEMTYPE_ITEM, GI_SWORD_BGS,      true,  &none);

--- a/source/item_list.hpp
+++ b/source/item_list.hpp
@@ -125,6 +125,8 @@ private:
 extern Item NoItem;
 extern Item I_Triforce;
 
+extern Item GenericSmallKey;
+
 //specific advancement items
 extern Item I_KokiriSword;
 extern Item I_BiggoronSword;

--- a/source/item_location.cpp
+++ b/source/item_location.cpp
@@ -11,11 +11,16 @@ u32 totalLocationsFound = 0;
 u16 itemsPlaced = 0;
 
 void PlaceItemInLocation(ItemLocation* loc, Item item, bool applyEffectImmediately /*= false*/) {
-    // Put item in the override table
-    overrides.insert({
-      .key = loc->Key(),
-      .value = item.Value(),
-    });
+    /*-------------------------------------------------
+    |    TEMPORARY FIX FOR FREESTANDING KEY CRASHES   |
+    --------------------------------------------------*/
+    //this prevents an override from being created for these two locations
+    if (loc->GetName() != "Shadow Temple Freestanding Key" && loc->GetName() != "Gerudo Training Grounds Freestanding Key") {
+      overrides.insert({
+        .key = loc->Key(),
+        .value = item.Value(),
+      });
+    }
 
     PlacementLog_Msg("\n");
     PlacementLog_Msg(item.GetName());

--- a/source/item_pool.cpp
+++ b/source/item_pool.cpp
@@ -911,6 +911,20 @@ static void SetMinimalItemPool() {
 template <typename Container>
 static void RandomizeDungeonKeys(const Container& KeyRequirements, Item smallKeyItem, u8 maxKeys) {
   for (size_t i = 0; i < maxKeys; i++) {
+
+    /*-------------------------------------------------
+    |    TEMPORARY FIX FOR FREESTANDING KEY CRASHES   |
+    --------------------------------------------------*/
+    //this keeps the number of keys for the Own Dungeon setting consistent
+    if (smallKeyItem == ShadowTemple_SmallKey && i == 2) {
+      i = 3;
+    } else if (smallKeyItem == GerudoTrainingGrounds_SmallKey && i == 0) {
+      i = 1;
+    }
+    /*-------------------------------------------------
+    |END OF TEMPORARY FIX FOR FREESTANDING KEY CRASHES|
+    --------------------------------------------------*/
+
     std::vector<ItemLocation *> dungeonPool;
     for (const ItemLocationKeyPairing& ilkp : KeyRequirements) {
       if (ilkp.keysRequired <= i && ilkp.loc->GetPlacedItemName() == "No Item") {
@@ -1241,6 +1255,16 @@ void GenerateItemPool() {
     PlaceVanillaMapsAndCompasses();
   }
 
+  /*-------------------------------------------------
+  |    TEMPORARY FIX FOR FREESTANDING KEY CRASHES   |
+  --------------------------------------------------*/
+  //Placing keys here for the logic to still work
+  PlaceItemInLocation(&ShadowTemple_FreestandingKey, ShadowTemple_SmallKey);
+  PlaceItemInLocation(&GerudoTrainingGrounds_FreestandingKey, GerudoTrainingGrounds_SmallKey);
+  /*-------------------------------------------------
+  |END OF TEMPORARY FIX FOR FREESTANDING KEY CRASHES|
+  --------------------------------------------------*/
+
   if (Keysanity.Is(KEYSANITY_VANILLA)) {
     PlaceVanillaSmallKeys();
   }
@@ -1309,9 +1333,9 @@ void GenerateItemPool() {
     AddItemToMainPool(FireTemple_SmallKey, 8);
     AddItemToMainPool(WaterTemple_SmallKey, 6);
     AddItemToMainPool(SpiritTemple_SmallKey, 5);
-    AddItemToMainPool(ShadowTemple_SmallKey, 5);
+    AddItemToMainPool(ShadowTemple_SmallKey, 4); //SHOULD BE 5, CHANGE WHEN CRASH IS FIXED
     AddItemToMainPool(BottomOfTheWell_SmallKey, 3);
-    AddItemToMainPool(GerudoTrainingGrounds_SmallKey, 9);
+    AddItemToMainPool(GerudoTrainingGrounds_SmallKey, 8); //SHOULD BE 9, CHANGE WHEN CRASH IS FIXED
     AddItemToMainPool(GanonsCastle_SmallKey, 2);
   }
 

--- a/source/menu.cpp
+++ b/source/menu.cpp
@@ -208,6 +208,13 @@ void UpdateSubMenu(u32 kDown) {
 
   // Bounds checking
   currentSetting->SanitizeSelectedOptionIndex();
+
+  //Set toggle for all tricks
+  if (((kDown & KEY_DRIGHT) != 0 || (kDown & KEY_DLEFT) != 0) && currentSetting->GetName() == "All Tricks")  {
+    for (u16 i = 0; i < Settings::detailedLogicOptions.size(); i++) {
+      Settings::detailedLogicOptions[i]->SetSelectedIndex(currentSetting->GetSelectedOptionIndex());
+    }
+  }
 }
 
 void UpdatePresetsMenu(u32 kDown) {

--- a/source/setting_descriptions.cpp
+++ b/source/setting_descriptions.cpp
@@ -310,7 +310,7 @@ std::string_view childHammerDesc      = "Child Link can swing the Megaton Hammer
 ------------------------------*/                                                                           //
 std::string_view ToggleAllDetailedLogicDesc           = "Enable or Disable all Detailed Logic tricks at\n" //
                                                         "once.";                                           //
-std::string_view LogicGrottosWithoutAgonyDesc         = "Allows entering hidden grottos without the Stone\n"
+std::string_view LogicGrottosWithoutAgonyDesc         = "Allows entering hidden grottos without the Shard\n"
                                                         "of Agony.";                                       //
 std::string_view LogicVisibleCollisionDesc            = "Allows going through the Kakariko Village Gate as\n"
                                                         "child when coming from the Mountain Trail side."; //

--- a/source/setting_descriptions.cpp
+++ b/source/setting_descriptions.cpp
@@ -308,6 +308,8 @@ std::string_view childHammerDesc      = "Child Link can swing the Megaton Hammer
 /*------------------------------                                                                           //
 |  DETAILED LOGIC EXPLANATIONS |                                                                           //
 ------------------------------*/                                                                           //
+std::string_view ToggleAllDetailedLogicDesc           = "Enable or Disable all Detailed Logic tricks at\n" //
+                                                        "once.";                                           //
 std::string_view LogicGrottosWithoutAgonyDesc         = "Allows entering hidden grottos without the Stone\n"
                                                         "of Agony.";                                       //
 std::string_view LogicVisibleCollisionDesc            = "Allows going through the Kakariko Village Gate as\n"

--- a/source/setting_descriptions.hpp
+++ b/source/setting_descriptions.hpp
@@ -109,6 +109,7 @@ extern std::string_view adultBoomerangDesc;
 
 extern std::string_view childHammerDesc;
 
+extern std::string_view ToggleAllDetailedLogicDesc;
 extern std::string_view LogicGrottosWithoutAgonyDesc;
 extern std::string_view LogicVisibleCollisionDesc;
 extern std::string_view LogicFewerTunicRequirementsDesc;

--- a/source/settings.cpp
+++ b/source/settings.cpp
@@ -117,10 +117,11 @@ namespace Settings {
     &IceTrapValue,
   };
 
-  //Excluded Locations (definitions made in ItemLocation class)
+  //Excluded Locations (Individual definitions made in ItemLocation class)
   std::vector<Option *> excludeLocationsOptions = {};
 
   //Detailed Logic Tricks                                 ---------------------
+  Option ToggleAllDetailedLogic           = Option::Bool("All Tricks",                                     {"Disable", "Enable"}, std::vector<std::string_view>{2, ToggleAllDetailedLogicDesc});
   Option LogicGrottosWithoutAgony         = Option::Bool("Grottos Without Agony",                          {"Disable", "Enable"}, std::vector<std::string_view>{2, LogicGrottosWithoutAgonyDesc});
   Option LogicVisibleCollision            = Option::Bool("Pass Through Visible\n One-Way Collisions",      {"Disable", "Enable"}, std::vector<std::string_view>{2, LogicVisibleCollisionDesc});
   Option LogicFewerTunicRequirements      = Option::Bool("Fewer Tunic\n Requirements",                     {"Disable", "Enable"}, std::vector<std::string_view>{2, LogicFewerTunicRequirementsDesc});
@@ -196,6 +197,7 @@ namespace Settings {
   Option LogicLensCastle                  = Option::Bool("Ganon's Castle w/o\n Lens of Truth",             {"Disable", "Enable"}, std::vector<std::string_view>{2, LogicLensCastleDesc});
   Option LogicSpiritTrialHookshot         = Option::Bool("Spirit Trial without\n Hookshot",                {"Disable", "Enable"}, std::vector<std::string_view>{2, LogicSpiritTrialHookshotDesc});
   std::vector<Option *> detailedLogicOptions = {
+    &ToggleAllDetailedLogic,
     &LogicGrottosWithoutAgony,
     &LogicVisibleCollision,
     &LogicFewerTunicRequirements,

--- a/source/settings.hpp
+++ b/source/settings.hpp
@@ -216,6 +216,7 @@ namespace Settings {
   extern bool GanonsCastleDungeonMode;
 
   //Logic Settings
+  extern Option ToggleAllDetailedLogic;
   extern Option LogicGrottosWithoutAgony;
   extern Option LogicVisibleCollision;
   extern Option LogicFewerTunicRequirements;

--- a/source/spoiler_log.cpp
+++ b/source/spoiler_log.cpp
@@ -129,7 +129,7 @@ static void WriteSettings() {
   //List Enabled Tricks
   logtxt += "\nEnabled Tricks:\n";
   for (auto& l : Settings::detailedLogicOptions) {
-    if (l->GetSelectedOption() == "Enable") {
+    if (l->GetSelectedOption() == "Enable" && l->GetName() != "All Tricks") {
       std::string name = l->GetName().data();
 
       //get rid of newline characters if necessary


### PR DESCRIPTION
- Prevent the randomizer from making an ItemOverride for the Shadow Temple and Gerudo Training Grounds Freestanding Key locations until the crash associated with them is fixed.
- Added a menu toggle for disabling or enabling all detailed logic tricks