### PR TITLE
App:Fix vanilla bridge description and closing file handlers for logs

### DIFF
--- a/source/setting_descriptions.cpp
+++ b/source/setting_descriptions.cpp
@@ -67,7 +67,7 @@ string_view gerudoOpen                = "The carpenters are rescued from the sta
 ------------------------------*/                                                           //
 string_view bridgeOpen                = "The Rainbow Bridge is always present.";           //
 string_view bridgeVanilla             = "The Rainbow Bridge requires Shadow and Spirit\n"  //
-                                        "Medallions.";                                     //
+                                        "Medallions as well as Light Arrows.";             //
 string_view bridgeStones              = "The Rainbow Bridge requires the Kokiri's Emerald,\n"
                                         "Goron's Ruby and Zora's Sapphire.";               //
 string_view bridgeMedallions          = "The Rainbow Bridge requires Forest, Fire, Water,\n"

--- a/source/spoiler_log.cpp
+++ b/source/spoiler_log.cpp
@@ -197,6 +197,9 @@ bool SpoilerLog_Write() {
     return false;
   }
 
+  FSFILE_Close(spoilerlog);
+  FSUSER_CloseArchive(sdmcArchive);
+
   logtxt = "";
   return true;
 }
@@ -226,6 +229,9 @@ bool PlacementLog_Write() {
   if (!R_SUCCEEDED(res = FSFILE_Write(placementlog, &bytesWritten, 0, placementtxt.c_str(), placementtxt.size(), FS_WRITE_FLUSH))) {
     return false;
   }
+
+  FSFILE_Close(placementlog);
+  FSUSER_CloseArchive(sdmcArchive);
 
   placementtxt = "";
   return true;


### PR DESCRIPTION
- Changed the description for vanilla rainbow bridge to include a note about needing Light Arrows
- Properly closed the file handlers when writing the log files so they can be opened even if Citra is still running.