### PR TITLE
menu: Centralize preset path construction and simplify string checks.

### DIFF
--- a/source/menu.cpp
+++ b/source/menu.cpp
@@ -549,7 +549,7 @@ static std::string PresetPath(std::string_view presetName) {
 }
 
 //Load the selected preset
-bool LoadPreset(std::string presetName, bool print) {
+bool LoadPreset(std::string_view presetName, bool print) {
   //clear any potential 'failed to load preset' message on previous attempt
   ClearDescription();
 
@@ -617,7 +617,7 @@ bool SaveCachedPreset() {
 }
 
 //Saves the new preset to a file
-bool SavePreset(std::string presetName) {
+bool SavePreset(std::string_view presetName) {
   Result res;
   FS_Archive sdmcArchive = 0;
   Handle presetFile;
@@ -658,7 +658,7 @@ bool SavePreset(std::string presetName) {
 }
 
 //Delete the selected preset
-bool DeletePreset(std::string presetName) {
+bool DeletePreset(std::string_view presetName) {
   //clear any potential message
   ClearDescription();
 

--- a/source/menu.cpp
+++ b/source/menu.cpp
@@ -544,6 +544,10 @@ void LoadCachedPreset() {
   }
 }
 
+static std::string PresetPath(std::string_view presetName) {
+  return std::string("/3ds/presets/oot3d/").append(presetName).append(".bin");
+}
+
 //Load the selected preset
 bool LoadPreset(std::string presetName, bool print) {
   //clear any potential 'failed to load preset' message on previous attempt
@@ -555,7 +559,7 @@ bool LoadPreset(std::string presetName, bool print) {
   u32 bytesRead = 0;
   u32 totalRW = 0;
 
-  std::string filepath = "/3ds/presets/oot3d/" + presetName + ".bin";
+  const std::string filepath = PresetPath(presetName);
 
   // Open SD archive
   if (!R_SUCCEEDED(res = FSUSER_OpenArchive(&sdmcArchive, ARCHIVE_SDMC, fsMakePath(PATH_EMPTY, "")))) {
@@ -620,9 +624,7 @@ bool SavePreset(std::string presetName) {
   u32 bytesWritten = 0;
   u32 totalRW = 0;
 
-  std::string presetsFilepath = "/3ds/presets/oot3d/";
-  std::string filepath = presetsFilepath + presetName + ".bin";
-
+  const std::string filepath = PresetPath(presetName);
   SettingsContext ctx = Settings::FillContext();
 
   // Open SD archive
@@ -663,7 +665,7 @@ bool DeletePreset(std::string presetName) {
   Result res;
   FS_Archive sdmcArchive = 0;
 
-  std::string filepath = "/3ds/presets/oot3d/" + presetName + ".bin";
+  const std::string filepath = PresetPath(presetName);
 
   // Open SD archive
   if (!R_SUCCEEDED(res = FSUSER_OpenArchive(&sdmcArchive, ARCHIVE_SDMC, fsMakePath(PATH_EMPTY, "")))) {

--- a/source/menu.cpp
+++ b/source/menu.cpp
@@ -601,7 +601,7 @@ bool LoadPreset(std::string presetName, bool print) {
 bool SaveSpecifiedPreset() {
   std::string presetName = (GetInput("Preset Name")).substr(0, 19);
   //don't save if the user cancelled
-  if (presetName == "") {
+  if (presetName.empty()) {
     return false;
   }
   return SavePreset(presetName);
@@ -683,16 +683,16 @@ void GenerateRandomizer() {
   consoleClear();
 
   //if a blank seed was entered, make a random one
-  if (Settings::seed == "") {
+  if (Settings::seed.empty()) {
     Settings::seed = std::to_string(rand());
   } else if (Settings::seed.rfind("seed_testing_count", 0) == 0) {
-    int count = std::stoi(Settings::seed.substr(18, std::string::npos), nullptr);
+    const int count = std::stoi(Settings::seed.substr(18), nullptr);
     Playthrough::Playthrough_Repeat(count);
     return;
   }
 
   //turn the settings into a string for hashing
-  std::string settingsStr = "";
+  std::string settingsStr;
   for (MenuItem* menu : Settings::mainMenu) {
     //don't go through non-menus
     if (menu->type == MenuItemType::Action) {

--- a/source/menu.hpp
+++ b/source/menu.hpp
@@ -44,11 +44,11 @@ void PrintOptionDescrption();
 bool CreatePresetDirectories();
 void GetPresets();
 void LoadCachedPreset();
-bool LoadPreset(std::string presetName, bool print);
+bool LoadPreset(std::string_view presetName, bool print);
 bool SaveSpecifiedPreset();
 bool SaveCachedPreset();
-bool SavePreset(std::string presetName);
-bool DeletePreset(std::string presetName);
+bool SavePreset(std::string_view presetName);
+bool DeletePreset(std::string_view presetName);
 void GenerateRandomizer();
 std::string GetInput(const char* hintText);
 


### PR DESCRIPTION
Adds a helper function to deduplicate the preset path construction. While we're at it, we can also change some empty string checks to `.empty()`.