### PR TITLE
Docker image update

### DIFF
--- a/.github/workflows/create_nightly.yml
+++ b/.github/workflows/create_nightly.yml
@@ -2,14 +2,14 @@ name: Create 3DSX and CIA Files, and drafts/posts a new Release.
 
 on:
   push:
-    branches: [ main, docker-image-update ]
+    branches: [ main ]
 
 jobs:
   build-cia-3dsx:
     runs-on: ubuntu-latest
     container:
       image: phlex/oot3dr-build-tools
-      
+
     steps:
       - uses: actions/checkout@v2
 

--- a/.github/workflows/create_nightly.yml
+++ b/.github/workflows/create_nightly.yml
@@ -2,14 +2,14 @@ name: Create 3DSX and CIA Files, and drafts/posts a new Release.
 
 on:
   push:
-    branches: [ main ]
+    branches: [ main, docker-image-update ]
 
 jobs:
   build-cia-3dsx:
     runs-on: ubuntu-latest
     container:
-      image: devkitpro/devkitarm
-
+      image: phlex/oot3dr-build-tools
+      
     steps:
       - uses: actions/checkout@v2
 

--- a/linux_build_rando.sh
+++ b/linux_build_rando.sh
@@ -1,49 +1,20 @@
 #!/bin/bash
 
-gather_required_files() {
-  echo "Our python version: "
-  python3 -V
-  sudo apt update && sudo apt install automake build-essential wget unzip zip  -y
-  sudo apt-get install libreadline-gplv2-dev libncursesw5-dev libssl-dev \
-    libsqlite3-dev tk-dev libgdbm-dev libc6-dev libbz2-dev libffi-dev zlib1g-dev -y
-  sudo wget https://www.python.org/ftp/python/3.8.5/Python-3.8.5.tgz
-  sudo tar xzf Python-3.8.5.tgz
-  cd Python-3.8.5
-  sudo ./configure --enable-optimizations
-  sudo make install
-  cd ../
-  wget https://github.com/3DSGuy/Project_CTR/releases/download/makerom-v0.17/makerom-v0.17-ubuntu_x86_64.zip
-  unzip makerom-v0.17-ubuntu_x86_64.zip
-  git clone https://github.com/Steveice10/bannertool.git
-  cd bannertool
-  git submodule update --init
-  make
-  unzip ./output/bannertool.zip
-  mv linux-x86_64/bannertool ../bannertoolexec
-  cd ..
-  wget https://github.com/dnasdw/3dstool/releases/download/v1.2.6/3dstool_linux_x86_64.tar.gz
-  tar -zxvf 3dstool_linux_x86_64.tar.gz
-  chmod +x bannertoolexec
-  chmod +x makerom
-  chmod + 3dstool
-}
-
 compile() {
   # If building manually just replace SHA with your own text.
   export commitHashShort=$(echo ${GITHUB_SHA::6})
   sed -i "s/COMMITNUM/$commitHashShort/" ./source/menu.cpp
   sed -i "s/COMMITNUM/$commitHashShort/" ./source/settings.cpp
   make
-  ./bannertoolexec makebanner -i ./banner.png -a ./audio.wav -o ./banner.bnr
-  ./bannertoolexec makesmdh -s "Ocarina of Time 3D Randomizer" -l "A different Ocarina of Time experience" -p "Gamestabled & Gymnast86" -i icon.png -o ./icon.icn
-  ./3dstool -cvtf romfs ./romfs.bin --romfs-dir ./romfs
-  ./makerom -f cia -o OoT3D_Randomizer.cia -DAPP_ENCRYPTED=false -target t -exefslogo -elf ./OoT3D_Randomizer.elf -icon ./icon.icn -banner ./banner.bnr -rsf ./ootrando.rsf -romfs ./romfs.bin -major 1 -minor 0 -micro 1
+  bannertoolexec makebanner -i ./banner.png -a ./audio.wav -o ./banner.bnr
+  bannertoolexec makesmdh -s "Ocarina of Time 3D Randomizer" -l "A different Ocarina of Time experience" -p "Gamestabled & Gymnast86" -i icon.png -o ./icon.icn
+  3dstool -cvtf romfs ./romfs.bin --romfs-dir ./romfs
+  makerom -f cia -o OoT3D_Randomizer.cia -DAPP_ENCRYPTED=false -target t -exefslogo -elf ./OoT3D_Randomizer.elf -icon ./icon.icn -banner ./banner.bnr -rsf ./ootrando.rsf -romfs ./romfs.bin -major 1 -minor 0 -micro 1
 }
 
 clean_up() {
   rm -rf bannertool* makerom* 3dstool* icon.icn ext_key.txt ignore_3dstool.txt banner.bnr romfs.bin
 }
 
-gather_required_files
 compile
 clean_up


### PR DESCRIPTION
Instead of compiling python 3.8.5 in the action itself, I forked the DevkitPro images and did it in there. Speeds up the build time by about 3-5 minutes. With that, I removed a bunch of unnecessary code in the build script as well.