### PR TITLE
Logic:Fixed an issue with Ganon's Trial Count and a logic error in Water Temple

### DIFF
--- a/code/src/savefile.c
+++ b/code/src/savefile.c
@@ -15,6 +15,7 @@ void SaveFile_Init() {
     gSaveContext.items[SLOT_BOW] = ITEM_BOW;
     gSaveContext.items[SLOT_ARROW_FIRE] = ITEM_ARROW_FIRE;
     gSaveContext.items[SLOT_HOVER_BOOTS] = ITEM_BOOTS_HOVER;
+    gSaveContext.items[SLOT_ARROW_LIGHT] = ITEM_ARROW_LIGHT;
     gSaveContext.magicAcquired = 1;
     gSaveContext.magicLevel = 2;
     gSaveContext.magic = 48;
@@ -101,6 +102,11 @@ void SaveFile_Init() {
     gSaveContext.eventChkInf[0xA] |= (gSettingsContext.spiritTrialSkip) ? 0x2000 : 0;
     gSaveContext.eventChkInf[0xB] |= (gSettingsContext.shadowTrialSkip) ? 0x2000 : 0;
     gSaveContext.eventChkInf[0xB] |= (gSettingsContext.lightTrialSkip)  ? 0x8000 : 0;
+
+    if (gSettingsContext.forestTrialSkip && gSettingsContext.fireTrialSkip && gSettingsContext.waterTrialSkip &&
+        gSettingsContext.spiritTrialSkip && gSettingsContext.shadowTrialSkip && gSettingsContext.lightTrialSkip) {
+          gSaveContext.eventChkInf[0xC] |= 0x0008; //dispel Ganon's Tower Barrier
+    }
 
     if (gSettingsContext.fourPoesCutscene == SKIP) {
         gSaveContext.sceneFlags[3].swch |= 0x08000000; //Remove Poe cutscene in Forest Temple

--- a/source/location_access.cpp
+++ b/source/location_access.cpp
@@ -1909,7 +1909,7 @@ namespace Exits { //name, scene, hint, events, locations, exits
   Exit WaterTemple_Lobby = Exit("Water Temple Lobby", "Water Temple", "", NO_DAY_NIGHT_CYCLE, {
                   //Events
                   EventPairing(&ChildWaterTemple, []{return IsChild;}),
-                  EventPairing(&RaiseWaterLevel,  []{return (IsAdult && (Hookshot || HoverBoots || Bow)) || (HasFireSourceWithTorch && CanUseProjectile);}),
+                  EventPairing(&RaiseWaterLevel,  []{return (IsAdult && ((LogicWaterTempleUpperBoost && Bombs) || HoverBoots || Bow)) || (HasFireSourceWithTorch && CanUseProjectile);}),
                 }, {}, {
                   //Exits
                   ExitPairing::Both(&LH_Main,                       []{return true;}),
@@ -2312,7 +2312,7 @@ namespace Exits { //name, scene, hint, events, locations, exits
                   ExitPairing::Both(&GanonsCastle_LightTrial,  []{return CanUse("Golden Gauntlets");}),
                   ExitPairing::Both(&GanonsCastle_Tower,       []{return (ForestTrialClear || ForestTrialSkip) &&
                                                                          (FireTrialClear   || FireTrialSkip)   &&
-                                                                         (WaterTrialClear  || WaterTrialSkip)  && 
+                                                                         (WaterTrialClear  || WaterTrialSkip)  &&
                                                                          (ShadowTrialClear || ShadowTrialSkip) &&
                                                                          (SpiritTrialClear || SpiritTrialSkip) &&
                                                                          (LightTrialClear  || LightTrialSkip);}),

--- a/source/setting_descriptions.cpp
+++ b/source/setting_descriptions.cpp
@@ -521,6 +521,11 @@ string_view LogicWaterTempleTorchLongshotDesc         = "Stand on the eastern si
                                                         "the tricks that allow you to skip Iron Boots in\n"//
                                                         "the Water Temple are not going to be relevant\n"  //
                                                         "unless this trick is first enabled.";             //
+string_view LogicWaterTempleUpperBoostDesc            = "Stand on the corner closest to the upper ledge\n" //
+                                                        "where you play Zelda's Lullaby to raise the water\n"
+                                                        "and put a bomb down behind you. Hold forward when\n"
+                                                        "the bomb explodes and Link should jump just far\n"//
+                                                        "enough to grab the ledge.";                       //
 string_view LogicWaterCentralBowDesc                  = "A very precise Bow shot can hit the eye switch\n" //
                                                         "from the floor above. Then, you can jump down into"
                                                         "the hallway and make through it before the gate\n"//

--- a/source/setting_descriptions.hpp
+++ b/source/setting_descriptions.hpp
@@ -173,6 +173,7 @@ extern string_view LogicFireScarecrowDesc;
 extern string_view LogicFireFlameMazeDesc;
 extern string_view LogicFireSongOfTimeDesc;
 extern string_view LogicWaterTempleTorchLongshotDesc;
+extern string_view LogicWaterTempleUpperBoostDesc;
 extern string_view LogicWaterCentralBowDesc;
 extern string_view LogicWaterCentralGSFWDesc;
 extern string_view LogicWaterCrackedWallNothingDesc;

--- a/source/settings.cpp
+++ b/source/settings.cpp
@@ -187,6 +187,7 @@ namespace Settings {
   Option LogicFireFlameMaze               = LogicTrick("FiT Flame Wall Maze\n Skip",                      LogicFireFlameMazeDesc);
   Option LogicFireSongOfTime              = LogicTrick("FiT Song of Time Room\n GS w/o Song of Time",     LogicFireSongOfTimeDesc);
   Option LogicWaterTempleTorchLongshot    = LogicTrick("WaT Torch Longshot",                              LogicWaterTempleTorchLongshotDesc);
+  Option LogicWaterTempleUpperBoost       = LogicTrick("WaT Upper Ledge Jump\n with Bombs",               LogicWaterTempleUpperBoostDesc);
   Option LogicWaterCentralBow             = LogicTrick("WaT Bow Target w/o\n Longshot or Hover Boots",    LogicWaterCentralBowDesc);
   Option LogicWaterCentralGSFW            = LogicTrick("WaT Central Pillar GS\n with Farore's Wind",      LogicWaterCentralGSFWDesc);
   Option LogicWaterCrackedWallNothing     = LogicTrick("WaT Cracked Wall with\n No Additional Items",     LogicWaterCrackedWallNothingDesc);
@@ -264,6 +265,7 @@ namespace Settings {
     &LogicFireFlameMaze,
     &LogicFireSongOfTime,
     &LogicWaterTempleTorchLongshot,
+    &LogicWaterTempleUpperBoost,
     &LogicWaterCentralBow,
     &LogicWaterCentralGSFW,
     &LogicWaterCrackedWallNothing,

--- a/source/settings.hpp
+++ b/source/settings.hpp
@@ -306,6 +306,7 @@ namespace Settings {
   extern Option LogicFireFlameMaze;
   extern Option LogicFireSongOfTime;
   extern Option LogicWaterTempleTorchLongshot;
+  extern Option LogicWaterTempleUpperBoost;
   extern Option LogicWaterCentralBow;
   extern Option LogicWaterCentralGSFW;
   extern Option LogicWaterCrackedWallNothing;


### PR DESCRIPTION
- Set Ganon's Tower barrier to be automatically dispelled if the trial count is set to zero
- Changed the logic for raising the water in Water Temple to account for the bomb jump trick instead of not needing anything.