### PR TITLE
settings: Add random starting age option

### DIFF
--- a/code/src/savefile.c
+++ b/code/src/savefile.c
@@ -68,7 +68,7 @@ void SaveFile_Init() {
         gSaveContext.eventChkInf[0x4] |= 0x2000;
     }
 
-    if (gSettingsContext.startingAge == AGE_ADULT) {
+    if (gSettingsContext.resolvedStartingAge == AGE_ADULT) {
         gSaveContext.linkAge       = AGE_ADULT;  //age is adult
         gSaveContext.entranceIndex = 0xF4050000; //spawn at temple of time
         gSaveContext.sceneIndex    = 0x6100;     //^

--- a/code/src/settings.h
+++ b/code/src/settings.h
@@ -59,6 +59,7 @@ typedef enum {
 typedef enum {
   AGE_ADULT,
   AGE_CHILD,
+  AGE_RANDOM,
 } AgeSetting;
 
 typedef enum {
@@ -171,6 +172,7 @@ typedef struct {
   u8 ganonsTrialsCount;
 
   u8 startingAge;
+  u8 resolvedStartingAge;
   u8 bombchusInLogic;
   u8 bombchuDrops;
   u8 randomMQDungeons;

--- a/source/location_access.cpp
+++ b/source/location_access.cpp
@@ -2698,13 +2698,13 @@ namespace Exits { //name, scene, hint, events, locations, exits
     }
 
     if(Settings::HasNightStart) {
-        if(Settings::StartingAge.Is(AGE_CHILD)) {
+        if(Settings::ResolvedStartingAge == AGE_CHILD) {
           Exits::Root.nightChild = true;
         } else {
           Exits::Root.nightAdult = true;
         }
       } else {
-        if(Settings::StartingAge.Is(AGE_CHILD)) {
+        if(Settings::ResolvedStartingAge == AGE_CHILD) {
           Exits::Root.dayChild = true;
         } else {
           Exits::Root.dayAdult = true;
@@ -2724,13 +2724,13 @@ namespace Exits { //name, scene, hint, events, locations, exits
     }
 
     if(Settings::HasNightStart) {
-        if(Settings::StartingAge.Is(AGE_CHILD)) {
+        if(Settings::ResolvedStartingAge == AGE_CHILD) {
           Exits::Root.nightChild = true;
         } else {
           Exits::Root.nightAdult = true;
         }
       } else {
-        if(Settings::StartingAge.Is(AGE_CHILD)) {
+        if(Settings::ResolvedStartingAge == AGE_CHILD) {
           Exits::Root.dayChild = true;
         } else {
           Exits::Root.dayAdult = true;

--- a/source/logic.cpp
+++ b/source/logic.cpp
@@ -251,7 +251,6 @@ namespace Logic {
   //Other
   bool AtDay         = false;
   bool AtNight       = false;
-  bool IsStartingAge = false;
   u8 Age             = 0;
 
   //Events
@@ -426,7 +425,6 @@ namespace Logic {
 
     IsChild = Age == AGE_CHILD;
     IsAdult = Age == AGE_ADULT;
-    IsStartingAge = StartingAge.Is(Age); //what's this for?
 
   //IsGlitched = false;
 
@@ -755,8 +753,7 @@ namespace Logic {
      //Other
      AtDay         = false;
      AtNight       = false;
-     IsStartingAge = false;
-     Age           = Settings::StartingAge.Value<u8>();
+     Age           = Settings::ResolvedStartingAge;
 
      //Events
      ShowedMidoSwordAndShield  = false;

--- a/source/logic.hpp
+++ b/source/logic.hpp
@@ -208,7 +208,6 @@ namespace Logic {
   extern bool HasExplosives;
   extern bool IsChild;
   extern bool IsAdult;
-  extern bool IsStartingAge;
 //extern bool IsGlitched;
   extern bool CanBlastOrSmash;
   extern bool CanChildAttack;
@@ -264,7 +263,6 @@ namespace Logic {
   extern bool ChildWaterTemple;
   extern bool RaiseWaterLevel;
   extern bool KingZoraThawed;
-  extern bool IsStartingAge;
   extern bool AtDampeTime;
   extern bool DeliverLetter;
   extern bool KakarikoVillageGateOpen;

--- a/source/settings.cpp
+++ b/source/settings.cpp
@@ -38,7 +38,8 @@ namespace Settings {
   };
 
   //World Settings
-  Option StartingAge         = Option::U8  ("Starting Age",           {"Adult", "Child"},                                      {ageDesc, ageDesc});
+  Option StartingAge         = Option::U8  ("Starting Age",           {"Adult", "Child", "Random"},                            {ageDesc, ageDesc, ageDesc});
+  u8 ResolvedStartingAge;
   Option BombchusInLogic     = Option::Bool("Bombchus in Logic",      {"Off", "On"},                                           {bombchuLogicDesc, bombchuLogicDesc});
   Option BombchuDrops        = Option::Bool("Bombchu Drops",          {"Off", "On"},                                           {bombchuDropDesc, bombchuDropDesc});
   Option RandomMQDungeons    = Option::Bool("Random MQ Dungeons",     {"Off", "On"},                                           {randomMQDungeonsDesc, randomMQDungeonsDesc});
@@ -372,6 +373,8 @@ namespace Settings {
     ctx.ganonsTrialsCount  = GanonsTrialsCount.Value<u8>();
 
     ctx.startingAge        = StartingAge.Value<u8>();
+    ctx.resolvedStartingAge = ResolvedStartingAge;
+
     ctx.bombchusInLogic    = (BombchusInLogic) ? 1 : 0;
     ctx.bombchuDrops       = (BombchuDrops) ? 1 : 0;
     ctx.randomMQDungeons   = (RandomMQDungeons) ? 1 : 0;
@@ -798,6 +801,19 @@ namespace Settings {
     }
     for (u8 i = 0; i < GanonsTrialsCount.Value<u8>(); i++) {
       *trialsSkipped[i] = false; //the selected trial is not skipped
+    }
+
+    if (StartingAge.Is(AGE_RANDOM)) {
+      int choice = Random(0, 2); //50% chance of each
+      if (choice == 0) {
+        ResolvedStartingAge = AGE_CHILD;
+      }
+      else {
+        ResolvedStartingAge = AGE_ADULT;
+      }
+    }
+    else {
+      ResolvedStartingAge = StartingAge.Value<u8>();
     }
 
     HasNightStart = StartingTime.Is(STARTINGTIME_NIGHT);

--- a/source/settings.hpp
+++ b/source/settings.hpp
@@ -210,6 +210,7 @@ namespace Settings {
   extern Option GanonsTrialsCount;
 
   extern Option StartingAge;
+  extern u8 ResolvedStartingAge;
   extern Option BombchusInLogic;
   extern Option BombchuDrops;
   extern Option RandomMQDungeons;


### PR DESCRIPTION
Added the option to start as a random age, with a 50% chance of each. To accommodate this added a property to Settings and SettingsContext, ResolvedStartingAge. Technically I could just directly write the random result to StartingAge and it would work, but then the selected age would a) Show up in the spoiler and b) Change the setting to whichever was chosen (both in the menu and in the cached preset).

Also, noticed a bool IsStartingAge which seemed to be unused (There was even a comment pointing this out) so I removed it.