### PR TITLE
item_pool: Take Item instances by reference in JoinPools

### DIFF
--- a/source/item_pool.cpp
+++ b/source/item_pool.cpp
@@ -465,7 +465,7 @@ static void AddItemToMainPool(const Item& item, size_t count = 1) {
 
 template <size_t N>
 static void JoinPools(std::vector<Item>& pool1, const std::array<Item, N>& pool2) {
-  for (const Item item : pool2) {
+  for (const Item& item : pool2) {
     AddItemToPool(pool1, item);
   }
 }


### PR DESCRIPTION
Prevents items from being copied and churning string allocations a little bit.