### PR TITLE
Logic:Added options for configurable number of stones/medallions on certain settings

### DIFF
--- a/code/src/cutscenes.c
+++ b/code/src/cutscenes.c
@@ -1,6 +1,7 @@
 #include "z3D/z3D.h"
 #include "item_override.h"
 #include "settings.h"
+#include "savefile.h"
 #include "z3D/actors/z_bg_dy_yoseizo.h"
 #include <stddef.h>
 
@@ -14,14 +15,19 @@ u32 LACS_ConditionVanilla(void) {
 }
 
 u32 LACS_ConditionStones(void) {
-    return ((gSaveContext.questItems & 0x40000) && (gSaveContext.questItems & 0x80000)
-        && (gSaveContext.questItems & 0x100000));
+    return SaveFile_GetStoneCount() >= gSettingsContext.lacsStoneCount;
 }
 
 u32 LACS_ConditionMedallions(void) {
-    return ((gSaveContext.questItems & 0x1) && (gSaveContext.questItems & 0x2)
-        && (gSaveContext.questItems & 0x4) && (gSaveContext.questItems & 0x8)
-        && (gSaveContext.questItems & 0x10) && (gSaveContext.questItems & 0x20));
+    return SaveFile_GetMedallionCount() >= gSettingsContext.lacsMedallionCount;
+}
+
+u32 LACS_ConditionDungeons(void) {
+    return SaveFile_GetStoneCount() + SaveFile_GetMedallionCount() >= gSettingsContext.lacsDungeonCount;
+}
+
+u32 LACS_ConditionTokens(void) {
+    return gSaveContext.gsTokens >= gSettingsContext.lacsTokenCount;
 }
 
 void Cutscene_OverrideLACS(void) {
@@ -38,7 +44,10 @@ void Cutscene_OverrideLACS(void) {
             conditionMet = LACS_ConditionMedallions();
             break;
         case LACSCONDITION_DUNGEONS:
-            conditionMet = (LACS_ConditionStones() && LACS_ConditionMedallions());
+            conditionMet = LACS_ConditionDungeons();
+            break;
+        case LACSCONDITION_TOKENS:
+            conditionMet = LACS_ConditionTokens();
             break;
     }
     if (conditionMet) {

--- a/code/src/entrance.c
+++ b/code/src/entrance.c
@@ -43,42 +43,42 @@ void Entrance_Init(void) {
     }
 
     // Delete the title card for Kokiri Forest from Deku Tree Death Cutscene
-    for (index = 0x457; index < 0x45A; ++index) {
+    for (index = 0x457; index <= 0x45A; ++index) {
         gEntranceTable[index].field = 0x0202;
     }
 
     // Delete the title card for Death Mountain Trail from Goron Ruby Cutscene
-    for (index = 0x47A; index < 0x47D; ++index) {
+    for (index = 0x47A; index <= 0x47D; ++index) {
         gEntranceTable[index].field = 0x0202;
     }
 
     // Delete the title card for Zora's Fountain from Inside Jabu Jabu's Belly
-    for (index = 0x221; index < 0x224; ++index) {
+    for (index = 0x221; index <= 0x224; ++index) {
         gEntranceTable[index].field = 0x0102;
     }
 
     // Delete the title card for Sacred Forest Meadow from Forest Temple Blue Warp
-    for (index = 0x608; index < 0x60B; ++index) {
+    for (index = 0x608; index <= 0x60B; ++index) {
         gEntranceTable[index].field = 0x0102;
     }
 
     // Delete the title card for Death Mountain Crater from Fire Temple Blue Warp
-    for (index = 0x564; index < 0x567; ++index) {
+    for (index = 0x564; index <= 0x567; ++index) {
         gEntranceTable[index].field = 0x0102;
     }
 
     // Delete the title card for Lake Hylia from Water Temple Blue Warp
-    for (index = 0x60C; index < 0x60F; ++index) {
+    for (index = 0x60C; index <= 0x60F; ++index) {
         gEntranceTable[index].field = 0x0102;
     }
 
     // Delete the title card for Desert Colossus from Spirit Temple Blue Warp
-    for (index = 0x610; index < 0x613; ++index) {
+    for (index = 0x610; index <= 0x613; ++index) {
         gEntranceTable[index].field = 0x0102;
     }
 
     // Delete the title card for Graveyard from Shadow Temple Blue Warp
-    for (index = 0x580; index < 0x583; ++index) {
+    for (index = 0x580; index <= 0x583; ++index) {
         gEntranceTable[index].field = 0x0102;
     }
 

--- a/code/src/gfx.c
+++ b/code/src/gfx.c
@@ -13,6 +13,7 @@
 static u8 GfxInit = 0;
 
 static void Gfx_DrawChangeMenuPrompt(void) {
+    Draw_DrawString(10, SCREEN_BOT_HEIGHT - 70, COLOR_TITLE, "Warning: Putting your 3DS into sleep mode with this menu up will crash.");
     Draw_DrawString(10, SCREEN_BOT_HEIGHT - 40, COLOR_TITLE, "Press B to close menu");
     Draw_DrawString(10, SCREEN_BOT_HEIGHT - 20, COLOR_TITLE, "Press L/R to change menu");
 }

--- a/code/src/rainbow_bridge.c
+++ b/code/src/rainbow_bridge.c
@@ -1,5 +1,6 @@
 #include "z3D/z3D.h"
 #include "settings.h"
+#include "savefile.h"
 
 u32 BgGjyoBridge_ConditionVanilla(void) {
     return ((gSaveContext.questItems & 0x8) && (gSaveContext.questItems & 0x10)
@@ -7,14 +8,15 @@ u32 BgGjyoBridge_ConditionVanilla(void) {
 }
 
 u32 BgGjyoBridge_ConditionStones(void) {
-    return ((gSaveContext.questItems & 0x40000) && (gSaveContext.questItems & 0x80000)
-        && (gSaveContext.questItems & 0x100000));
+    return SaveFile_GetStoneCount() >= gSettingsContext.bridgeStoneCount;
 }
 
 u32 BgGjyoBridge_ConditionMedallions(void) {
-    return ((gSaveContext.questItems & 0x1) && (gSaveContext.questItems & 0x2)
-        && (gSaveContext.questItems & 0x4) && (gSaveContext.questItems & 0x8)
-        && (gSaveContext.questItems & 0x10) && (gSaveContext.questItems & 0x20));
+    return SaveFile_GetMedallionCount() >= gSettingsContext.bridgeMedallionCount;
+}
+
+u32 BgGjyoBridge_ConditionDungeons(void) {
+    return SaveFile_GetMedallionCount() + SaveFile_GetStoneCount() >= gSettingsContext.bridgeDungeonCount;
 }
 
 u32 BgGjyoBridge_CheckCondition(void) {
@@ -28,7 +30,7 @@ u32 BgGjyoBridge_CheckCondition(void) {
         case RAINBOWBRIDGE_MEDALLIONS:
             return BgGjyoBridge_ConditionMedallions();
         case RAINBOWBRIDGE_DUNGEONS:
-            return BgGjyoBridge_ConditionStones() && BgGjyoBridge_ConditionMedallions();
+            return BgGjyoBridge_ConditionDungeons();
         case RAINBOWBRIDGE_TOKENS:
             return gSaveContext.gsTokens >= gSettingsContext.bridgeTokenCount;
         default:

--- a/code/src/savefile.c
+++ b/code/src/savefile.c
@@ -1,5 +1,6 @@
 #include "z3D/z3D.h"
 #include "settings.h"
+#include "savefile.h"
 
 void SaveFile_Init() {
 #ifdef ENABLE_DEBUG
@@ -205,4 +206,22 @@ void SaveFile_SwapFaroresWind(void) {
         curFWData++;
         storedFWData += sizeof(SaveSceneFlags);
     }
+}
+
+u8 SaveFile_GetMedallionCount(void) {
+  u8 count = 0;
+
+  for (u8 i = 0; i <= 5; i++) {
+    count += (gSaveContext.questItems >> i) & 0x1;
+  }
+  return count;
+}
+
+u8 SaveFile_GetStoneCount(void) {
+  u8 count = 0;
+
+  for (u8 i = 18; i <= 20; i++) {
+    count += (gSaveContext.questItems >> i) & 0x1;
+  }
+  return count;
 }

--- a/code/src/savefile.h
+++ b/code/src/savefile.h
@@ -1,0 +1,9 @@
+#ifndef _SAVEFILE_H_
+#define _SAVEFILE_H_
+
+#include "z3D/z3D.h"
+
+u8 SaveFile_GetMedallionCount(void);
+u8 SaveFile_GetStoneCount(void);
+
+#endif //_SAVEFILE_H_

--- a/code/src/settings.h
+++ b/code/src/settings.h
@@ -54,6 +54,7 @@ typedef enum {
   LACSCONDITION_STONES,
   LACSCONDITION_MEDALLIONS,
   LACSCONDITION_DUNGEONS,
+  LACSCONDITION_TOKENS,
 } LACSConditionSetting;
 
 typedef enum {
@@ -122,6 +123,7 @@ typedef enum {
   GANONSBOSSKEY_LACS_MEDALLIONS,
   GANONSBOSSKEY_LACS_STONES,
   GANONSBOSSKEY_LACS_DUNGEONS,
+  GANONSBOSSKEY_LACS_TOKENS,
 } GanonsBossKeySetting;
 
 typedef enum {
@@ -167,6 +169,9 @@ typedef struct {
   u8 zorasFountain;
   u8 gerudoFortress;
   u8 rainbowBridge;
+  u8 bridgeStoneCount;
+  u8 bridgeMedallionCount;
+  u8 bridgeDungeonCount;
   u8 bridgeTokenCount;
   u8 randomGanonsTrials;
   u8 ganonsTrialsCount;
@@ -195,6 +200,10 @@ typedef struct {
   u8 bossKeysanity;
   u8 ganonsBossKey;
   u8 lacsCondition;
+  u8 lacsMedallionCount;
+  u8 lacsStoneCount;
+  u8 lacsDungeonCount;
+  u8 lacsTokenCount;
 
   u8 skipChildStealth;
   u8 skipTowerEscape;

--- a/source/cosmetics.cpp
+++ b/source/cosmetics.cpp
@@ -68,11 +68,11 @@ namespace Cosmetics {
     "Lime",
     "Purple",
   };
-  std::vector<std::string_view> gauntletDescriptions = {
+  std::vector<std::string_view> cosmeticDescriptions = {
     RANDOM_CHOICE_DESC,
     RANDOM_COLOR_DESC,
     CUSTOM_COLOR_DESC,
-    "","","","","","","","","","","","","",
+    "",
   };
 
 } //namespace Cosmetics

--- a/source/cosmetics.hpp
+++ b/source/cosmetics.hpp
@@ -37,5 +37,5 @@ namespace Cosmetics {
 
   extern const std::array<std::string, 13> gauntletColors;
   extern std::vector<std::string> gauntletOptions;
-  extern std::vector<std::string_view> gauntletDescriptions;
+  extern std::vector<std::string_view> cosmeticDescriptions;
 } //namespace Cosmetics

--- a/source/item_location.hpp
+++ b/source/item_location.hpp
@@ -120,14 +120,14 @@ public:
 
       //add option to forbid any location from progress items
       if (name.length() < 23) {
-        excludedOption = Option::Bool(name, {"Include", "Exclude"}, {desc, desc});
+        excludedOption = Option::Bool(name, {"Include", "Exclude"}, {desc});
       } else {
         //insert a newline character if the text is too long for one row
         size_t lastSpace = name.rfind(' ', 23);
         std::string settingText = name;
         settingText.replace(lastSpace, 1, "\n ");
 
-        excludedOption = Option::Bool(settingText, {"Include", "Exclude"}, {desc, desc});
+        excludedOption = Option::Bool(settingText, {"Include", "Exclude"}, {desc});
       }
 
       Settings::excludeLocationsOptions.push_back(&excludedOption);

--- a/source/logic.cpp
+++ b/source/logic.cpp
@@ -242,7 +242,9 @@ namespace Logic {
   bool CanJumpslash     = false;
   bool CanUseProjectile = false;
 
-  //Bridge Requirements
+  //Bridge and LACS Requirements
+  u8 MedallionCount          = 0;
+  u8 StoneCount              = 0;
   bool HasAllStones          = false;
   bool HasAllMedallions      = false;
   bool CanBuildRainbowBridge = false;
@@ -459,20 +461,24 @@ namespace Logic {
     CanJumpslash     = IsAdult || Sticks || KokiriSword;
     CanUseProjectile = HasExplosives || (IsAdult && (Bow || Hookshot)) || (IsChild && (Slingshot || Boomerang));
 
-    //Bridge Requirements
-    HasAllStones          = KokiriEmerald   && GoronRuby     && ZoraSapphire;
-    HasAllMedallions      = ForestMedallion && FireMedallion && WaterMedallion && ShadowMedallion && SpiritMedallion && LightMedallion;
-    CanBuildRainbowBridge = Bridge.Is(RAINBOWBRIDGE_OPEN)       ||
-                           (Bridge.Is(RAINBOWBRIDGE_VANILLA)    && ShadowMedallion && SpiritMedallion && LightArrows) ||
-                           (Bridge.Is(RAINBOWBRIDGE_STONES)     && HasAllStones) ||
-                           (Bridge.Is(RAINBOWBRIDGE_MEDALLIONS) && HasAllMedallions) ||
-                           (Bridge.Is(RAINBOWBRIDGE_DUNGEONS)   && HasAllStones && HasAllMedallions) ||
+    //Bridge and LACS Requirements
+    MedallionCount        = (ForestMedallion ? 1:0) + (FireMedallion ? 1:0) + (WaterMedallion ? 1:0) + (SpiritMedallion ? 1:0) + (ShadowMedallion ? 1:0) + (LightMedallion ? 1:0);
+    StoneCount            = (KokiriEmerald ? 1:0) + (GoronRuby ? 1:0) + (ZoraSapphire ? 1:0);
+    HasAllStones          = StoneCount == 3;
+    HasAllMedallions      = MedallionCount == 6;
+
+    CanBuildRainbowBridge = Bridge.Is(RAINBOWBRIDGE_OPEN)                                                                         ||
+                           (Bridge.Is(RAINBOWBRIDGE_VANILLA)    && ShadowMedallion && SpiritMedallion && LightArrows)             ||
+                           (Bridge.Is(RAINBOWBRIDGE_STONES)     && StoneCount >= BridgeStoneCount.Value<u8>())                    ||
+                           (Bridge.Is(RAINBOWBRIDGE_MEDALLIONS) && MedallionCount >= BridgeMedallionCount.Value<u8>())            ||
+                           (Bridge.Is(RAINBOWBRIDGE_DUNGEONS)   && StoneCount + MedallionCount >= BridgeDungeonCount.Value<u8>()) ||
                            (Bridge.Is(RAINBOWBRIDGE_TOKENS)     && GoldSkulltulaTokens >= BridgeTokenCount.Value<u8>());
 
-    CanTriggerLACS = (LACSCondition == LACSCONDITION_VANILLA    && ShadowMedallion && SpiritMedallion) ||
-                     (LACSCondition == LACSCONDITION_STONES     && HasAllStones)                       ||
-                     (LACSCondition == LACSCONDITION_MEDALLIONS && HasAllMedallions)                   ||
-                     (LACSCondition == LACSCONDITION_DUNGEONS   && HasAllStones && HasAllMedallions);
+    CanTriggerLACS = (LACSCondition == LACSCONDITION_VANILLA    && ShadowMedallion && SpiritMedallion)                          ||
+                     (LACSCondition == LACSCONDITION_STONES     && StoneCount >= LACSStoneCount.Value<u8>())                    ||
+                     (LACSCondition == LACSCONDITION_MEDALLIONS && MedallionCount >= LACSMedallionCount.Value<u8>())            ||
+                     (LACSCondition == LACSCONDITION_DUNGEONS   && StoneCount + MedallionCount >= LACSDungeonCount.Value<u8>()) ||
+                     (LACSCondition == LACSCONDITION_TOKENS     && GoldSkulltulaTokens >= LACSTokenCount.Value<u8>());
 
   }
 

--- a/source/preset.cpp
+++ b/source/preset.cpp
@@ -163,6 +163,7 @@ bool LoadPreset(std::string presetName, OptionCategory category) {
           linearly from the beginning. This will get us back on track if the
           next setting and element line up with each other*/
           curNode = preset.FirstChild();
+          bool settingFound = false;
           while (curNode != nullptr) {
             curSettingName = curNode->FirstChildElement("settingName")->GetText();
             curSettingValue = curNode->FirstChildElement("valueName")->GetText();
@@ -170,9 +171,14 @@ bool LoadPreset(std::string presetName, OptionCategory category) {
             if (curSettingName == settingToFind) {
               setting->SetSelectedIndexByString(curSettingValue);
               curNode = curNode->NextSibling();
+              settingFound = true;
               break;
             }
             curNode = curNode->NextSibling();
+          }
+          //reset to the beginning if the setting wasn't found
+          if (!settingFound) {
+            curNode = preset.FirstChild();
           }
         }
       }

--- a/source/setting_descriptions.cpp
+++ b/source/setting_descriptions.cpp
@@ -39,7 +39,7 @@ string_view kakGateClosed             = "The gate and the Happy Mask Shop both r
 string_view doorOfTimeDesc            = "The Door of Time starts opened instead of needing\n"
                                         "to play the Song of Time. If closed, only an\n"   //
                                         "Ocarina and the Song of Time need to be found to\n"
-                                        "open the Door of Time";                           //
+                                        "open the Door of Time.";                          //
 /*------------------------------                                                           //
 |       ZORA'S FOUNTAIN        |                                                           //
 ------------------------------*/                                                           //
@@ -68,18 +68,26 @@ string_view gerudoOpen                = "The carpenters are rescued from the sta
 string_view bridgeOpen                = "The Rainbow Bridge is always present.";           //
 string_view bridgeVanilla             = "The Rainbow Bridge requires Shadow and Spirit\n"  //
                                         "Medallions as well as Light Arrows.";             //
-string_view bridgeStones              = "The Rainbow Bridge requires the Kokiri's Emerald,\n"
-                                        "Goron's Ruby and Zora's Sapphire.";               //
-string_view bridgeMedallions          = "The Rainbow Bridge requires Forest, Fire, Water,\n"
-                                        "Shadow, Spirit, and Light Medallions";            //
-string_view bridgeDungeons            = "The Rainbow Bridge requires beating every dungeon.";
-string_view bridgeTokens              = "The Rainbow Bridge requires collecting a certain\n"
-                                        "number of Gold Skulltula Tokens.";                //
+string_view bridgeStones              = "The Rainbow Bridge requires collecting a\n"       //
+                                        "configurable number of Spiritual Stones.";        //
+string_view bridgeMedallions          = "The Rainbow Bridge requires collecting a\n"       //
+                                        "configurable number of Medallions.";              //
+string_view bridgeDungeons            = "The Rainbow Bridge requires collecting a\n"       //
+                                        "configurable number of Dungeon Rewards.";         //
+string_view bridgeTokens              = "The Rainbow Bridge requires collecting a\n"       //
+                                        "configurable number of Gold Skulltula Tokens.";   //
 /*------------------------------                                                           //
-|      BRIDGE TOKEN COUNT      |                                                           //
+|      BRIDGE CONDITIONS       |                                                           //
 ------------------------------*/                                                           //
-string_view bridgeTokenCountDesc      = "Set the number of Gold Skulltula Tokens for the\n"//
+string_view bridgeStoneCountDesc      = "Set the number of Spiritual Stones required to\n" //
+                                        "spawn the Rainbow Bridge.";                       //
+string_view bridgeMedallionCountDesc  = "Set the number of Medallions required to spawn the"
                                         "Rainbow Bridge.";                                 //
+string_view bridgeDungeonCountDesc    = "Set the number of Dungeon Rewards (Spiritual\n"   //
+                                        "Stones and Medallions) required to spawn the\n"   //
+                                        "Rainbow Bridge.";                                 //
+string_view bridgeTokenCountDesc      = "Set the number of Gold Skulltula Tokens required\n"
+                                        "to spawn the Rainbow Bridge.";                    //
 /*------------------------------                                                           //
 |     RANDOM GANONS TRIALS     |                                                           //
 ------------------------------*/                                                           //
@@ -88,7 +96,7 @@ string_view randomGanonsTrialsDesc    = "Sets a random number of required trials
 /*------------------------------                                                           //
 |     GANON'S TRIAL COUNT      |                                                           //
 ------------------------------*/                                                           //
-string_view ganonsTrialCountDesc      = "Sets the number of trials required to enter\n"    //
+string_view ganonsTrialCountDesc      = "Set the number of trials required to enter\n"     //
                                         "Ganon's Tower. Trials will be randomly selected.";//
 /*------------------------------                                                           //
 |         STARTING AGE         |                                                           //
@@ -282,6 +290,18 @@ string_view ganonKeyAnywhere          = "Ganon's Castle Boss Key can appear anyw
 string_view ganonKeyLACS              = "These settings put the boss key on the Light Arrow"
                                         "Cutscene location, from Zelda in Temple of Time as"
                                         "adult, with differing requirements.";             //
+/*------------------------------                                                           //
+|        LACS CONDITIONS       |                                                           //
+------------------------------*/                                                           //
+string_view lacsMedallionCountDesc    = "Set the number of Medallions required to trigger\n"
+                                        "the Light Arrow Cutscene.";                       //
+string_view lacsStoneCountDesc        = "Set the number of Spiritual Stones required to\n" //
+                                        "trigger the Light Arrow Cutscene.";               //
+string_view lacsDungeonCountDesc      = "Set the number of Dungeon Rewards (Spiritual\n"   //
+                                        "Stones and Medallions) required to trigger the\n" //
+                                        "Light Arrow Cutscene.";                           //
+string_view lacsTokenCountDesc        = "Set the number of Gold Skulltula Tokens required\n"
+                                        "to trigger the Light Arrow Cutscene.";            //
 /*------------------------------                                                           //
 |      SKIP CHILD STEALTH      |                                                           //
 ------------------------------*/                                                           //

--- a/source/setting_descriptions.hpp
+++ b/source/setting_descriptions.hpp
@@ -29,6 +29,9 @@ extern string_view bridgeMedallions;
 extern string_view bridgeDungeons;
 extern string_view bridgeTokens;
 
+extern string_view bridgeStoneCountDesc;
+extern string_view bridgeMedallionCountDesc;
+extern string_view bridgeDungeonCountDesc;
 extern string_view bridgeTokenCountDesc;
 
 extern string_view randomGanonsTrialsDesc;
@@ -96,6 +99,11 @@ extern string_view ganonKeyVanilla;
 extern string_view ganonKeyOwnDungeon;
 extern string_view ganonKeyAnywhere;
 extern string_view ganonKeyLACS;
+
+extern string_view lacsMedallionCountDesc;
+extern string_view lacsStoneCountDesc;
+extern string_view lacsDungeonCountDesc;
+extern string_view lacsTokenCountDesc;
 
 extern string_view childStealthDesc;
 

--- a/source/settings.cpp
+++ b/source/settings.cpp
@@ -15,18 +15,21 @@ namespace Settings {
   std::array<u8, 5> hashIconIndexes;
 
   //                                        Setting name,              Options,                                                Setting Descriptions (assigned in setting_descriptions.cpp)
-  //Open Settings
+  //Open Settings                                                                                                              Any option index past the last description will use the last description
   Option Logic               = Option::U8  ("Logic",                  {"Glitchless", "No Logic"},                              {logicGlitchless, logicNoLogic});
   Option OpenForest          = Option::U8  ("Forest",                 {"Closed", "Open"},                                      {forestClosed, forestOpen});
   Option OpenKakariko        = Option::U8  ("Kakariko Gate",          {"Closed", "Open"},                                      {kakGateClosed, kakGateOpen});
-  Option OpenDoorOfTime      = Option::Bool("Door of Time",           {"Closed", "Open"},                                      {doorOfTimeDesc, doorOfTimeDesc});
+  Option OpenDoorOfTime      = Option::Bool("Door of Time",           {"Closed", "Open"},                                      {doorOfTimeDesc});
   Option ZorasFountain       = Option::U8  ("Zora's Fountain",        {"Normal", "Adult", "Open"},                             {fountainNormal, fountainAdult, fountainOpen});
   Option GerudoFortress      = Option::U8  ("Gerudo Fortress",        {"Normal", "Fast", "Open"},                              {gerudoNormal, gerudoFast, gerudoOpen});
   Option Bridge              = Option::U8  ("Rainbow Bridge",         {"Open", "Vanilla", "Stones", "Medallions", "Dungeons", "Tokens"},
                                                                       {bridgeOpen, bridgeVanilla, bridgeStones, bridgeMedallions, bridgeDungeons, bridgeTokens});
-  Option BridgeTokenCount    = Option::U8  ("  Token Count",          {/*Options 0-100 defined in SetDefaultOptions()*/},      std::vector<std::string_view>{101, bridgeTokenCountDesc});
-  Option RandomGanonsTrials  = Option::Bool("Random Ganon's Trials",  {"Off", "On"},                                           {randomGanonsTrialsDesc, randomGanonsTrialsDesc});
-  Option GanonsTrialsCount   = Option::U8  ("  Trial Count",          {"0", "1", "2", "3", "4", "5", "6"},                     std::vector<std::string_view>{7, ganonsTrialCountDesc});
+  Option BridgeStoneCount    = Option::U8  ("  Stone Count",          {"0", "1", "2", "3"},                                    {bridgeStoneCountDesc});
+  Option BridgeMedallionCount= Option::U8  ("  Medallion Count",      {"0", "1", "2", "3", "4", "5", "6"},                     {bridgeMedallionCountDesc});
+  Option BridgeDungeonCount  = Option::U8  ("  Dungeon Count",        {"0", "1", "2", "3", "4", "5", "6", "7", "8", "9"},      {bridgeDungeonCountDesc});
+  Option BridgeTokenCount    = Option::U8  ("  Token Count",          {/*Options 0-100 defined in SetDefaultSettings()*/},     {bridgeTokenCountDesc});
+  Option RandomGanonsTrials  = Option::Bool("Random Ganon's Trials",  {"Off", "On"},                                           {randomGanonsTrialsDesc});
+  Option GanonsTrialsCount   = Option::U8  ("  Trial Count",          {"0", "1", "2", "3", "4", "5", "6"},                     {ganonsTrialCountDesc});
   std::vector<Option *> openOptions = {
     &Logic,
     &OpenForest,
@@ -35,18 +38,21 @@ namespace Settings {
     &ZorasFountain,
     &GerudoFortress,
     &Bridge,
+    &BridgeStoneCount,
+    &BridgeMedallionCount,
+    &BridgeDungeonCount,
     &BridgeTokenCount,
     &RandomGanonsTrials,
     &GanonsTrialsCount,
   };
 
   //World Settings
-  Option StartingAge         = Option::U8  ("Starting Age",           {"Adult", "Child", "Random"},                            {ageDesc, ageDesc, ageDesc});
+  Option StartingAge         = Option::U8  ("Starting Age",           {"Adult", "Child", "Random"},                            {ageDesc});
   u8 ResolvedStartingAge;
-  Option BombchusInLogic     = Option::Bool("Bombchus in Logic",      {"Off", "On"},                                           {bombchuLogicDesc, bombchuLogicDesc});
-  Option BombchuDrops        = Option::Bool("Bombchu Drops",          {"Off", "On"},                                           {bombchuDropDesc, bombchuDropDesc});
-  Option RandomMQDungeons    = Option::Bool("Random MQ Dungeons",     {"Off", "On"},                                           {randomMQDungeonsDesc, randomMQDungeonsDesc});
-  Option MQDungeonCount      = Option::U8  ("  MQ Dungeon Count",     {"0","1","2","3","4","5","6","7","8","9","10","11","12"},std::vector<std::string_view>{13, mqDungeonCountDesc});
+  Option BombchusInLogic     = Option::Bool("Bombchus in Logic",      {"Off", "On"},                                           {bombchuLogicDesc});
+  Option BombchuDrops        = Option::Bool("Bombchu Drops",          {"Off", "On"},                                           {bombchuDropDesc});
+  Option RandomMQDungeons    = Option::Bool("Random MQ Dungeons",     {"Off", "On"},                                           {randomMQDungeonsDesc});
+  Option MQDungeonCount      = Option::U8  ("  MQ Dungeon Count",     {"0","1","2","3","4","5","6","7","8","9","10","11","12"},{mqDungeonCountDesc});
   std::vector<Option *> worldOptions = {
     &StartingAge,
     &BombchusInLogic,
@@ -58,12 +64,12 @@ namespace Settings {
   Option ShuffleSongs        = Option::U8  ("Shuffle Songs",          {"Song Locations", "Dungeon Rewards", "Anywhere"},       {songsSongLocations, songsDungeonRewards, songsAllLocations});
   Option Tokensanity         = Option::U8  ("Tokensanity",            {"Off", "Dungeons", "Overworld", "All Tokens"},          {tokensOff, tokensDungeon, tokensOverworld, tokensAllTokens});
   Option Scrubsanity         = Option::U8  ("Scrub Shuffle",          {"Off", "Affordable", "Expensive", "Random Prices"},     {scrubsOff, scrubsAffordable, scrubsExpensive, scrubsRandomPrices});
-  Option ShuffleCows         = Option::Bool("Shuffle Cows",           {"Off", "On"},                                           {shuffleCowsDesc, shuffleCowsDesc});
-  Option ShuffleKokiriSword  = Option::Bool("Shuffle Kokiri Sword",   {"Off", "On"},                                           {kokiriSwordDesc, kokiriSwordDesc});
-  Option ShuffleOcarinas     = Option::Bool("Shuffle Ocarinas",       {"Off", "On"},                                           {ocarinasDesc, ocarinasDesc});
-  Option ShuffleWeirdEgg     = Option::Bool("Shuffle Weird Egg",      {"Off", "On"},                                           {weirdEggDesc, weirdEggDesc});
-  Option ShuffleGerudoToken  = Option::Bool("Shuffle Gerudo Token",   {"Off", "On"},                                           {gerudoTokenDesc, gerudoTokenDesc});
-  Option ShuffleMagicBeans   = Option::Bool("Shuffle Magic Beans",    {"Off", "On"},                                           {magicBeansDesc, magicBeansDesc});
+  Option ShuffleCows         = Option::Bool("Shuffle Cows",           {"Off", "On"},                                           {shuffleCowsDesc});
+  Option ShuffleKokiriSword  = Option::Bool("Shuffle Kokiri Sword",   {"Off", "On"},                                           {kokiriSwordDesc});
+  Option ShuffleOcarinas     = Option::Bool("Shuffle Ocarinas",       {"Off", "On"},                                           {ocarinasDesc});
+  Option ShuffleWeirdEgg     = Option::Bool("Shuffle Weird Egg",      {"Off", "On"},                                           {weirdEggDesc});
+  Option ShuffleGerudoToken  = Option::Bool("Shuffle Gerudo Token",   {"Off", "On"},                                           {gerudoTokenDesc});
+  Option ShuffleMagicBeans   = Option::Bool("Shuffle Magic Beans",    {"Off", "On"},                                           {magicBeansDesc});
   //TODO: Medigoron and Carpet Salesman
   std::vector<Option *> shuffleOptions = {
     &ShuffleSongs,
@@ -83,25 +89,33 @@ namespace Settings {
   Option Keysanity           = Option::U8  ("Small Keys",             {"Start With", "Vanilla", "Own Dungeon", "Anywhere"},    {smallKeyStartWith, smallKeyVanilla, smallKeyOwnDungeon, smallKeyAnywhere});
   Option GerudoKeys          = Option::U8  ("Gerudo Fortress Keys",   {"Vanilla", "Anywhere"},                                 {gerudoKeysVanilla, gerudoKeysAnywhere});
   Option BossKeysanity       = Option::U8  ("Boss Keys",              {"Start With", "Vanilla", "Own Dungeon", "Anywhere"},    {bossKeyStartWith, bossKeyVanilla, bossKeyOwnDungeon, bossKeyAnywhere});
-  Option GanonsBossKey       = Option::U8  ("Ganon's Boss Key",       {"Start With", "Vanilla", "Own Dungeon", "Anywhere", "LACS-Vanilla", "LACS-Medallions", "LACS-Stones", "LACS-Dungeons"},
-                                                                      {ganonKeyStartWith, ganonKeyVanilla, ganonKeyOwnDungeon, ganonKeyAnywhere, ganonKeyLACS, ganonKeyLACS, ganonKeyLACS, ganonKeyLACS});
+  Option GanonsBossKey       = Option::U8  ("Ganon's Boss Key",       {"Start With", "Vanilla", "Own Dungeon", "Anywhere", "LACS-Vanilla", "LACS-Medallions", "LACS-Stones", "LACS-Dungeons", "LACS-Tokens"},
+                                                                      {ganonKeyStartWith, ganonKeyVanilla, ganonKeyOwnDungeon, ganonKeyAnywhere, ganonKeyLACS});
   u8 LACSCondition           = 0;
+  Option LACSMedallionCount  = Option::U8  ("  Medallion Count",      {"0", "1", "2", "3", "4", "5", "6"},                     {lacsMedallionCountDesc});
+  Option LACSStoneCount      = Option::U8  ("  Stone Count",          {"0", "1", "2", "3"},                                    {lacsStoneCountDesc});
+  Option LACSDungeonCount    = Option::U8  ("  Dungeon Count",        {"0", "1", "2", "3", "4", "5", "6", "7", "8", "9"},      {lacsDungeonCountDesc});
+  Option LACSTokenCount      = Option::U8  ("  Token Count",          {/*Options 0-100 defined in SetDefaultSettings()*/},     {lacsTokenCountDesc});
   std::vector<Option *> shuffleDungeonItemOptions = {
     &MapsAndCompasses,
     &Keysanity,
     &GerudoKeys,
     &BossKeysanity,
     &GanonsBossKey,
+    &LACSMedallionCount,
+    &LACSStoneCount,
+    &LACSDungeonCount,
+    &LACSTokenCount,
   };
 
   //Timesaver Settings
-  Option SkipChildStealth    = Option::Bool("Skip Child Stealth",     {"Don't Skip", "Skip"},                                  {childStealthDesc, childStealthDesc});
-  Option SkipTowerEscape     = Option::Bool("Skip Tower Escape",      {"Don't Skip", "Skip"},                                  {skipTowerEscapeDesc, skipTowerEscapeDesc});
-  Option SkipEponaRace       = Option::Bool("Skip Epona Race",        {"Don't Skip", "Skip"},                                  {skipEponaRaceDesc, skipEponaRaceDesc});
-  Option FourPoesCutscene    = Option::Bool("Four Poes Cutscene",     {"Don't Skip", "Skip"},                                  {fourPoesDesc, fourPoesDesc});
-  Option TempleOfTimeIntro   = Option::Bool("Temple of Time Intro",   {"Don't Skip", "Skip"},                                  {templeOfTimeIntroDesc, templeOfTimeIntroDesc});
-  Option BigPoeTargetCount   = Option::U8  ("Big Poe Target Count",   {"1", "2", "3", "4", "5", "6", "7", "8", "9", "10"},     std::vector<std::string_view>{10, bigPoeTargetCountDesc});
-  Option NumRequiredCuccos   = Option::U8  ("Cuccos to return",       {"0", "1", "2", "3", "4", "5", "6", "7"},                std::vector<std::string_view>{8, numRequiredCuccosDesc});
+  Option SkipChildStealth    = Option::Bool("Skip Child Stealth",     {"Don't Skip", "Skip"},                                  {childStealthDesc});
+  Option SkipTowerEscape     = Option::Bool("Skip Tower Escape",      {"Don't Skip", "Skip"},                                  {skipTowerEscapeDesc});
+  Option SkipEponaRace       = Option::Bool("Skip Epona Race",        {"Don't Skip", "Skip"},                                  {skipEponaRaceDesc});
+  Option FourPoesCutscene    = Option::Bool("Four Poes Cutscene",     {"Don't Skip", "Skip"},                                  {fourPoesDesc});
+  Option TempleOfTimeIntro   = Option::Bool("Temple of Time Intro",   {"Don't Skip", "Skip"},                                  {templeOfTimeIntroDesc});
+  Option BigPoeTargetCount   = Option::U8  ("Big Poe Target Count",   {"1", "2", "3", "4", "5", "6", "7", "8", "9", "10"},     {bigPoeTargetCountDesc});
+  Option NumRequiredCuccos   = Option::U8  ("Cuccos to return",       {"0", "1", "2", "3", "4", "5", "6", "7"},                {numRequiredCuccosDesc});
   std::vector<Option *> timesaverOptions = {
     &SkipChildStealth,
     &SkipTowerEscape,
@@ -113,8 +127,8 @@ namespace Settings {
   };
 
   //Misc Settings
-  Option DamageMultiplier    = Option::U8  ("Damage Multiplier",      {"Half", "Default", "Double", "Quadruple", "OHKO"},      std::vector<std::string_view>{5, damageMultiDesc});
-  Option StartingTime        = Option::U8  ("Starting Time",          {"Day", "Night"},                                        {startingTimeDesc, startingTimeDesc});
+  Option DamageMultiplier    = Option::U8  ("Damage Multiplier",      {"Half", "Default", "Double", "Quadruple", "OHKO"},      {damageMultiDesc});
+  Option StartingTime        = Option::U8  ("Starting Time",          {"Day", "Night"},                                        {startingTimeDesc});
   Option GenerateSpoilerLog  = Option::Bool("Generate Spoiler Log",   {"No", "Yes"},                                           {"", ""});
   bool HasNightStart         = false;
   std::vector<Option *> miscOptions = {
@@ -124,9 +138,9 @@ namespace Settings {
   };
 
   //Item Usability Settings
-  Option StickAsAdult        = Option::Bool("Adult Deku Stick",       {"Disabled", "Enabled"},                                 {adultStickDesc, adultStickDesc});
-  Option BoomerangAsAdult    = Option::Bool("Adult Boomerang",        {"Disabled", "Enabled"},                                 {adultBoomerangDesc, adultBoomerangDesc});
-  Option HammerAsChild       = Option::Bool("Child Hammer",           {"Disabled", "Enabled"},                                 {childHammerDesc, childHammerDesc});
+  Option StickAsAdult        = Option::Bool("Adult Deku Stick",       {"Disabled", "Enabled"},                                 {adultStickDesc});
+  Option BoomerangAsAdult    = Option::Bool("Adult Boomerang",        {"Disabled", "Enabled"},                                 {adultBoomerangDesc});
+  Option HammerAsChild       = Option::Bool("Child Hammer",           {"Disabled", "Enabled"},                                 {childHammerDesc});
   std::vector<Option *> itemUsabilityOptions = {
     &StickAsAdult,
     &BoomerangAsAdult,
@@ -146,11 +160,11 @@ namespace Settings {
 
   //Function to make defining logic tricks easier to read
   Option LogicTrick(std::string setting, std::string_view description) {
-    return Option::Bool(setting, {"Disabled", "Enabled"}, std::vector<std::string_view>{2, description});
+    return Option::Bool(setting, {"Disabled", "Enabled"}, {description});
   }
 
   //Detailed Logic Tricks                               ---------------------
-  Option ToggleAllDetailedLogic           = Option::Bool("All Tricks", {"Disabled", "Enabled"},           std::vector<std::string_view>{2, "Toggle all tricks at once."}, OptionCategory::Toggle);
+  Option ToggleAllDetailedLogic           = Option::Bool("All Tricks", {"Disabled", "Enabled"},           {"Toggle all tricks at once."}, OptionCategory::Toggle);
   Option LogicGrottosWithoutAgony         = LogicTrick("Grottos Without Agony",                           LogicGrottosWithoutAgonyDesc);
   Option LogicVisibleCollision            = LogicTrick("Pass Through Visible\n One-Way Collisions",       LogicVisibleCollisionDesc);
   Option LogicFewerTunicRequirements      = LogicTrick("Fewer Tunic\n Requirements",                      LogicFewerTunicRequirementsDesc);
@@ -307,11 +321,11 @@ namespace Settings {
     &LogicSpiritTrialHookshot,
   };
 
-  Option SilverGauntletsColor       = Option::U8("Silver Gauntlets Color", gauntletOptions, gauntletDescriptions, OptionCategory::Cosmetic);
-  Option GoldGauntletsColor         = Option::U8("Gold Gauntlets Color",   gauntletOptions, gauntletDescriptions, OptionCategory::Cosmetic);
+  Option SilverGauntletsColor       = Option::U8("Silver Gauntlets Color", gauntletOptions, cosmeticDescriptions, OptionCategory::Cosmetic);
+  Option GoldGauntletsColor         = Option::U8("Gold Gauntlets Color",   gauntletOptions, cosmeticDescriptions, OptionCategory::Cosmetic);
   std::string finalSilverGauntletsColor = SilverGauntletsColor.GetSelectedOptionText();
   std::string finalGoldGauntletsColor  = GoldGauntletsColor.GetSelectedOptionText();
-  Option MirrorWorld                = Option::Bool("Mirror World",         {"Off", "On"},   {mirrorWorldDesc, mirrorWorldDesc}, OptionCategory::Cosmetic);
+  Option MirrorWorld                = Option::Bool("Mirror World",         {"Off", "On"},   {mirrorWorldDesc}, OptionCategory::Cosmetic);
   std::vector<Option *> cosmeticOptions = {
     &SilverGauntletsColor,
     &GoldGauntletsColor,
@@ -374,61 +388,68 @@ namespace Settings {
     ctx.hashIndexes[3] = hashIconIndexes[3];
     ctx.hashIndexes[4] = hashIconIndexes[4];
 
-    ctx.logic              = Logic.Value<u8>();
-    ctx.openForest         = OpenForest.Value<u8>();
-    ctx.openKakariko       = OpenKakariko.Value<u8>();
-    ctx.openDoorOfTime     = (OpenDoorOfTime) ? 1 : 0;
-    ctx.zorasFountain      = ZorasFountain.Value<u8>();
-    ctx.gerudoFortress     = GerudoFortress.Value<u8>();
-    ctx.rainbowBridge      = Bridge.Value<u8>();
-    ctx.bridgeTokenCount   = BridgeTokenCount.Value<u8>();
-    ctx.randomGanonsTrials = (RandomGanonsTrials) ? 1 : 0;
-    ctx.ganonsTrialsCount  = GanonsTrialsCount.Value<u8>();
+    ctx.logic                = Logic.Value<u8>();
+    ctx.openForest           = OpenForest.Value<u8>();
+    ctx.openKakariko         = OpenKakariko.Value<u8>();
+    ctx.openDoorOfTime       = (OpenDoorOfTime) ? 1 : 0;
+    ctx.zorasFountain        = ZorasFountain.Value<u8>();
+    ctx.gerudoFortress       = GerudoFortress.Value<u8>();
+    ctx.rainbowBridge        = Bridge.Value<u8>();
+    ctx.bridgeStoneCount     = BridgeStoneCount.Value<u8>();
+    ctx.bridgeMedallionCount = BridgeMedallionCount.Value<u8>();
+    ctx.bridgeDungeonCount   = BridgeDungeonCount.Value<u8>();
+    ctx.bridgeTokenCount     = BridgeTokenCount.Value<u8>();
+    ctx.randomGanonsTrials   = (RandomGanonsTrials) ? 1 : 0;
+    ctx.ganonsTrialsCount    = GanonsTrialsCount.Value<u8>();
 
-    ctx.startingAge        = StartingAge.Value<u8>();
-    ctx.resolvedStartingAge = ResolvedStartingAge;
+    ctx.startingAge          = StartingAge.Value<u8>();
+    ctx.resolvedStartingAge  = ResolvedStartingAge;
 
-    ctx.bombchusInLogic    = (BombchusInLogic) ? 1 : 0;
-    ctx.bombchuDrops       = (BombchuDrops) ? 1 : 0;
-    ctx.randomMQDungeons   = (RandomMQDungeons) ? 1 : 0;
-    ctx.mqDungeonCount     = MQDungeonCount.Value<u8>();
-    ctx.mirrorWorld        = (MirrorWorld) ? 1 : 0;
+    ctx.bombchusInLogic      = (BombchusInLogic) ? 1 : 0;
+    ctx.bombchuDrops         = (BombchuDrops) ? 1 : 0;
+    ctx.randomMQDungeons     = (RandomMQDungeons) ? 1 : 0;
+    ctx.mqDungeonCount       = MQDungeonCount.Value<u8>();
+    ctx.mirrorWorld          = (MirrorWorld) ? 1 : 0;
 
-    ctx.shuffleSongs       = ShuffleSongs.Value<u8>();
-    ctx.tokensanity        = Tokensanity.Value<u8>();
-    ctx.scrubsanity        = Scrubsanity.Value<u8>();
-    ctx.shuffleCows        = (ShuffleCows) ? 1 : 0;
-    ctx.shuffleKokiriSword = (ShuffleKokiriSword) ? 1 : 0;
-    ctx.shuffleOcarinas    = (ShuffleOcarinas) ? 1 : 0;
-    ctx.shuffleWeirdEgg    = (ShuffleWeirdEgg) ? 1 : 0;
-    ctx.shuffleGerudoToken = (ShuffleGerudoToken) ? 1 : 0;
-    ctx.shuffleMagicBeans  = (ShuffleMagicBeans) ? 1 : 0;
+    ctx.shuffleSongs         = ShuffleSongs.Value<u8>();
+    ctx.tokensanity          = Tokensanity.Value<u8>();
+    ctx.scrubsanity          = Scrubsanity.Value<u8>();
+    ctx.shuffleCows          = (ShuffleCows) ? 1 : 0;
+    ctx.shuffleKokiriSword   = (ShuffleKokiriSword) ? 1 : 0;
+    ctx.shuffleOcarinas      = (ShuffleOcarinas) ? 1 : 0;
+    ctx.shuffleWeirdEgg      = (ShuffleWeirdEgg) ? 1 : 0;
+    ctx.shuffleGerudoToken   = (ShuffleGerudoToken) ? 1 : 0;
+    ctx.shuffleMagicBeans    = (ShuffleMagicBeans) ? 1 : 0;
 
-    ctx.mapsAndCompasses   = MapsAndCompasses.Value<u8>();
-    ctx.keysanity          = Keysanity.Value<u8>();
-    ctx.gerudoKeys         = GerudoKeys.Value<u8>();
-    ctx.bossKeysanity      = BossKeysanity.Value<u8>();
-    ctx.ganonsBossKey      = GanonsBossKey.Value<u8>();
-    ctx.lacsCondition      = LACSCondition;
+    ctx.mapsAndCompasses     = MapsAndCompasses.Value<u8>();
+    ctx.keysanity            = Keysanity.Value<u8>();
+    ctx.gerudoKeys           = GerudoKeys.Value<u8>();
+    ctx.bossKeysanity        = BossKeysanity.Value<u8>();
+    ctx.ganonsBossKey        = GanonsBossKey.Value<u8>();
+    ctx.lacsCondition        = LACSCondition;
+    ctx.lacsMedallionCount   = LACSMedallionCount.Value<u8>();
+    ctx.lacsStoneCount       = LACSStoneCount.Value<u8>();
+    ctx.lacsDungeonCount     = LACSDungeonCount.Value<u8>();
+    ctx.lacsTokenCount       = LACSTokenCount.Value<u8>();
 
-    ctx.skipChildStealth   = (SkipChildStealth) ? 1 : 0;
-    ctx.skipTowerEscape    = (SkipTowerEscape) ? 1 : 0;
-    ctx.skipEponaRace      = (SkipEponaRace) ? 1 : 0;
-    ctx.fourPoesCutscene   = (FourPoesCutscene) ? 1 : 0;
-    ctx.templeOfTimeIntro  = (TempleOfTimeIntro) ? 1 : 0;
-    ctx.bigPoeTargetCount  = BigPoeTargetCount.Value<u8>() + 1;
-    ctx.numRequiredCuccos  = NumRequiredCuccos.Value<u8>();
+    ctx.skipChildStealth     = (SkipChildStealth) ? 1 : 0;
+    ctx.skipTowerEscape      = (SkipTowerEscape) ? 1 : 0;
+    ctx.skipEponaRace        = (SkipEponaRace) ? 1 : 0;
+    ctx.fourPoesCutscene     = (FourPoesCutscene) ? 1 : 0;
+    ctx.templeOfTimeIntro    = (TempleOfTimeIntro) ? 1 : 0;
+    ctx.bigPoeTargetCount    = BigPoeTargetCount.Value<u8>() + 1;
+    ctx.numRequiredCuccos    = NumRequiredCuccos.Value<u8>();
 
-    ctx.damageMultiplier   = DamageMultiplier.Value<u8>();
-    ctx.startingTime       = StartingTime.Value<u8>();
-    ctx.generateSpoilerLog = (GenerateSpoilerLog) ? 1 : 0;
+    ctx.damageMultiplier     = DamageMultiplier.Value<u8>();
+    ctx.startingTime         = StartingTime.Value<u8>();
+    ctx.generateSpoilerLog   = (GenerateSpoilerLog) ? 1 : 0;
 
-    ctx.stickAsAdult       = (StickAsAdult) ? 1 : 0;
-    ctx.boomerangAsAdult   = (BoomerangAsAdult) ? 1 : 0;
-    ctx.hammerAsChild      = (HammerAsChild) ? 1 : 0;
+    ctx.stickAsAdult         = (StickAsAdult) ? 1 : 0;
+    ctx.boomerangAsAdult     = (BoomerangAsAdult) ? 1 : 0;
+    ctx.hammerAsChild        = (HammerAsChild) ? 1 : 0;
 
-    ctx.itemPoolValue      = ItemPoolValue.Value<u8>();
-    ctx.iceTrapValue       = IceTrapValue.Value<u8>();
+    ctx.itemPoolValue        = ItemPoolValue.Value<u8>();
+    ctx.iceTrapValue         = IceTrapValue.Value<u8>();
 
     ctx.dekuTreeDungeonMode              = (DekuTreeDungeonMode)              ? 1 : 0;
     ctx.dodongosCavernDungeonMode        = (DodongosCavernDungeonMode)        ? 1 : 0;
@@ -480,13 +501,15 @@ namespace Settings {
     GanonsTrialsCount.Hide();
 
     {
-      std::vector<std::string> bridgeTokenOptions;
-      bridgeTokenOptions.reserve(101);
+      std::vector<std::string> tokenOptions;
+      tokenOptions.reserve(101);
       for (int i = 0; i <= 100; i++) {
-        bridgeTokenOptions.push_back(std::to_string(i));
+        tokenOptions.push_back(std::to_string(i));
       }
-      BridgeTokenCount.SetOptions(std::move(bridgeTokenOptions));
+      BridgeTokenCount.SetOptions(tokenOptions);
       BridgeTokenCount.SetSelectedIndex(1);
+      LACSTokenCount.SetOptions(tokenOptions);
+      LACSTokenCount.SetSelectedIndex(1);
     }
 
     StartingAge.SetSelectedIndex(AGE_CHILD);
@@ -670,6 +693,30 @@ namespace Settings {
       StartingAge.Unlock();
     }
 
+    //Only show stone count option if Stones is selected
+    if (Bridge.Is(RAINBOWBRIDGE_STONES)) {
+      BridgeStoneCount.Unhide();
+    } else {
+      BridgeStoneCount.Hide();
+      BridgeStoneCount.SetSelectedIndex(3);
+    }
+
+    //Only show medallion count option if Medallions is selected
+    if (Bridge.Is(RAINBOWBRIDGE_MEDALLIONS)) {
+      BridgeMedallionCount.Unhide();
+    } else {
+      BridgeMedallionCount.Hide();
+      BridgeMedallionCount.SetSelectedIndex(6);
+    }
+
+    //Only show dungeon count option if Dungeons is selected
+    if (Bridge.Is(RAINBOWBRIDGE_DUNGEONS)) {
+      BridgeDungeonCount.Unhide();
+    } else {
+      BridgeDungeonCount.Hide();
+      BridgeDungeonCount.SetSelectedIndex(9);
+    }
+
     //Only show token count option if Tokens is selected
     if (Bridge.Is(RAINBOWBRIDGE_TOKENS)) {
       BridgeTokenCount.Unhide();
@@ -700,6 +747,38 @@ namespace Settings {
       MQDungeonCount.SetSelectedIndex(0);
     } else {
       MQDungeonCount.Unhide();
+    }
+
+    //Only show Medallion Count if setting Ganons Boss Key to LACS Medallions
+    if (GanonsBossKey.Is(GANONSBOSSKEY_LACS_MEDALLIONS)) {
+      LACSMedallionCount.Unhide();
+    } else {
+      LACSMedallionCount.SetSelectedIndex(6);
+      LACSMedallionCount.Hide();
+    }
+
+    //Only show Stone Count if setting Ganons Boss Key to LACS Stones
+    if (GanonsBossKey.Is(GANONSBOSSKEY_LACS_STONES)) {
+      LACSStoneCount.Unhide();
+    } else {
+      LACSStoneCount.SetSelectedIndex(3);
+      LACSStoneCount.Hide();
+    }
+
+    //Only show Dungeon Count if setting Ganons Boss Key to LACS Dungeons
+    if (GanonsBossKey.Is(GANONSBOSSKEY_LACS_DUNGEONS)) {
+      LACSDungeonCount.Unhide();
+    } else {
+      LACSDungeonCount.SetSelectedIndex(9);
+      LACSDungeonCount.Hide();
+    }
+
+    //Only show Token Count if setting Ganons Boss Key to LACS Tokens
+    if (GanonsBossKey.Is(GANONSBOSSKEY_LACS_TOKENS)) {
+      LACSTokenCount.Unhide();
+    } else {
+      LACSTokenCount.SetSelectedIndex(100);
+      LACSTokenCount.Hide();
     }
 
     //Set toggle for all tricks
@@ -812,6 +891,8 @@ namespace Settings {
       LACSCondition = LACSCONDITION_STONES;
     } else if (GanonsBossKey.Is(GANONSBOSSKEY_LACS_DUNGEONS)) {
       LACSCondition = LACSCONDITION_DUNGEONS;
+    } else if (GanonsBossKey.Is(GANONSBOSSKEY_LACS_TOKENS)) {
+      LACSCondition = LACSCONDITION_TOKENS;
     } else {
       LACSCondition = LACSCONDITION_VANILLA;
     }

--- a/source/settings.hpp
+++ b/source/settings.hpp
@@ -76,6 +76,10 @@ public:
     }
 
     std::string_view GetSelectedOptionDescription() const {
+      //bounds checking
+      if (selectedOption >= optionDescriptions.size()) {
+        return optionDescriptions[optionDescriptions.size()-1];
+      }
       return optionDescriptions[selectedOption];
     }
 
@@ -235,6 +239,9 @@ namespace Settings {
   extern Option ZorasFountain;
   extern Option GerudoFortress;
   extern Option Bridge;
+  extern Option BridgeStoneCount;
+  extern Option BridgeMedallionCount;
+  extern Option BridgeDungeonCount;
   extern Option BridgeTokenCount;
   extern Option RandomGanonsTrials;
   extern Option GanonsTrialsCount;
@@ -263,6 +270,10 @@ namespace Settings {
   extern Option BossKeysanity;
   extern Option GanonsBossKey;
   extern u8 LACSCondition;
+  extern Option LACSMedallionCount;
+  extern Option LACSStoneCount;
+  extern Option LACSDungeonCount;
+  extern Option LACSTokenCount;
 
   extern Option SkipChildStealth;
   extern Option SkipTowerEscape;


### PR DESCRIPTION
- The Rainbow Bridge and Ganon Boss Key on LACS can now be configured with exact amounts of stones/medallions/dungeon rewards
- Added a warning message on the in game menu to not put the 3DS into sleep mode