### PR TITLE
Logic:Re-add EventsUpdated check to GetAccessibleLocations

### DIFF
--- a/code/src/savefile.c
+++ b/code/src/savefile.c
@@ -3,7 +3,7 @@
 
 void SaveFile_Init() {
 #ifdef ENABLE_DEBUG
-    //gSaveContext.equipment  |= 0xFFFF;  //Swords, shields, tunics, boots
+    gSaveContext.equipment  |= 0x0FFF;  //Swords, shields, tunics, boots
     gSaveContext.bgsFlag     = 1;
     gSaveContext.bgsHitsLeft = 1;
     gSaveContext.upgrades   |= 0x109;   //bomb bag, quiver, strength

--- a/source/fill.cpp
+++ b/source/fill.cpp
@@ -88,8 +88,8 @@ static std::vector<ItemLocation*> GetAccessibleLocations(std::vector<ItemLocatio
   //Variables for search
   std::vector<ItemLocation *> newItemLocations;
   bool firstIteration = true;
-  //If no new items are found, then the next iteration won't provide any new location
-  while(newItemLocations.size() > 0 || firstIteration) {
+  //If no new items are found and no events are updated, then the next iteration won't provide any new location
+  while(newItemLocations.size() > 0 || firstIteration || EventsUpdated()) {
     firstIteration = false;;
 
     //Add items found during previous search iteration to logic
@@ -161,13 +161,13 @@ static std::vector<ItemLocation*> GetAccessibleLocations(std::vector<ItemLocatio
             }
 
             //Playthrough stuff
-            if (playthrough && !playthroughBeatable && location->GetPlacedItem().IsAdvancement()) {            
+            if (playthrough && !playthroughBeatable && location->GetPlacedItem().IsAdvancement()) {
               ItemType type = location->GetPlacedItem().GetItemType();
               bool bombchus = location->GetPlacedItem().GetName().find("Bombchu") != std::string::npos;
               //Don't print Buy locations
               if(type != ITEMTYPE_SHOP && type != ITEMTYPE_TOKEN && !bombchus) {
                 sphere.push_back(location);
-              }     
+              }
               //Only print first 50 token locations
               else if(type == ITEMTYPE_TOKEN && gsCount < 50 && !bombchus) {
                 sphere.push_back(location);
@@ -181,7 +181,7 @@ static std::vector<ItemLocation*> GetAccessibleLocations(std::vector<ItemLocatio
             }
             //Triforce has been found, seed is beatable, nothing else in this or future spheres matters
             else if(playthrough && location->GetPlacedItem().GetName() == "Triforce") {
-              sphere.clear(); 
+              sphere.clear();
               sphere.push_back(location);
               playthroughBeatable = true;
             }

--- a/source/menu.cpp
+++ b/source/menu.cpp
@@ -695,7 +695,7 @@ void GenerateRandomizer() {
   std::string settingsStr = "";
   for (MenuItem* menu : Settings::mainMenu) {
     //don't go through non-menus
-    if (menu->type == MenuItemType::Action) {
+    if (menu->mode != OPTION_SUB_MENU) {
       continue;
     }
 

--- a/source/spoiler_log.cpp
+++ b/source/spoiler_log.cpp
@@ -102,7 +102,7 @@ static void WriteSettings() {
   logtxt += "Settings:\n";
   for (MenuItem* menu : Settings::mainMenu) {
     //don't log the detailed logic or exclude location menus yet
-    if (menu->name == "Detailed Logic Settings" || menu->name == "Exclude Locations" || menu->type == MenuItemType::Action) {
+    if (menu->name == "Detailed Logic Settings" || menu->name == "Exclude Locations" || menu->mode != OPTION_SUB_MENU) {
       continue;
     }
 


### PR DESCRIPTION
- Currently getting the accessible locations only checks for items obtained, but needs to also check for any updated events that might now be true, since events can also open up new locations.
- Fixed a crash that was happening when trying to read the Settings Presets menu as if it was an options menu