### PR TITLE
Reworked RNG to use Mersenne Twister

### DIFF
--- a/source/fill.cpp
+++ b/source/fill.cpp
@@ -107,16 +107,15 @@ static std::vector<ItemLocation*> GetAccessibleLocations(std::vector<ItemLocatio
   std::vector<Exit *> exitPool = {&Exits::Root};
 
   std::vector<ItemLocation *> newItemLocations;
-  bool iterationWithNoLocations = false;
-  while(!iterationWithNoLocations) {
-    iterationWithNoLocations = true;
+  bool firstIteration = true;
+  while(newItemLocations.size() > 0 || firstIteration) {
+    firstIteration = false;;
 
     //Add items found during previous search iteration to logic
-    if (newItemLocations.size() > 0) {
-      for (ItemLocation* location : newItemLocations) {
-        location->ApplyPlacedItemEffect();
-      }
+    for (ItemLocation* location : newItemLocations) {
+      location->ApplyPlacedItemEffect();
     }
+    newItemLocations.clear();
 
     for (size_t i = 0; i < exitPool.size(); i++) {
       Exit* area = exitPool[i];
@@ -171,7 +170,6 @@ static std::vector<ItemLocation*> GetAccessibleLocations(std::vector<ItemLocatio
           if ((locPair.ConditionsMet() || Settings::Logic.Is(LOGIC_NONE)) && !location->IsAddedToPool()) {
 
             location->AddToPool();
-            iterationWithNoLocations = false; //At least new one location has been found, continue looping
 
             if (location->GetPlacedItem() == NoItem) {
               accessibleLocations.push_back(location);

--- a/source/fill.cpp
+++ b/source/fill.cpp
@@ -108,6 +108,7 @@ static std::vector<ItemLocation*> GetAccessibleLocations(std::vector<ItemLocatio
 
   std::vector<ItemLocation *> newItemLocations;
   bool firstIteration = true;
+  //If no new items are found, then the next iteration won't provide any new location
   while(newItemLocations.size() > 0 || firstIteration) {
     firstIteration = false;;
 
@@ -172,7 +173,7 @@ static std::vector<ItemLocation*> GetAccessibleLocations(std::vector<ItemLocatio
             location->AddToPool();
 
             if (location->GetPlacedItem() == NoItem) {
-              accessibleLocations.push_back(location);
+              accessibleLocations.push_back(location); //Empty location, consider for placement
             } else {
               newItemLocations.push_back(location); //Add item to cache to be considered in logic next iteration
             }

--- a/source/fill.cpp
+++ b/source/fill.cpp
@@ -48,7 +48,7 @@ static void RandomizeDungeonRewards() {
   //shuffle an array of indices so that we can randomize the rewards both
   //logically and for the patch
   std::array<u8, 9> idxArray = {0, 1, 2, 3, 4, 5, 6, 7, 8};
-  std::shuffle(idxArray.begin(), idxArray.end(), std::default_random_engine(Random()));
+  Shuffle(idxArray);
 
   for (size_t i = 0; i < dungeonRewards.size(); i++) {
     const u8 idx = idxArray[i];
@@ -209,13 +209,8 @@ static void FastFill(std::vector<Item> items, std::vector<ItemLocation*> locatio
 
   //Place everything randomly
   while (!locations.empty()) {
-    unsigned int itemIdx = Random() % items.size();
-    unsigned int locIdx = Random() % locations.size();
 
-    PlaceItemInLocation(locations[locIdx], items[itemIdx]);
-
-    items.erase(items.begin() + itemIdx);
-    locations.erase(locations.begin() + locIdx);
+    PlaceItemInLocation(RandomElement(locations, true), RandomElement(items, true));
 
     if (items.empty()) {
       items.push_back(GetJunkItem());
@@ -247,7 +242,7 @@ static void AssumedFill(std::vector<Item> items, std::vector<ItemLocation*> allo
     std::vector<Item> itemsToNotPlace = FilterFromPool(ItemPool, [](const Item& i){ return i .IsAdvancement();});
 
     //shuffle the order of items to place
-    std::shuffle(itemsToPlace.begin(), itemsToPlace.end(), std::default_random_engine(Random()));
+    Shuffle(itemsToPlace);
 
     while (!itemsToPlace.empty()) {
       Item item = std::move(itemsToPlace.back());
@@ -287,9 +282,9 @@ static void AssumedFill(std::vector<Item> items, std::vector<ItemLocation*> allo
       }
 
       //place the item within one of the allowed locations
-      unsigned int locIdx = Random() % accessibleLocations.size();
-      PlaceItemInLocation(accessibleLocations[locIdx], item);
-      attemptedLocations.push_back(accessibleLocations[locIdx]);
+      ItemLocation* selectedLocation = RandomElement(accessibleLocations, false);
+      PlaceItemInLocation(selectedLocation, item);
+      attemptedLocations.push_back(selectedLocation);
 
     }
   } while (unsuccessfulPlacement);

--- a/source/item_list.hpp
+++ b/source/item_list.hpp
@@ -80,7 +80,7 @@ public:
         val.all = 0;
         val.itemId = getItemId;
         if (getItemId == GI_ICE_TRAP) {
-            val.looksLikeItemId = items[Random() % items.size()];
+            val.looksLikeItemId = RandomElement(items);
         }
         return val;
     }

--- a/source/item_pool.cpp
+++ b/source/item_pool.cpp
@@ -471,20 +471,17 @@ static void JoinPools(std::vector<Item>& pool1, const std::array<Item, N>& pool2
 }
 
 static void AddRandomBottle(std::vector<Item> bottlePool) {
-  u32 idx = Random() % bottlePool.size();
-  AddItemToMainPool(bottlePool[idx]);
-  bottlePool.erase(bottlePool.begin() + idx);
+  AddItemToMainPool(RandomElement(bottlePool, true));
 }
 
 Item GetJunkItem() {
   if (IceTrapValue.Is(ICETRAPS_MAYHEM) || IceTrapValue.Is(ICETRAPS_ONSLAUGHT)) {
     return IceTrap;
   } else if (IceTrapValue.Is(ICETRAPS_EXTRA)) {
-    u8 idx = Random() % (JunkPoolItems.size());
-    return JunkPoolItems[idx];
+      return RandomElement(JunkPoolItems);
   }
   //Ice Trap is the last item in JunkPoolItems, so subtract 1 to never hit that index
-  u8 idx = Random() % (JunkPoolItems.size() - 1);
+  u8 idx = Random(0, JunkPoolItems.size() - 1);
   return JunkPoolItems[idx];
 }
 
@@ -493,9 +490,7 @@ static Item GetPendingJunkItem() {
     return GetJunkItem();
   }
 
-  int idx = Random() % (PendingJunkPool.size());
-  Item returnItem = PendingJunkPool[idx];
-  PendingJunkPool.erase(PendingJunkPool.begin() + idx);
+  Item returnItem = RandomElement(PendingJunkPool, true);
   return returnItem;
 }
 
@@ -1150,7 +1145,7 @@ void GenerateItemPool() {
 
     //I'm not sure what this is for, but it was in ootr so I copied it
     for (u8 i = 0; i < 7; i++) {
-      if (Random() % 3) {
+      if (Random(0, 3)) {
         AddItemToMainPool(Arrows30);
       } else {
         AddItemToMainPool(DekuSeeds30);

--- a/source/playthrough.cpp
+++ b/source/playthrough.cpp
@@ -67,6 +67,6 @@ namespace Playthrough {
 
     //idk where else to put this so it goes here
     s16 GetRandomPrice() {
-      return 5 * ((Random() % 19) + 1);
+      return 5 * Random(1, 20);
     }
 }

--- a/source/random.cpp
+++ b/source/random.cpp
@@ -1,19 +1,22 @@
 #include "random.hpp"
 
 static bool init = false;
-static unsigned int state;
+std::mt19937_64 generator;
 
 void Random_Init(unsigned int seed) {
-    state = 0;
     init = true;
-    srand(seed);
+    std::mt19937_64 newgen(seed);
+    generator = newgen;
 }
 
-unsigned int Random() {
+//Returns a random integer in range [min, max-1]
+unsigned int Random(int min, int max) {
     if (!init) {
-        state = 0;
+        std::random_device rd;
+        std::mt19937_64 newgen(rd());
+        generator = newgen;
         init = true;
     }
-    state = rand();
-    return state;
+    std::uniform_int_distribution<> distribution(min, max-1);
+    return distribution(generator);
 }

--- a/source/random.cpp
+++ b/source/random.cpp
@@ -3,6 +3,7 @@
 static bool init = false;
 std::mt19937_64 generator;
 
+//Initialize with seed specified
 void Random_Init(unsigned int seed) {
     init = true;
     std::mt19937_64 newgen(seed);
@@ -12,6 +13,7 @@ void Random_Init(unsigned int seed) {
 //Returns a random integer in range [min, max-1]
 unsigned int Random(int min, int max) {
     if (!init) {
+        //No seed given, get a random number from device to seed
         std::random_device rd;
         std::mt19937_64 newgen(rd());
         generator = newgen;

--- a/source/random.hpp
+++ b/source/random.hpp
@@ -1,6 +1,38 @@
 #pragma once
 #include <stdlib.h>
 #include <random>
+#include <array>
 
 extern void Random_Init(unsigned int seed);
-extern unsigned int Random();
+extern unsigned int Random(int min, int max);
+
+template <typename T>
+T RandomElement(std::vector<T> &vector, bool erase) {
+    int idx = Random(0, vector.size());
+    T selected = vector[idx];
+    if(erase) {
+        vector.erase(vector.begin() + idx);
+    }
+    return selected;
+}
+
+template <typename T, std::size_t size>
+T RandomElement(std::array<T, size> arr) {
+    return arr[Random(0, arr.size())];
+}
+
+template <typename T>
+void Shuffle(std::vector<T> &vector) {
+    for (uint i = 0; i + 1 < vector.size(); i++)
+    {
+        std::swap(vector[i], vector[Random(i, vector.size())]);
+    }
+}
+
+template <typename T, std::size_t size>
+void Shuffle(std::array<T, size> &arr) {
+    for (uint i = 0; i + 1 < arr.size(); i++)
+    {
+        std::swap(arr[i], arr[Random(i, arr.size())]);
+    }
+}

--- a/source/random.hpp
+++ b/source/random.hpp
@@ -6,6 +6,7 @@
 extern void Random_Init(unsigned int seed);
 extern unsigned int Random(int min, int max);
 
+//Get a random element from a vector or array
 template <typename T>
 T RandomElement(std::vector<T> &vector, bool erase) {
     int idx = Random(0, vector.size());
@@ -15,12 +16,12 @@ T RandomElement(std::vector<T> &vector, bool erase) {
     }
     return selected;
 }
-
 template <typename T, std::size_t size>
 T RandomElement(std::array<T, size> arr) {
     return arr[Random(0, arr.size())];
 }
 
+//Shuffle items within a vector or array
 template <typename T>
 void Shuffle(std::vector<T> &vector) {
     for (uint i = 0; i + 1 < vector.size(); i++)
@@ -28,10 +29,9 @@ void Shuffle(std::vector<T> &vector) {
         std::swap(vector[i], vector[Random(i, vector.size())]);
     }
 }
-
 template <typename T, std::size_t size>
 void Shuffle(std::array<T, size> &arr) {
-    for (uint i = 0; i + 1 < arr.size(); i++)
+    for (std::size_t i = 0; i + 1 < arr.size(); i++)
     {
         std::swap(arr[i], arr[Random(i, arr.size())]);
     }

--- a/source/settings.cpp
+++ b/source/settings.cpp
@@ -611,10 +611,10 @@ namespace Settings {
     std::array<bool*, 12> dungeonModes = {&DekuTreeDungeonMode, &DodongosCavernDungeonMode, &JabuJabusBellyDungeonMode, &ForestTempleDungeonMode,
                                           &FireTempleDungeonMode, &WaterTempleDungeonMode, &SpiritTempleDungeonMode, &ShadowTempleDungeonMode,
                                           &BottomOfTheWellDungeonMode, &IceCavernDungeonMode, &GerudoTrainingGroundsDungeonMode, &GanonsCastleDungeonMode};
-    std::shuffle(dungeonModes.begin(), dungeonModes.end(), std::default_random_engine(Random()));
+    Shuffle(dungeonModes);
 
     if (RandomMQDungeons) {
-      MQDungeonCount.SetSelectedIndex(Random() % MQDungeonCount.GetOptionCount());
+      MQDungeonCount.SetSelectedIndex(Random(0, MQDungeonCount.GetOptionCount()+1));
     }
     for (u8 i = 0; i < MQDungeonCount.Value<u8>(); i++) {
       *dungeonModes[i] = DUNGEONMODE_MQ;
@@ -622,10 +622,10 @@ namespace Settings {
 
     //shuffle the trials then require the amount set in GanonsTrialsCount
     std::array<bool*, 6> trialsSkipped = {&ForestTrialSkip, &FireTrialSkip, &WaterTrialSkip, &SpiritTrialSkip, &ShadowTrialSkip, &LightTrialSkip};
-    std::shuffle(trialsSkipped.begin(), trialsSkipped.end(), std::default_random_engine(Random()));
+    Shuffle(trialsSkipped);
 
     if (RandomGanonsTrials) {
-      GanonsTrialsCount.SetSelectedIndex(Random() % GanonsTrialsCount.GetOptionCount());
+      GanonsTrialsCount.SetSelectedIndex(Random(0, GanonsTrialsCount.GetOptionCount()+1));
     }
     for (u8 i = 0; i < GanonsTrialsCount.Value<u8>(); i++) {
       *trialsSkipped[i] = false; //the selected trial is not skipped

--- a/source/spoiler_log.cpp
+++ b/source/spoiler_log.cpp
@@ -58,7 +58,7 @@ std::array<std::string, 5> randomizerHash = {"", "", "", "", ""};
 
 void GenerateHash() {
   for (u32 i = 0; i < 5; i++) {
-    u8 iconIndex = Random() % hashIcons.size();
+    u8 iconIndex = Random(0, hashIcons.size());
     Settings::hashIconIndexes[i] = iconIndex;
     randomizerHash[i] = hashIcons[iconIndex];
   }


### PR DESCRIPTION
rand() is not considered a good way to produce randomness, mainly due to distribution of numbers not being even and the PRNG algorithm behind it not being great.

I changed the RNG to use Mersenne Twister, which is a standard PRNG in many things such as Python. I also made some helpful functions utilizing the generator, for getting a random element from and shuffling vectors/arrays.

Finally, I further reworked the reachability search a little bit because I still wasn't quite happy with it.