### PR TITLE
App: Fix Ganon and MQ random counts

### DIFF
--- a/source/settings.cpp
+++ b/source/settings.cpp
@@ -624,7 +624,7 @@ namespace Settings {
     Shuffle(dungeonModes);
 
     if (RandomMQDungeons) {
-      MQDungeonCount.SetSelectedIndex(Random(0, MQDungeonCount.GetOptionCount()+1));
+      MQDungeonCount.SetSelectedIndex(Random(0, MQDungeonCount.GetOptionCount()));
     }
     for (u8 i = 0; i < MQDungeonCount.Value<u8>(); i++) {
       *dungeonModes[i] = DUNGEONMODE_MQ;
@@ -635,7 +635,7 @@ namespace Settings {
     Shuffle(trialsSkipped);
 
     if (RandomGanonsTrials) {
-      GanonsTrialsCount.SetSelectedIndex(Random(0, GanonsTrialsCount.GetOptionCount()+1));
+      GanonsTrialsCount.SetSelectedIndex(Random(0, GanonsTrialsCount.GetOptionCount()));
     }
     for (u8 i = 0; i < GanonsTrialsCount.Value<u8>(); i++) {
       *trialsSkipped[i] = false; //the selected trial is not skipped


### PR DESCRIPTION
Would accidentally potentially get 1 higher than the right value (ex. get 7 for random trial count)