### PR TITLE
Patch:Skip Zelda's Letter Cutscene and minor fixes

### DIFF
--- a/code/src/entrance.c
+++ b/code/src/entrance.c
@@ -46,6 +46,11 @@ void Entrance_Init(void) {
         gEntranceTable[index].field = 0x0102;
     }
 
+    // Delete the title card for Temple of Time from Pulling/Placing Master Sword
+    for (index = 0x2CA; index < 0x2CE; ++index) {
+        gEntranceTable[index].field = 0x0102;
+    }
+
     // Delete the title card for Kakariko Village from Nocturne
     for (index = 0x513; index < 0x517; ++index) {
         gEntranceTable[index].field = 0x0102;

--- a/code/src/entrance.c
+++ b/code/src/entrance.c
@@ -30,7 +30,7 @@ void Entrance_Init(void) {
     // Skip Child Stealth if given by settings
     if (gSettingsContext.skipChildStealth == SKIP) {
         gEntranceTable[0x07A].scene = 0x4A;
-        gEntranceTable[0x07A].spawn = 0x01;
+        gEntranceTable[0x07A].spawn = 0x00;
         gEntranceTable[0x07A].field = 0x0183;
     }
 

--- a/code/src/item_override.c
+++ b/code/src/item_override.c
@@ -253,6 +253,7 @@ static void ItemOverride_TryPendingItem(void) {
 }
 
 void ItemOverride_Update(void) {
+    ItemOverride_CheckZeldasLetter();
     IceTrap_Update();
     if (ItemOverride_PlayerIsReady()) {
         ItemOverride_PopIceTrap();
@@ -412,4 +413,17 @@ s32 ItemOverride_GiveSariasGift(void) {
 
     // return 1 to skip the cutscene
     return 1;
+}
+
+//If we haven't obtained Zelda's Letter and are in the castle courtyard, push it
+void ItemOverride_CheckZeldasLetter() {
+  if (EventCheck(0x40) == 0 && gGlobalContext->sceneNum == 0x4A) {
+      ItemOverride_Key key = { .all = 0 };
+      key.scene = 0x4A;
+      key.type = OVR_BASE_ITEM;
+      key.flag = 0x0B;
+      ItemOverride override = ItemOverride_LookupByKey(key);
+      ItemOverride_PushPendingOverride(override);
+      EventSet(0x40);
+  }
 }

--- a/code/src/item_override.h
+++ b/code/src/item_override.h
@@ -42,5 +42,6 @@ typedef struct {
 ItemOverride ItemOverride_LookupByKey(ItemOverride_Key key);
 ItemOverride ItemOverride_Lookup(Actor* actor, u8 scene, u8 item_id);
 void ItemOverride_PushDelayedOverride(u8 flag);
+void ItemOverride_CheckZeldasLetter();
 
 #endif

--- a/source/menu.cpp
+++ b/source/menu.cpp
@@ -703,7 +703,7 @@ void GenerateRandomizer() {
 
     for (size_t i = 0; i < menu->settingsList->size(); i++) {
       Option* setting = menu->settingsList->at(i);
-      if (setting->GetName() != "Mirror World") {
+      if (setting->GetName() != "Mirror World" && setting->GetName() != "All Tricks") {
         settingsStr += setting->GetSelectedOption();
       }
     }


### PR DESCRIPTION
- The Item Override for Zelda's Letter is now pushed immediately upon entering Zelda's Courtyard
- The "All Tricks" toggle now does not affect the settings string
- Deleted the Temple of Time title card since it was interfering with the prelude check