### PR TITLE
Logic: Decoupled ItemOverrides from Logically placing items during filling algorithm

### DIFF
--- a/source/fill.cpp
+++ b/source/fill.cpp
@@ -428,6 +428,7 @@ int Fill() {
     //Successful placement, produced beatable result
     if(playthroughBeatable) {
       printf("Done");
+      CreateOverrides();
       return 1;
     }
     //Unsuccessful placement

--- a/source/item_location.cpp
+++ b/source/item_location.cpp
@@ -1699,16 +1699,6 @@ void GenerateLocationPool() {
 }
 
 void PlaceItemInLocation(ItemLocation* loc, Item item, bool applyEffectImmediately /*= false*/) {
-    /*-------------------------------------------------
-    |    TEMPORARY FIX FOR FREESTANDING KEY CRASHES   |
-    --------------------------------------------------*/
-    //this prevents an override from being created for these two locations
-    if (loc->GetName() != "Shadow Temple Freestanding Key" && loc->GetName() != "Gerudo Training Grounds Freestanding Key") {
-      overrides.insert({
-        .key = loc->Key(),
-        .value = item.Value(),
-      });
-    }
 
     PlacementLog_Msg("\n");
     PlacementLog_Msg(item.GetName());
@@ -1819,4 +1809,27 @@ void AddExcludedOptions() {
   for (ItemLocation * il: everyPossibleLocation) {
     il->AddExcludeOption();
   }
+}
+
+void CreateOverrides() {
+  PlacementLog_Msg("NOW CREATING OVERRIDES\n\n");
+  for (ItemLocation* loc : allLocations) {
+    PlacementLog_Msg("\t");
+    PlacementLog_Msg(loc->GetName());
+    PlacementLog_Msg(": ");
+    PlacementLog_Msg(loc->GetPlacedItemName());
+    PlacementLog_Msg("\n");
+    /*-------------------------------------------------
+    |    TEMPORARY FIX FOR FREESTANDING KEY CRASHES   |
+    --------------------------------------------------*/
+    //this prevents an override from being created for these two locations
+    if (loc->GetName() != "Shadow Temple Freestanding Key" && loc->GetName() != "Gerudo Training Grounds Freestanding Key") {
+      overrides.insert({
+        .key = loc->Key(),
+        .value = loc->GetPlacedItem().Value(),
+      });
+    }
+  }
+  PlacementLog_Msg("Overrides Created: ");
+  PlacementLog_Msg(std::to_string(overrides.size()));
 }

--- a/source/item_location.hpp
+++ b/source/item_location.hpp
@@ -1033,3 +1033,4 @@ extern std::vector<ItemLocation*> GetLocations(std::vector<ItemLocation*> locati
 extern void LocationReset();
 extern void ItemReset();
 extern void AddExcludedOptions();
+extern void CreateOverrides();

--- a/source/location_access.cpp
+++ b/source/location_access.cpp
@@ -1862,8 +1862,12 @@ namespace Exits { //name, scene, hint, events, locations, exits
                   ItemLocationPairing(&FireTemple_NearBossChest,    []{return LogicFewerTunicRequirements || CanUse("Goron Tunic");}),
                   ItemLocationPairing(&FireTemple_FlareDancerChest, []{return /*SmallKeys(FireTempleKeys, 8) &&*/ CanUse("Hammer");}),
                   ItemLocationPairing(&FireTemple_BossKeyChest,     []{return /*SmallKeys(FireTempleKeys, 8) &&*/ CanUse("Hammer");}),
-                  ItemLocationPairing(&FireTemple_VolvagiaHeart,    []{return CanUse("Goron Tunic") && CanUse("Hammer") && BossKeyFireTemple && (LogicFireBossDoorJump || HoverBoots || CanPlay(SongOfTime) || HasExplosives);}),
-                  ItemLocationPairing(&Volvagia,                    []{return CanUse("Goron Tunic") && CanUse("Hammer") && BossKeyFireTemple && (LogicFireBossDoorJump || HoverBoots || CanPlay(SongOfTime) || HasExplosives);}),
+                  ItemLocationPairing(&FireTemple_VolvagiaHeart,    []{return CanUse("Goron Tunic") && CanUse("Hammer") && BossKeyFireTemple &&
+                                                                                (LogicFireBossDoorJump || HoverBoots ||
+                                                                                  (FireTemple_Upper.Adult() && (CanPlay(SongOfTime) || HasExplosives)));}),
+                  ItemLocationPairing(&Volvagia,                    []{return CanUse("Goron Tunic") && CanUse("Hammer") && BossKeyFireTemple &&
+                                                                                (LogicFireBossDoorJump || HoverBoots ||
+                                                                                  (FireTemple_Upper.Adult() && (CanPlay(SongOfTime) || HasExplosives)));}),
                   ItemLocationPairing(&FireTemple_GS_BossKeyLoop,   []{return /*SmallKeys(FireTempleKeys, 8) &&*/ CanUse("Hammer");}),
                 }, {
                   //Exits

--- a/source/playthrough.cpp
+++ b/source/playthrough.cpp
@@ -62,7 +62,7 @@ namespace Playthrough {
         repeatedSeed = rand() % 0xFFFFFFFF;
         Settings::seed = std::to_string(repeatedSeed);
         Playthrough_Init(repeatedSeed);
-
+        PlacementLog_Clear();
         printf("\x1b[15;15HSeeds Generated: %d\n", i + 1);
       }
 

--- a/source/spoiler_log.cpp
+++ b/source/spoiler_log.cpp
@@ -220,6 +220,10 @@ void PlacementLog_Msg(std::string_view msg) {
   placementtxt += msg;
 }
 
+void PlacementLog_Clear() {
+  placementtxt = "";
+}
+
 bool PlacementLog_Write() {
   Result res = 0;
   u32 bytesWritten = 0;
@@ -245,6 +249,5 @@ bool PlacementLog_Write() {
   FSFILE_Close(placementlog);
   FSUSER_CloseArchive(sdmcArchive);
 
-  placementtxt = "";
   return true;
 }

--- a/source/spoiler_log.hpp
+++ b/source/spoiler_log.hpp
@@ -12,4 +12,5 @@ const RandomizerHash& GetRandomizerHash();
 bool SpoilerLog_Write();
 
 void PlacementLog_Msg(std::string_view msg);
+void PlacementLog_Clear();
 bool PlacementLog_Write();


### PR DESCRIPTION
- Creating ItemOverrides during the filling algorithm was causing there to be multiple overrides for the same location. Overrides are now created after a beatable playthrough is generated.
- Fixed a logic error in Fire Temple Lower