### PR TITLE
item_pool: Fix bottle vector erases not persisting in AddRandomBottle()

### DIFF
--- a/source/item_pool.cpp
+++ b/source/item_pool.cpp
@@ -470,7 +470,7 @@ static void JoinPools(std::vector<Item>& pool1, const std::array<Item, N>& pool2
   }
 }
 
-static void AddRandomBottle(std::vector<Item> bottlePool) {
+static void AddRandomBottle(std::vector<Item>& bottlePool) {
   AddItemToMainPool(RandomElement(bottlePool, true));
 }
 


### PR DESCRIPTION
`AddRandomBottle` was previously taking the bottle vector by value, but `RandomElement` was told to remove the randomized bottle from the pool (since `true` was passed). Since it was taking the vector by value, the erasure from the vector would never persist. This fixes that.