### PR TITLE
spoiler_log: Place randomizer hash behind accessor

### DIFF
--- a/source/menu.cpp
+++ b/source/menu.cpp
@@ -600,14 +600,14 @@ void GenerateRandomizer() {
       printf("\x1b[14;10HOoT3D mods folder, then launch OoT3D!\n");
     }
 
-
+    const auto& randomizerHash = GetRandomizerHash();
     printf("\x1b[16;10HHash:");
-    for (u8 i = 0; i < randomizerHash.size(); i++) {
-      printf("\x1b[%d;11H- %s", i + 17, randomizerHash[i].c_str());
+    for (size_t i = 0; i < randomizerHash.size(); i++) {
+      printf("\x1b[%zu;11H- %s", i + 17, randomizerHash[i].c_str());
     }
-	} else {
-		printf("Failed\nPress Select to exit.\n");
-	}
+  } else {
+    printf("Failed\nPress Select to exit.\n");
+  }
 }
 
 //opens up the 3ds software keyboard for getting user input

--- a/source/spoiler_log.cpp
+++ b/source/spoiler_log.cpp
@@ -54,14 +54,18 @@ namespace {
   };
 }
 
-std::array<std::string, 5> randomizerHash = {"", "", "", "", ""};
+static RandomizerHash randomizerHash;
 
 void GenerateHash() {
-  for (u32 i = 0; i < 5; i++) {
-    u8 iconIndex = Random(0, hashIcons.size());
+  for (size_t i = 0; i < randomizerHash.size(); i++) {
+    const auto iconIndex = static_cast<u8>(Random(0, hashIcons.size()));
     Settings::hashIconIndexes[i] = iconIndex;
     randomizerHash[i] = hashIcons[iconIndex];
   }
+}
+
+const RandomizerHash& GetRandomizerHash() {
+  return randomizerHash;
 }
 
 static void SpoilerLog_SaveLocation(std::string_view loc, std::string_view item) {

--- a/source/spoiler_log.hpp
+++ b/source/spoiler_log.hpp
@@ -1,11 +1,13 @@
 #pragma once
+
+#include <string>
 #include <string_view>
 #include <vector>
 #include "item_location.hpp"
 
-extern std::array<std::string, 5> randomizerHash;
-
+using RandomizerHash = std::array<std::string, 5>;
 void GenerateHash();
+const RandomizerHash& GetRandomizerHash();
 
 bool SpoilerLog_Write();
 


### PR DESCRIPTION
Prevents unintentional modification of the hash from ever occurring outside of the API

Also eliminates an implicit type truncation