### PR TITLE
item_pool: Don't add songs to plentiful pool on dungeon rewards

### DIFF
--- a/source/item_pool.cpp
+++ b/source/item_pool.cpp
@@ -1225,7 +1225,7 @@ void GenerateItemPool() {
 
   //add songs
   AddItemsToPool(ItemPool, songList);
-  if (ShuffleSongs && ItemPoolValue.Is(ITEMPOOL_PLENTIFUL)) {
+  if (ShuffleSongs && ItemPoolValue.Is(ITEMPOOL_PLENTIFUL) && !ShuffleSongs.Is(SONGSHUFFLE_DUNGEON_REWARDS)) {
     AddItemsToPool(PendingJunkPool, songList);
   }
 


### PR DESCRIPTION
Fixes a minor issue that would cause seeds with songs as dungeon rewards and plentiful item pool to fail, since songs would be added to the pool twice.