### PR TITLE
Logic: Changed CanUse() and related functions to use an enum

### DIFF
--- a/source/location_access.cpp
+++ b/source/location_access.cpp
@@ -15,7 +15,7 @@ bool NO_DAY_NIGHT_CYCLE = false;
 //generic grotto event list
 std::vector<EventPairing> grottoEvents = {
   EventPairing(&GossipStoneFairy, []{return GossipStoneFairy || CanSummonGossipFairy;}),
-  EventPairing(&ButterflyFairy,   []{return ButterflyFairy   || (CanUse("Sticks"));}),
+  EventPairing(&ButterflyFairy,   []{return ButterflyFairy   || (CanUse(CanUseItem::Sticks));}),
   EventPairing(&BugShrub,         []{return CanCutShrubs;}),
   EventPairing(&LoneFish,         []{return true;}),
 };
@@ -52,7 +52,7 @@ namespace Exits { //name, scene, hint, events, locations, exits
                   ItemLocationPairing(&KF_KokiriSwordChest,  []{return IsChild;}),
                   ItemLocationPairing(&KF_GS_KnowItAllHouse, []{return IsChild && CanChildAttack && AtNight && (HasNightStart || CanLeaveForest || CanPlay(SunsSong));}),
                   ItemLocationPairing(&KF_GS_BeanPatch,      []{return CanPlantBugs && CanChildAttack;}),
-                  ItemLocationPairing(&KF_GS_HouseOfTwins,   []{return IsAdult && AtNight && CanUse("Hookshot");}),
+                  ItemLocationPairing(&KF_GS_HouseOfTwins,   []{return IsAdult && AtNight && CanUse(CanUseItem::Hookshot);}),
                 }, {
                   //Exits
                   ExitPairing::Both(&KF_LinksHouse,       []{return true;}),
@@ -70,7 +70,7 @@ namespace Exits { //name, scene, hint, events, locations, exits
   Exit KF_OutsideDekuTree = Exit("KF Outside Deku Tree", "Kokiri Forest", "Kokiri Forest", NO_DAY_NIGHT_CYCLE, {
                   //Events
                   EventPairing(&DekuBabaSticks, []{return DekuBabaSticks || ((IsAdult && !ShuffleDungeonEntrances) || KokiriSword || Boomerang);}),
-                  EventPairing(&DekuBabaNuts,   []{return DekuBabaNuts   || ((IsAdult && !ShuffleDungeonEntrances) || KokiriSword || Slingshot || Sticks || HasExplosives || CanUse("Dins Fire"));}),
+                  EventPairing(&DekuBabaNuts,   []{return DekuBabaNuts   || ((IsAdult && !ShuffleDungeonEntrances) || KokiriSword || Slingshot || Sticks || HasExplosives || CanUse(CanUseItem::Dins_Fire));}),
                 }, {
                   //Locations
                   // ItemLocationPairing(&KF_DekuTreeGossipStoneLeft,  []{return true;}),
@@ -155,7 +155,7 @@ namespace Exits { //name, scene, hint, events, locations, exits
                   //Locations
                   ItemLocationPairing(&LW_SkullKid,               []{return IsChild && CanPlay(SariasSong);}),
                   ItemLocationPairing(&LW_OcarinaMemoryGame,      []{return IsChild && Ocarina;}),
-                  ItemLocationPairing(&LW_TargetInWoods,          []{return CanUse("Slingshot");}),
+                  ItemLocationPairing(&LW_TargetInWoods,          []{return CanUse(CanUseItem::Slingshot);}),
                   ItemLocationPairing(&LW_DekuScrubNearBridge,    []{return IsChild && CanStunDeku;}),
                   ItemLocationPairing(&LW_GS_BeanPatchNearBridge, []{return CanPlantBugs && CanChildAttack;}),
                   //LW Gossip Stone
@@ -163,20 +163,20 @@ namespace Exits { //name, scene, hint, events, locations, exits
                   //Exits
                   ExitPairing::Both(&LW_ForestExit,          []{return true;}),
                   ExitPairing::Both(&GC_WoodsWarp,           []{return true;}),
-                  ExitPairing::Both(&LW_Bridge,              []{return IsAdult && (CanUse("Hover Boots") || CanUse("Longshot") || LW_Main.CanPlantBean());}),
-                  ExitPairing::Both(&ZR_Main,                []{return CanLeaveForest && (CanDive || CanUse("Iron Boots"));}),
+                  ExitPairing::Both(&LW_Bridge,              []{return IsAdult && (CanUse(CanUseItem::Hover_Boots) || CanUse(CanUseItem::Longshot) || LW_Main.CanPlantBean());}),
+                  ExitPairing::Both(&ZR_Main,                []{return CanLeaveForest && (CanDive || CanUse(CanUseItem::Iron_Boots));}),
                   ExitPairing::Both(&LW_BeyondMido,          []{return IsChild || CanPlay(SariasSong);}),
                   ExitPairing::Both(&LW_NearShortcutsGrotto, []{return CanBlastOrSmash;})
   });
 
   Exit LW_BeyondMido = Exit("LW Beyond Mido", "Lost Woods", "Lost Woods", NO_DAY_NIGHT_CYCLE, {
                   //Events
-                  EventPairing(&ButterflyFairy, []{return ButterflyFairy || CanUse("Sticks");}),
+                  EventPairing(&ButterflyFairy, []{return ButterflyFairy || CanUse(CanUseItem::Sticks);}),
                 }, {
                   //Locations
                   ItemLocationPairing(&LW_DekuScrubNearDekuTheaterRight, []{return IsChild && CanStunDeku;}),
                   ItemLocationPairing(&LW_DekuScrubNearDekuTheaterLeft,  []{return IsChild && CanStunDeku;}),
-                  ItemLocationPairing(&LW_GS_AboveTheater,               []{return IsAdult && AtNight && (LW_BeyondMido.CanPlantBean() || (LogicLostWoodsGSBean && CanUse("Hookshot") && (CanUse("Longshot") || CanUse("Bow") || HasBombchus || CanUse("Dins Fire"))));}),
+                  ItemLocationPairing(&LW_GS_AboveTheater,               []{return IsAdult && AtNight && (LW_BeyondMido.CanPlantBean() || (LogicLostWoodsGSBean && CanUse(CanUseItem::Hookshot) && (CanUse(CanUseItem::Longshot) || CanUse(CanUseItem::Bow) || HasBombchus || CanUse(CanUseItem::Dins_Fire))));}),
                   ItemLocationPairing(&LW_GS_BeanPatchNearTheater,       []{return CanPlantBugs && (CanChildAttack || (Scrubsanity.Is(SCRUBSANITY_OFF) && DekuShield));}),
                 }, {
                   //Exits
@@ -217,7 +217,7 @@ namespace Exits { //name, scene, hint, events, locations, exits
   Exit SFM_Entryway = Exit("SFM Entryway", "Sacred Forest Meadow", "Sacred Forest Meadow", NO_DAY_NIGHT_CYCLE, {}, {}, {
                   //Exits
                   ExitPairing::Both(&LW_BeyondMido,    []{return true;}),
-                  ExitPairing::Both(&SFM_Main,         []{return IsAdult || Slingshot || Sticks || KokiriSword || CanUse("Dins Fire");}),
+                  ExitPairing::Both(&SFM_Main,         []{return IsAdult || Slingshot || Sticks || KokiriSword || CanUse(CanUseItem::Dins_Fire);}),
                   ExitPairing::Both(&SFM_WolfosGrotto, []{return CanOpenBombGrotto;}),
   });
 
@@ -228,14 +228,14 @@ namespace Exits { //name, scene, hint, events, locations, exits
                   //Locations
                   ItemLocationPairing(&SongFromSaria, []{return IsChild && ZeldasLetter;}),
                   ItemLocationPairing(&SheikInForest, []{return IsAdult;}),
-                  ItemLocationPairing(&SFM_GS,        []{return CanUse("Hookshot") && AtNight;}),
+                  ItemLocationPairing(&SFM_GS,        []{return CanUse(CanUseItem::Hookshot) && AtNight;}),
                   //SFM Maze Gossip Stone (Lower)
                   //SFM Maze Gossip Stone (Upper)
                   //SFM Saria Gossip Stone
                 }, {
                   //Exits
                   ExitPairing::Both(&SFM_Entryway,       []{return true;}),
-                  ExitPairing::Both(&ForestTemple_Lobby, []{return CanUse("Hookshot");}),
+                  ExitPairing::Both(&ForestTemple_Lobby, []{return CanUse(CanUseItem::Hookshot);}),
                   ExitPairing::Both(&SFM_FairyGrotto,    []{return true;}),
                   ExitPairing::Both(&SFM_StormsGrotto,   []{return CanOpenStormGrotto;}),
   });
@@ -250,7 +250,7 @@ namespace Exits { //name, scene, hint, events, locations, exits
 
   Exit SFM_WolfosGrotto = Exit("SFM Wolfos Grotto", "", "", NO_DAY_NIGHT_CYCLE, {}, {
                   //Locations
-                  ItemLocationPairing(&SFM_WolfosGrottoChest, []{return IsAdult || Slingshot || Sticks || KokiriSword || CanUse("Dins Fire");})
+                  ItemLocationPairing(&SFM_WolfosGrottoChest, []{return IsAdult || Slingshot || Sticks || KokiriSword || CanUse(CanUseItem::Dins_Fire);})
                 }, {
                   //Exits
                   ExitPairing::Both(&SFM_Main, []{return true;}),
@@ -277,12 +277,12 @@ namespace Exits { //name, scene, hint, events, locations, exits
                   //Exits
                   ExitPairing::Both(&KF_Main, []{return true;}),
                   ExitPairing::Both(&HF_Main, []{return true;}),
-                  ExitPairing::Both(&LW_Main, []{return CanUse("Longshot");})
+                  ExitPairing::Both(&LW_Main, []{return CanUse(CanUseItem::Longshot);})
   });
 
   Exit HF_Main = Exit("Hyrule Field", "Hyrule Field", "Hyrule Field", DAY_NIGHT_CYCLE, {
                   //Events
-                  EventPairing(&BigPoeKill, []{return CanUse("Bow") && CanRideEpona && HasBottle;}),
+                  EventPairing(&BigPoeKill, []{return CanUse(CanUseItem::Bow) && CanRideEpona && HasBottle;}),
                 }, {
                   //Locations
                   ItemLocationPairing(&HF_OcarinaOfTimeItem,  []{return IsChild && HasAllStones;}),
@@ -299,7 +299,7 @@ namespace Exits { //name, scene, hint, events, locations, exits
                   ExitPairing::Both(&HF_SoutheastGrotto,   []{return CanBlastOrSmash;}),
                   ExitPairing::Both(&HF_OpenGrotto,        []{return true;}),
                   ExitPairing::Both(&HF_InsideFenceGrotto, []{return CanOpenBombGrotto;}),
-                  ExitPairing::Both(&HF_CowGrotto,         []{return (CanUse("Hammer") || IsChild) && CanOpenBombGrotto;}),
+                  ExitPairing::Both(&HF_CowGrotto,         []{return (CanUse(CanUseItem::Hammer) || IsChild) && CanOpenBombGrotto;}),
                   ExitPairing::Both(&HF_NearMarketGrotto,  []{return CanBlastOrSmash;}),
                   ExitPairing::Both(&HF_FairyGrotto,       []{return CanBlastOrSmash;}),
                   ExitPairing::Both(&HF_NearKakGrotto,     []{return CanOpenBombGrotto;}),
@@ -369,7 +369,7 @@ namespace Exits { //name, scene, hint, events, locations, exits
 
   Exit HF_TektiteGrotto = Exit("HF Tektite Grotto", "", "", NO_DAY_NIGHT_CYCLE, {}, {
                   //Locations
-                  ItemLocationPairing(&HF_TektiteGrottoFreestandingPoH, []{return ProgressiveScale >= 2 || CanUse("Iron Boots");}),
+                  ItemLocationPairing(&HF_TektiteGrottoFreestandingPoH, []{return ProgressiveScale >= 2 || CanUse(CanUseItem::Iron_Boots);}),
                 }, {
                   //Exits
                   ExitPairing::Both(&HF_Main, []{return true;}),
@@ -379,18 +379,18 @@ namespace Exits { //name, scene, hint, events, locations, exits
                   //Events
                   EventPairing(&GossipStoneFairy, []{return GossipStoneFairy || CanSummonGossipFairy;}),
                   EventPairing(&BeanPlantFairy,   []{return BeanPlantFairy   || (LH_Main.CanPlantBean() && CanPlay(SongOfStorms));}),
-                  EventPairing(&ButterflyFairy,   []{return ButterflyFairy   || CanUse("Sticks");}),
+                  EventPairing(&ButterflyFairy,   []{return ButterflyFairy   || CanUse(CanUseItem::Sticks);}),
                   EventPairing(&BugShrub,         []{return BugShrub         || (IsChild && CanCutShrubs);}),
                   EventPairing(&ScarecrowSong,    []{return ScarecrowSong    || (Ocarina && LH_Main.BothAges());}),
                 }, {
                   //Locations
                   ItemLocationPairing(&LH_UnderwaterItem,  []{return IsChild && CanDive;}),
-                  ItemLocationPairing(&LH_Sun,             []{return IsAdult && WaterTempleClear && CanUse("Bow");}),
-                  ItemLocationPairing(&LH_FreestandingPoH, []{return IsAdult && (CanUse("Scarecrow") || LH_Main.CanPlantBean());}),
+                  ItemLocationPairing(&LH_Sun,             []{return IsAdult && WaterTempleClear && CanUse(CanUseItem::Bow);}),
+                  ItemLocationPairing(&LH_FreestandingPoH, []{return IsAdult && (CanUse(CanUseItem::Scarecrow) || LH_Main.CanPlantBean());}),
                   ItemLocationPairing(&LH_GS_BeanPatch,    []{return CanPlantBugs && CanChildAttack;}),
                   ItemLocationPairing(&LH_GS_LabWall,      []{return IsChild && (Boomerang || (LogicLabWallGS && (Sticks || KokiriSword))) && AtNight;}),
                   ItemLocationPairing(&LH_GS_SmallIsland,  []{return IsChild && CanChildAttack && AtNight;}),
-                  ItemLocationPairing(&LH_GS_Tree,         []{return CanUse("Longshot") && AtNight;}),
+                  ItemLocationPairing(&LH_GS_Tree,         []{return CanUse(CanUseItem::Longshot) && AtNight;}),
                   //LH Gossip Stone (Southeast)
                   //LH Gossip Stone (Southwest)
                 }, {
@@ -399,8 +399,8 @@ namespace Exits { //name, scene, hint, events, locations, exits
                   ExitPairing::Both(&ZD_Main,           []{return IsChild && CanDive;}),
                   ExitPairing::Both(&LH_OwlFlight,      []{return IsChild;}),
                   ExitPairing::Both(&LH_Lab,            []{return true;}),
-                  ExitPairing::Both(&LH_FishingHole,    []{return IsChild || CanUse("Scarecrow") || LH_Main.CanPlantBean() || WaterTempleClear;}),
-                  ExitPairing::Both(&WaterTemple_Lobby, []{return CanUse("Hookshot") && (CanUse("Iron Boots") || ((CanUse("Longshot")) && ProgressiveScale >= 2));}),
+                  ExitPairing::Both(&LH_FishingHole,    []{return IsChild || CanUse(CanUseItem::Scarecrow) || LH_Main.CanPlantBean() || WaterTempleClear;}),
+                  ExitPairing::Both(&WaterTemple_Lobby, []{return CanUse(CanUseItem::Hookshot) && (CanUse(CanUseItem::Iron_Boots) || ((CanUse(CanUseItem::Longshot)) && ProgressiveScale >= 2));}),
                   ExitPairing::Both(&LH_Grotto,         []{return true;})
   });
 
@@ -414,8 +414,8 @@ namespace Exits { //name, scene, hint, events, locations, exits
                   EventPairing(&EyedropsAccess, []{return EyedropsAccess || (IsAdult && (EyeballFrogAccess || (EyeballFrog && DisableTradeRevert)));}),
                 }, {
                   //Locations
-                  ItemLocationPairing(&LH_LabDive,     []{return ProgressiveScale >= 2 || (LogicLabDiving && IronBoots && CanUse("Hookshot"));}),
-                  ItemLocationPairing(&LH_GS_LabCrate, []{return IronBoots && CanUse("Hookshot");}),
+                  ItemLocationPairing(&LH_LabDive,     []{return ProgressiveScale >= 2 || (LogicLabDiving && IronBoots && CanUse(CanUseItem::Hookshot));}),
+                  ItemLocationPairing(&LH_GS_LabCrate, []{return IronBoots && CanUse(CanUseItem::Hookshot);}),
                 }, {
                   //Exits
                   ExitPairing::Both(&LH_Main, []{return true;})
@@ -445,14 +445,14 @@ namespace Exits { //name, scene, hint, events, locations, exits
                   EventPairing(&BugRock, []{return IsChild && HasBottle;}),
                 }, {
                   //Locations
-                  ItemLocationPairing(&GV_GS_SmallBridge, []{return CanUse("Boomerang") && AtNight;}),
+                  ItemLocationPairing(&GV_GS_SmallBridge, []{return CanUse(CanUseItem::Boomerang) && AtNight;}),
                 }, {
                   //Exits
                   ExitPairing::Both(&HF_Main,          []{return true;}),
                   ExitPairing::Both(&GV_Stream,        []{return true;}),
-                  ExitPairing::Both(&GV_CrateLedge,    []{return IsChild || CanUse("Longshot");}),
-                  ExitPairing::Both(&GV_OctorokGrotto, []{return CanUse("Silver Gauntlets");}),
-                  ExitPairing::Both(&GV_FortressSide,  []{return IsAdult && (CanRideEpona || CanUse("Longshot") || GerudoFortress.Is(GERUDOFORTRESS_OPEN) || CarpenterRescue);})
+                  ExitPairing::Both(&GV_CrateLedge,    []{return IsChild || CanUse(CanUseItem::Longshot);}),
+                  ExitPairing::Both(&GV_OctorokGrotto, []{return CanUse(CanUseItem::Silver_Gauntlets);}),
+                  ExitPairing::Both(&GV_FortressSide,  []{return IsAdult && (CanRideEpona || CanUse(CanUseItem::Longshot) || GerudoFortress.Is(GERUDOFORTRESS_OPEN) || CarpenterRescue);})
   });
 
   Exit GV_Stream = Exit("GV Stream", "Gerudo Valley", "Gerudo Valley", DAY_NIGHT_CYCLE, {
@@ -482,14 +482,14 @@ namespace Exits { //name, scene, hint, events, locations, exits
                   EventPairing(&BrokenSwordAccess, []{return IsAdult && (PoachersSawAccess || PoachersSaw);}),
                 }, {
                   //Locations
-                  ItemLocationPairing(&GV_Chest,         []{return CanUse("Hammer");}),
-                  ItemLocationPairing(&GV_GS_BehindTent, []{return CanUse("Hookshot") && AtNight;}),
-                  ItemLocationPairing(&GV_GS_Pillar,     []{return CanUse("Hookshot") && AtNight;}),
+                  ItemLocationPairing(&GV_Chest,         []{return CanUse(CanUseItem::Hammer);}),
+                  ItemLocationPairing(&GV_GS_BehindTent, []{return CanUse(CanUseItem::Hookshot) && AtNight;}),
+                  ItemLocationPairing(&GV_GS_Pillar,     []{return CanUse(CanUseItem::Hookshot) && AtNight;}),
                 }, {
                   //Exits
                   ExitPairing::Both(&GF_Main,          []{return true;}),
                   ExitPairing::Both(&GV_Stream,        []{return true;}),
-                  ExitPairing::Both(&GV_Main,          []{return IsChild || CanRideEpona || CanUse("Longshot") || GerudoFortress.Is(GERUDOFORTRESS_OPEN) || CarpenterRescue;}),
+                  ExitPairing::Both(&GV_Main,          []{return IsChild || CanRideEpona || CanUse(CanUseItem::Longshot) || GerudoFortress.Is(GERUDOFORTRESS_OPEN) || CarpenterRescue;}),
                   ExitPairing::Both(&GV_CarpenterTent, []{return IsAdult;}),
                   ExitPairing::Both(&GV_StormsGrotto,  []{return IsAdult && CanOpenStormGrotto;})
   });
@@ -519,16 +519,16 @@ namespace Exits { //name, scene, hint, events, locations, exits
                   EventPairing(&GF_GateOpen,     []{return IsAdult && GerudoToken;}),
                 }, {
                   //Locations
-                  ItemLocationPairing(&GF_Chest,            []{return CanUse("Hover Boots") || CanUse("Scarecrow") || CanUse("Longshot");}),
+                  ItemLocationPairing(&GF_Chest,            []{return CanUse(CanUseItem::Hover_Boots) || CanUse(CanUseItem::Scarecrow) || CanUse(CanUseItem::Longshot);}),
                   ItemLocationPairing(&GF_HBA1000Points,    []{return GerudoToken && CanRideEpona && Bow && AtDay;}),
                   ItemLocationPairing(&GF_HBA1500Points,    []{return GerudoToken && CanRideEpona && Bow && AtDay;}),
                   ItemLocationPairing(&GF_NorthF1Carpenter, []{return  IsAdult || KokiriSword;}),
-                  ItemLocationPairing(&GF_NorthF2Carpenter, []{return (IsAdult || KokiriSword) && (GerudoToken || CanUse("Bow") || CanUse("Hookshot") || CanUse("Hover Boots") || LogicGerudoKitchen);}),
+                  ItemLocationPairing(&GF_NorthF2Carpenter, []{return (IsAdult || KokiriSword) && (GerudoToken || CanUse(CanUseItem::Bow) || CanUse(CanUseItem::Hookshot) || CanUse(CanUseItem::Hover_Boots) || LogicGerudoKitchen);}),
                   ItemLocationPairing(&GF_SouthF1Carpenter, []{return  IsAdult || KokiriSword;}),
                   ItemLocationPairing(&GF_SouthF2Carpenter, []{return  IsAdult || KokiriSword;}),
                   ItemLocationPairing(&GF_GerudoToken,      []{return CanFinishGerudoFortress;}),
-                  ItemLocationPairing(&GF_GS_ArcheryRange,  []{return CanUse("Hookshot") && GerudoToken && AtNight;}),
-                  ItemLocationPairing(&GF_GS_TopFloor,      []{return IsAdult && AtNight && (GerudoToken || CanUse("Bow") || CanUse("Hookshot") || CanUse("Hover Boots") || LogicGerudoKitchen);})
+                  ItemLocationPairing(&GF_GS_ArcheryRange,  []{return CanUse(CanUseItem::Hookshot) && GerudoToken && AtNight;}),
+                  ItemLocationPairing(&GF_GS_TopFloor,      []{return IsAdult && AtNight && (GerudoToken || CanUse(CanUseItem::Bow) || CanUse(CanUseItem::Hookshot) || CanUse(CanUseItem::Hover_Boots) || LogicGerudoKitchen);})
                 }, {
                   //Exits
                   ExitPairing::Both(&GV_FortressSide,             []{return true;}),
@@ -557,7 +557,7 @@ namespace Exits { //name, scene, hint, events, locations, exits
   Exit HW_NearFortress = Exit("Wasteland Near Fortress", "Haunted Wasteland", "Haunted Wasteland", NO_DAY_NIGHT_CYCLE, {}, {}, {
                   //Exits
                   ExitPairing::Both(&GF_OutsideGate, []{return true;}),
-                  ExitPairing::Both(&HW_Main,        []{return CanUse("Hover Boots") || CanUse("Longshot");}),
+                  ExitPairing::Both(&HW_Main,        []{return CanUse(CanUseItem::Hover_Boots) || CanUse(CanUseItem::Longshot);}),
   });
 
   Exit HW_Main = Exit("Haunted Wasteland", "Haunted Wasteland", "Haunted Wasteland", NO_DAY_NIGHT_CYCLE, {
@@ -571,8 +571,8 @@ namespace Exits { //name, scene, hint, events, locations, exits
                   ItemLocationPairing(&HW_GS,    []{return HookshotOrBoomerang;}),
                 }, {
                   //Exits
-                  ExitPairing::Both(&HW_NearColossus, []{return LogicLensWasteland || CanUse("Lens of Truth");}),
-                  ExitPairing::Both(&HW_NearFortress, []{return CanUse("Hover Boots") || CanUse("Longshot");}),
+                  ExitPairing::Both(&HW_NearColossus, []{return LogicLensWasteland || CanUse(CanUseItem::Lens_of_Truth);}),
+                  ExitPairing::Both(&HW_NearFortress, []{return CanUse(CanUseItem::Hover_Boots) || CanUse(CanUseItem::Longshot);}),
   });
 
   Exit HW_NearColossus = Exit("Wasteland Near Colossus", "Haunted Wasteland", "", NO_DAY_NIGHT_CYCLE, {}, {}, {
@@ -590,15 +590,15 @@ namespace Exits { //name, scene, hint, events, locations, exits
                   ItemLocationPairing(&Colossus_FreestandingPoH, []{return IsAdult && Colossus_Main.CanPlantBean();}),
                   ItemLocationPairing(&SheikAtColossus,          []{return true;}),
                   ItemLocationPairing(&Colossus_GS_BeanPatch,    []{return CanPlantBugs && CanChildAttack;}),
-                  ItemLocationPairing(&Colossus_GS_Tree,         []{return CanUse("Hookshot") && AtNight;}),
-                  ItemLocationPairing(&Colossus_GS_Hill,         []{return IsAdult && AtNight && (Colossus_Main.CanPlantBean() || CanUse("Longshot") || (LogicColossusGS && CanUse("Hookshot")));})
+                  ItemLocationPairing(&Colossus_GS_Tree,         []{return CanUse(CanUseItem::Hookshot) && AtNight;}),
+                  ItemLocationPairing(&Colossus_GS_Hill,         []{return IsAdult && AtNight && (Colossus_Main.CanPlantBean() || CanUse(CanUseItem::Longshot) || (LogicColossusGS && CanUse(CanUseItem::Hookshot)));})
                   //Colossus Gossip Stone
                 }, {
                   //Exits
                   ExitPairing::Both(&Colossus_GreatFairyFountain, []{return HasExplosives;}),
                   ExitPairing::Both(&SpiritTemple_Lobby,          []{return true;}),
                   ExitPairing::Both(&HW_NearColossus,             []{return true;}),
-                  ExitPairing::Both(&Colossus_Grotto,             []{return CanUse("Silver Gauntlets");})
+                  ExitPairing::Both(&Colossus_Grotto,             []{return CanUse(CanUseItem::Silver_Gauntlets);})
   });
 
   Exit Colossus_GreatFairyFountain = Exit("Colossus Great Fairy Fountain", "", "", NO_DAY_NIGHT_CYCLE, {}, {
@@ -627,17 +627,17 @@ namespace Exits { //name, scene, hint, events, locations, exits
 
   Exit MK_Main = Exit("Market", "Market", "Market", NO_DAY_NIGHT_CYCLE, {}, {}, {
                   //Exits
-                  ExitPairing::Both(&MK_Entrance,          []{return true;}),
-                  ExitPairing::Both(&ToT_Entrance,         []{return true;}),
-                  ExitPairing::Both(&CastleGrounds,        []{return true;}),
-                  ExitPairing::Day(&MK_Bazaar,            []{return IsChild && AtDay;}),
-                  ExitPairing::Day(&MK_MaskShop,          []{return IsChild && AtDay;}),
-                  ExitPairing::Day(&MK_ShootingGallery,   []{return IsChild && AtDay;}),
-                  ExitPairing::Both(&MK_BombchuBowling,    []{return IsChild;}),
+                  ExitPairing::Both(&MK_Entrance,           []{return true;}),
+                  ExitPairing::Both(&ToT_Entrance,          []{return true;}),
+                  ExitPairing::Both(&CastleGrounds,         []{return true;}),
+                  ExitPairing::Day(&MK_Bazaar,              []{return IsChild && AtDay;}),
+                  ExitPairing::Day(&MK_MaskShop,            []{return IsChild && AtDay;}),
+                  ExitPairing::Day(&MK_ShootingGallery,     []{return IsChild && AtDay;}),
+                  ExitPairing::Both(&MK_BombchuBowling,     []{return IsChild;}),
                   ExitPairing::Night(&MK_TreasureChestGame, []{return IsChild && AtNight;}),
-                  ExitPairing::Day(&MK_PotionShop,        []{return IsChild && AtDay;}),
+                  ExitPairing::Day(&MK_PotionShop,          []{return IsChild && AtDay;}),
                   ExitPairing::Night(&MK_BombchuShop,       []{return IsChild && AtNight;}),
-                  ExitPairing::Both(&MK_DogLadyHouse,      []{return IsChild;}),
+                  ExitPairing::Both(&MK_DogLadyHouse,       []{return IsChild;}),
                   ExitPairing::Night(&MK_ManInGreenHouse,   []{return IsChild && AtNight;})
   });
 
@@ -683,7 +683,7 @@ namespace Exits { //name, scene, hint, events, locations, exits
   Exit HC_Grounds = Exit("Hyrule Castle Grounds", "Castle Grounds", "Hyrule Castle", DAY_NIGHT_CYCLE, {
                   //Events
                   EventPairing(&GossipStoneFairy, []{return GossipStoneFairy || CanSummonGossipFairy;}),
-                  EventPairing(&ButterflyFairy,   []{return ButterflyFairy   || CanUse("Sticks");}),
+                  EventPairing(&ButterflyFairy,   []{return ButterflyFairy   || CanUse(CanUseItem::Sticks);}),
                   EventPairing(&BugRock,          []{return true;}),
                 }, {
                   //Locations
@@ -734,11 +734,11 @@ namespace Exits { //name, scene, hint, events, locations, exits
 
   Exit OGC_Grounds = Exit("Ganon's Castle Grounds", "Castle Grounds", "outside Ganon's Castle", NO_DAY_NIGHT_CYCLE, {}, {
                   //Locations                     //the terrain was lowered such that you can't get this GS with a simple sword slash
-                  ItemLocationPairing(&OGC_GS, []{return HasExplosives || (IsAdult && (LogicOutsideGanonsGS || Bow || Hookshot || CanUse("Dins Fire")));}),
+                  ItemLocationPairing(&OGC_GS, []{return HasExplosives || (IsAdult && (LogicOutsideGanonsGS || Bow || Hookshot || CanUse(CanUseItem::Dins_Fire)));}),
                 }, {
                   //Exits
                   ExitPairing::Night(&CastleGrounds,          []{return AtNight;}),
-                  ExitPairing::Night(&OGC_GreatFairyFountain, []{return CanUse("Golden Gauntlets") && AtNight;}),
+                  ExitPairing::Night(&OGC_GreatFairyFountain, []{return CanUse(CanUseItem::Golden_Gauntlets) && AtNight;}),
                   ExitPairing::Both(&GanonsCastle_Lobby,      []{return CanBuildRainbowBridge;})
   });
 
@@ -818,7 +818,7 @@ namespace Exits { //name, scene, hint, events, locations, exits
 
   Exit MK_TreasureChestGame = Exit("Market Treasure Chest Game", "", "", NO_DAY_NIGHT_CYCLE, {}, {
                   //Locations
-                  ItemLocationPairing(&MK_TreasureChestGameReward, []{return CanUse("Lens of Truth");})
+                  ItemLocationPairing(&MK_TreasureChestGameReward, []{return CanUse(CanUseItem::Lens_of_Truth);})
                 }, {
                   //Exits
                   ExitPairing::Both(&MK_Main, []{return true;})
@@ -873,7 +873,7 @@ namespace Exits { //name, scene, hint, events, locations, exits
                   ItemLocationPairing(&Kak_GS_GuardsHouse,            []{return IsChild && AtNight;}),
                   ItemLocationPairing(&Kak_GS_Tree,                   []{return IsChild && AtNight;}),
                   ItemLocationPairing(&Kak_GS_Watchtower,             []{return IsChild && (Slingshot || HasBombchus) && AtNight;}),
-                  ItemLocationPairing(&Kak_GS_AboveImpasHouse,        []{return CanUse("Hookshot") && AtNight;}),
+                  ItemLocationPairing(&Kak_GS_AboveImpasHouse,        []{return CanUse(CanUseItem::Hookshot) && AtNight;}),
                 }, {
                   //Exits
                   ExitPairing::Both(&HF_Main,                []{return true;}),
@@ -889,7 +889,7 @@ namespace Exits { //name, scene, hint, events, locations, exits
                   ExitPairing::Both(&Kak_RedeadGrotto,       []{return CanOpenBombGrotto;}),
                   ExitPairing::Both(&Kak_ImpasLedge,         []{return (IsAdult && LogicVisibleCollision);}),
                   ExitPairing::Day(&Kak_ImpasLedge,          []{return (IsChild && AtDay);}),
-                  ExitPairing::Both(&Kak_Rooftop,            []{return CanUse("Hookshot") || (LogicManOnRoof && (IsAdult || Slingshot || HasBombchus));}),
+                  ExitPairing::Both(&Kak_Rooftop,            []{return CanUse(CanUseItem::Hookshot) || (LogicManOnRoof && (IsAdult || Slingshot || HasBombchus));}),
                   ExitPairing::Day(&Kak_Rooftop,             []{return LogicManOnRoof && AtDay;}),
                   ExitPairing::Both(&GY_Main,                []{return true;}),
                   ExitPairing::Both(&Kak_BehindGate,         []{return IsAdult || (KakarikoVillageGateOpen);})
@@ -965,7 +965,7 @@ namespace Exits { //name, scene, hint, events, locations, exits
                   EventPairing(&DrainWell, []{return DrainWell || (IsChild && CanPlay(SongOfStorms));}),
                 }, {
                   //Locations
-                  ItemLocationPairing(&Kak_WindmillFreestandingPoH, []{return CanUse("Boomerang") || DampesWindmillAccess;}),
+                  ItemLocationPairing(&Kak_WindmillFreestandingPoH, []{return CanUse(CanUseItem::Boomerang) || DampesWindmillAccess;}),
                   ItemLocationPairing(&SongFromWindmill,            []{return IsAdult && Ocarina;}),
                 }, {
                   //Exits
@@ -1027,7 +1027,7 @@ namespace Exits { //name, scene, hint, events, locations, exits
 
   Exit Kak_RedeadGrotto = Exit("Kak Redead Grotto", "", "", NO_DAY_NIGHT_CYCLE, {}, {
                   //Locations
-                  ItemLocationPairing(&Kak_RedeadGrottoChest, []{return IsAdult || (Sticks || KokiriSword || CanUse("Dins Fire"));})
+                  ItemLocationPairing(&Kak_RedeadGrottoChest, []{return IsAdult || (Sticks || KokiriSword || CanUse(CanUseItem::Dins_Fire));})
                 }, {
                   //Exits
                   ExitPairing::Both(&Kak_Main, []{return true;})
@@ -1044,14 +1044,14 @@ namespace Exits { //name, scene, hint, events, locations, exits
 
   Exit GY_Main = Exit("Graveyard", "Graveyard", "the Graveyard", NO_DAY_NIGHT_CYCLE, {
                   //Events
-                  EventPairing(&ButterflyFairy, []{return ButterflyFairy || (CanUse("Sticks") && AtDay);}),
+                  EventPairing(&ButterflyFairy, []{return ButterflyFairy || (CanUse(CanUseItem::Sticks) && AtDay);}),
                   EventPairing(&BeanPlantFairy, []{return BeanPlantFairy || (GY_Main.CanPlantBean() && CanPlay(SongOfStorms));}),
                   EventPairing(&BugRock,        []{return true;}),
                 }, {
                   //Locations
-                  ItemLocationPairing(&GY_FreestandingPoH,       []{return (IsAdult && (GY_Main.CanPlantBean() || CanUse("Longshot"))) || (LogicGraveyardPoH && CanUse("Boomerang"));}),
+                  ItemLocationPairing(&GY_FreestandingPoH,       []{return (IsAdult && (GY_Main.CanPlantBean() || CanUse(CanUseItem::Longshot))) || (LogicGraveyardPoH && CanUse(CanUseItem::Boomerang));}),
                   ItemLocationPairing(&GY_DampeGravediggingTour, []{return IsChild && AtNight;}), //This needs to change
-                  ItemLocationPairing(&GY_GS_Wall,               []{return CanUse("Boomerang") && AtNight;}),
+                  ItemLocationPairing(&GY_GS_Wall,               []{return CanUse(CanUseItem::Boomerang) && AtNight;}),
                   ItemLocationPairing(&GY_GS_BeanPatch,          []{return CanPlantBugs && CanChildAttack;}),
                 }, {
                   //Exits
@@ -1119,7 +1119,7 @@ namespace Exits { //name, scene, hint, events, locations, exits
                 }, {
                   //Exits
                   ExitPairing::Both(&GY_Main,               []{return true;}),
-                  ExitPairing::Both(&ShadowTemple_Entryway, []{return CanUse("Dins Fire") || (LogicShadowFireArrowEntry && CanUse("Fire Arrows"));}),
+                  ExitPairing::Both(&ShadowTemple_Entryway, []{return CanUse(CanUseItem::Dins_Fire) || (LogicShadowFireArrowEntry && CanUse(CanUseItem::Fire_Arrows));}),
   });
 
   Exit Kak_BehindGate = Exit("Kak Behind Gate", "Kakariko Village", "", NO_DAY_NIGHT_CYCLE, {}, {}, {
@@ -1134,10 +1134,10 @@ namespace Exits { //name, scene, hint, events, locations, exits
                 }, {
                   //Locations
                   ItemLocationPairing(&DMT_Chest,                  []{return CanBlastOrSmash || (LogicDMTBombable && IsChild && GoronBracelet);}),
-                  ItemLocationPairing(&DMT_FreestandingPoH,        []{return (DamageMultiplier.IsNot(DAMAGEMULTIPLIER_OHKO)) || CanUse("Nayrus Love") || Fairy || CanUse("Hover Boots") || (IsAdult && DMT_Main.CanPlantBean() && (HasExplosives || GoronBracelet));}),
-                  ItemLocationPairing(&DMT_GS_BeanPatch,           []{return CanPlantBugs && (HasExplosives || GoronBracelet || (LogicDMTSoilGS && CanUse("Boomerang")));}),
+                  ItemLocationPairing(&DMT_FreestandingPoH,        []{return (DamageMultiplier.IsNot(DAMAGEMULTIPLIER_OHKO)) || CanUse(CanUseItem::Nayrus_Love) || Fairy || CanUse(CanUseItem::Hover_Boots) || (IsAdult && DMT_Main.CanPlantBean() && (HasExplosives || GoronBracelet));}),
+                  ItemLocationPairing(&DMT_GS_BeanPatch,           []{return CanPlantBugs && (HasExplosives || GoronBracelet || (LogicDMTSoilGS && CanUse(CanUseItem::Boomerang)));}),
                   ItemLocationPairing(&DMT_GS_NearKak,             []{return CanBlastOrSmash;}),
-                  ItemLocationPairing(&DMT_GS_AboveDodongosCavern, []{return IsAdult && AtNight && CanUse("Hammer");})
+                  ItemLocationPairing(&DMT_GS_AboveDodongosCavern, []{return IsAdult && AtNight && CanUse(CanUseItem::Hammer);})
                 }, {
                   //Exits
                   ExitPairing::Both(&Kak_BehindGate,          []{return true;}),
@@ -1155,7 +1155,7 @@ namespace Exits { //name, scene, hint, events, locations, exits
                 }, {
                   //Locations
                   ItemLocationPairing(&DMT_Biggoron,            []{return IsAdult && (ClaimCheck || (GuaranteeTradePath && (EyedropsAccess || (Eyedrops && DisableTradeRevert))));}),
-                  ItemLocationPairing(&DMT_GS_FallingRocksPath, []{return IsAdult && AtNight && CanUse("Hammer");}),
+                  ItemLocationPairing(&DMT_GS_FallingRocksPath, []{return IsAdult && AtNight && CanUse(CanUseItem::Hammer);}),
                   //DMT Gossip Stone
                 }, {
                   //Exits
@@ -1208,14 +1208,14 @@ namespace Exits { //name, scene, hint, events, locations, exits
                   EventPairing(&GossipStoneFairy,          []{return GossipStoneFairy          || CanSummonGossipFairyWithoutSuns;}),
                   EventPairing(&StickPot,                  []{return StickPot                  || IsChild;}),
                   EventPairing(&BugRock,                   []{return true;}),
-                  EventPairing(&GoronCityChildFire,        []{return GoronCityChildFire        || (IsChild && CanUse("Dins Fire"));}),
-                  EventPairing(&GCWoodsWarpOpen,           []{return GCWoodsWarpOpen           || (CanBlastOrSmash || CanUse("Dins Fire") || CanUse("Bow") || GoronBracelet || GoronCityChildFire);}),
-                  EventPairing(&StopGCRollingGoronAsAdult, []{return StopGCRollingGoronAsAdult || (IsAdult && (GoronBracelet || HasExplosives || Bow || (LogicLinkGoronDins && CanUse("Dins Fire"))));}),
+                  EventPairing(&GoronCityChildFire,        []{return GoronCityChildFire        || (IsChild && CanUse(CanUseItem::Dins_Fire));}),
+                  EventPairing(&GCWoodsWarpOpen,           []{return GCWoodsWarpOpen           || (CanBlastOrSmash || CanUse(CanUseItem::Dins_Fire) || CanUse(CanUseItem::Bow) || GoronBracelet || GoronCityChildFire);}),
+                  EventPairing(&StopGCRollingGoronAsAdult, []{return StopGCRollingGoronAsAdult || (IsAdult && (GoronBracelet || HasExplosives || Bow || (LogicLinkGoronDins && CanUse(CanUseItem::Dins_Fire))));}),
                 }, {
                   //Locations
-                  ItemLocationPairing(&GC_MazeLeftChest,       []{return CanUse("Hammer") || CanUse("Silver Gauntlets") || (LogicGoronCityLeftMost && HasExplosives && CanUse("Hover Boots"));}),
-                  ItemLocationPairing(&GC_MazeCenterChest,     []{return CanBlastOrSmash  || CanUse("Silver Gauntlets");}),
-                  ItemLocationPairing(&GC_MazeRightChest,      []{return CanBlastOrSmash  || CanUse("Silver Gauntlets");}),
+                  ItemLocationPairing(&GC_MazeLeftChest,       []{return CanUse(CanUseItem::Hammer) || CanUse(CanUseItem::Silver_Gauntlets) || (LogicGoronCityLeftMost && HasExplosives && CanUse(CanUseItem::Hover_Boots));}),
+                  ItemLocationPairing(&GC_MazeCenterChest,     []{return CanBlastOrSmash  || CanUse(CanUseItem::Silver_Gauntlets);}),
+                  ItemLocationPairing(&GC_MazeRightChest,      []{return CanBlastOrSmash  || CanUse(CanUseItem::Silver_Gauntlets);}),
                   ItemLocationPairing(&GC_PotFreestandingPoH,  []{return IsChild && GoronCityChildFire && (Bombs || (GoronBracelet && LogicGoronCityPotWithStrength) || (HasBombchus && LogicGoronCityPot));}),
                   ItemLocationPairing(&GC_RollingGoronAsChild, []{return IsChild && (HasExplosives || (GoronBracelet && LogicChildRollingWithStrength));}),
                   ItemLocationPairing(&GC_RollingGoronAsAdult, []{return StopGCRollingGoronAsAdult;}),
@@ -1229,12 +1229,12 @@ namespace Exits { //name, scene, hint, events, locations, exits
                   ExitPairing::Both(&GC_WoodsWarp,       []{return GCWoodsWarpOpen;}),
                   ExitPairing::Both(&GC_Shop,            []{return (IsAdult && StopGCRollingGoronAsAdult) || (IsChild && (HasExplosives || GoronBracelet || GoronCityChildFire));}),
                   ExitPairing::Both(&GC_DaruniasChamber, []{return (IsAdult && StopGCRollingGoronAsAdult) || (IsChild && CanPlay(ZeldasLullaby));}),
-                  ExitPairing::Both(&GC_Grotto,          []{return IsAdult && ((CanPlay(SongOfTime) && ((DamageMultiplier.IsNot(DAMAGEMULTIPLIER_OHKO) && DamageMultiplier.IsNot(DAMAGEMULTIPLIER_QUADRUPLE)) || CanUse("Goron Tunic") || CanUse("Longshot") || CanUse("Nayrus Love"))) || (DamageMultiplier.IsNot(DAMAGEMULTIPLIER_OHKO) && CanUse("Goron Tunic") && CanUse("Hookshot")) ||(CanUse("Nayrus Love") && CanUse("Hookshot")));}),
+                  ExitPairing::Both(&GC_Grotto,          []{return IsAdult && ((CanPlay(SongOfTime) && ((DamageMultiplier.IsNot(DAMAGEMULTIPLIER_OHKO) && DamageMultiplier.IsNot(DAMAGEMULTIPLIER_QUADRUPLE)) || CanUse(CanUseItem::Goron_Tunic) || CanUse(CanUseItem::Longshot) || CanUse(CanUseItem::Nayrus_Love))) || (DamageMultiplier.IsNot(DAMAGEMULTIPLIER_OHKO) && CanUse(CanUseItem::Goron_Tunic) && CanUse(CanUseItem::Hookshot)) ||(CanUse(CanUseItem::Nayrus_Love) && CanUse(CanUseItem::Hookshot)));}),
   });
 
   Exit GC_WoodsWarp = Exit("GC Woods Warp", "Goron City", "", NO_DAY_NIGHT_CYCLE, {
                   //Events
-                  EventPairing(&GCWoodsWarpOpen, []{return GCWoodsWarpOpen || (CanBlastOrSmash || CanUse("Dins Fire"));}),
+                  EventPairing(&GCWoodsWarpOpen, []{return GCWoodsWarpOpen || (CanBlastOrSmash || CanUse(CanUseItem::Dins_Fire));}),
                 }, {}, {
                   //Exits
                   ExitPairing::Both(&GC_Main, []{return CanLeaveForest && GCWoodsWarpOpen;}),
@@ -1243,7 +1243,7 @@ namespace Exits { //name, scene, hint, events, locations, exits
 
   Exit GC_DaruniasChamber = Exit("GC Darunias Chamber", "Goron City", "Goron City", NO_DAY_NIGHT_CYCLE, {
                   //Events
-                  EventPairing(&GoronCityChildFire, []{return GoronCityChildFire || (CanUse("Sticks"));}),
+                  EventPairing(&GoronCityChildFire, []{return GoronCityChildFire || (CanUse(CanUseItem::Sticks));}),
                 }, {
                   //Locations
                   ItemLocationPairing(&GC_DaruniasJoy, []{return IsChild && CanPlay(SariasSong);})
@@ -1280,7 +1280,7 @@ namespace Exits { //name, scene, hint, events, locations, exits
 
   Exit DMC_UpperNearby = Exit("DMC Upper Nearby", "Death Mountain Crater", "Death Mountain Crater", NO_DAY_NIGHT_CYCLE, {}, {}, {
                   //Exits
-                  ExitPairing::Both(&DMC_UpperLocal,  []{return CanUse("Goron Tunic");}),
+                  ExitPairing::Both(&DMC_UpperLocal,  []{return CanUse(CanUseItem::Goron_Tunic);}),
                   ExitPairing::Both(&DMT_Summit,      []{return true;}),
                   ExitPairing::Both(&DMC_UpperGrotto, []{return CanBlastOrSmash;})
   });
@@ -1297,7 +1297,7 @@ namespace Exits { //name, scene, hint, events, locations, exits
                   //Exits
                   ExitPairing::Both(&DMC_UpperNearby,      []{return true;}),
                   ExitPairing::Both(&DMC_LadderAreaNearby, []{return true;}),
-                  ExitPairing::Both(&DMC_CentralNearby,    []{return CanUse("Goron Tunic") && CanUse("Longshot") && ((DamageMultiplier.IsNot(DAMAGEMULTIPLIER_OHKO) && DamageMultiplier.IsNot(DAMAGEMULTIPLIER_QUADRUPLE)) || (Fairy && !ShuffleDungeonEntrances) || CanUse("Nayrus Love"));})
+                  ExitPairing::Both(&DMC_CentralNearby,    []{return CanUse(CanUseItem::Goron_Tunic) && CanUse(CanUseItem::Longshot) && ((DamageMultiplier.IsNot(DAMAGEMULTIPLIER_OHKO) && DamageMultiplier.IsNot(DAMAGEMULTIPLIER_QUADRUPLE)) || (Fairy && !ShuffleDungeonEntrances) || CanUse(CanUseItem::Nayrus_Love));})
   });
 
   Exit DMC_LadderAreaNearby = Exit("DMC Ladder Area Nearby", "Death Mountain Crater", "Death Mountain Crater", NO_DAY_NIGHT_CYCLE, {}, {
@@ -1306,23 +1306,23 @@ namespace Exits { //name, scene, hint, events, locations, exits
                 }, {
                   //Exits
                   ExitPairing::Both(&DMC_UpperNearby, []{return IsAdult;}),
-                  ExitPairing::Both(&DMC_LowerNearby, []{return CanUse("Hover Boots") || (LogicCraterUpperToLower && CanUse("Hammer"));})
+                  ExitPairing::Both(&DMC_LowerNearby, []{return CanUse(CanUseItem::Hover_Boots) || (LogicCraterUpperToLower && CanUse(CanUseItem::Hammer));})
   });
 
   Exit DMC_LowerNearby = Exit("DMC Lower Nearby", "Death Mountain Crater", "Death Mountain Crater", NO_DAY_NIGHT_CYCLE, {}, {}, {
                   //Exits
-                  ExitPairing::Both(&DMC_LowerLocal,         []{return CanUse("Goron Tunic");}),
+                  ExitPairing::Both(&DMC_LowerLocal,         []{return CanUse(CanUseItem::Goron_Tunic);}),
                   ExitPairing::Both(&GC_DaruniasChamber,     []{return true;}),
-                  ExitPairing::Both(&DMC_GreatFairyFountain, []{return CanUse("Hammer");}),
-                  ExitPairing::Both(&DMC_HammerGrotto,       []{return CanUse("Hammer");})
+                  ExitPairing::Both(&DMC_GreatFairyFountain, []{return CanUse(CanUseItem::Hammer);}),
+                  ExitPairing::Both(&DMC_HammerGrotto,       []{return CanUse(CanUseItem::Hammer);})
   });
 
   Exit DMC_LowerLocal = Exit("DMC Lower Local", "Death Mountain Crater", "Death Mountain Crater", NO_DAY_NIGHT_CYCLE, {}, {}, {
                   //Exits
                   ExitPairing::Both(&DMC_LowerNearby,      []{return true;}),
                   ExitPairing::Both(&DMC_LadderAreaNearby, []{return true;}),
-                  ExitPairing::Both(&DMC_CentralNearby,    []{return CanUse("Hover Boots") || CanUse("Hookshot");}),
-                  ExitPairing::Both(&FireTemple_Entrance,  []{return (CanUse("Hover Boots") || CanUse("Hookshot")) && (LogicFewerTunicRequirements || CanUse("Goron Tunic"));}),
+                  ExitPairing::Both(&DMC_CentralNearby,    []{return CanUse(CanUseItem::Hover_Boots) || CanUse(CanUseItem::Hookshot);}),
+                  ExitPairing::Both(&FireTemple_Entrance,  []{return (CanUse(CanUseItem::Hover_Boots) || CanUse(CanUseItem::Hookshot)) && (LogicFewerTunicRequirements || CanUse(CanUseItem::Goron_Tunic));}),
   });
 
   Exit DMC_CentralNearby = Exit("DMC Central Nearby", "Death Mountain Crater", "Death Mountain Crater", NO_DAY_NIGHT_CYCLE, {}, {
@@ -1331,7 +1331,7 @@ namespace Exits { //name, scene, hint, events, locations, exits
                   ItemLocationPairing(&SheikInCrater,              []{return IsAdult;}),
                 }, {
                   //Exits
-                  ExitPairing::Both(&DMC_CentralLocal, []{return CanUse("Goron Tunic");})
+                  ExitPairing::Both(&DMC_CentralLocal, []{return CanUse(CanUseItem::Goron_Tunic);})
   });
 
   Exit DMC_CentralLocal = Exit("DMC Central Local", "Death Mountain Crater", "Death Mountain Crater", NO_DAY_NIGHT_CYCLE, {
@@ -1343,9 +1343,9 @@ namespace Exits { //name, scene, hint, events, locations, exits
                 }, {
                   //Exits
                   ExitPairing::Both(&DMC_CentralNearby,   []{return true;}),
-                  ExitPairing::Both(&DMC_LowerNearby,     []{return IsAdult && (CanUse("Hover Boots") || CanUse("Hookshot") || DMC_CentralLocal.CanPlantBean());}),
+                  ExitPairing::Both(&DMC_LowerNearby,     []{return IsAdult && (CanUse(CanUseItem::Hover_Boots) || CanUse(CanUseItem::Hookshot) || DMC_CentralLocal.CanPlantBean());}),
                   ExitPairing::Both(&DMC_UpperNearby,     []{return IsAdult && DMC_CentralLocal.CanPlantBean();}),
-                  ExitPairing::Both(&FireTemple_Entrance, []{return (IsChild && ShuffleDungeonEntrances) || (IsAdult && (LogicFewerTunicRequirements || CanUse("Goron Tunic")));}),
+                  ExitPairing::Both(&FireTemple_Entrance, []{return (IsChild && ShuffleDungeonEntrances) || (IsAdult && (LogicFewerTunicRequirements || CanUse(CanUseItem::Goron_Tunic)));}),
   });
 
   Exit FireTemple_Entrance = Exit("Fire Temple Entrance", "Death Mountain Crater", "Death Mountain Crater", NO_DAY_NIGHT_CYCLE, {}, {}, {
@@ -1393,18 +1393,18 @@ namespace Exits { //name, scene, hint, events, locations, exits
                   //Events
                   EventPairing(&GossipStoneFairy, []{return GossipStoneFairy || CanSummonGossipFairy;}),
                   EventPairing(&BeanPlantFairy,   []{return BeanPlantFairy   || (ZR_Main.CanPlantBean() && CanPlay(SongOfStorms));}),
-                  EventPairing(&ButterflyFairy,   []{return ButterflyFairy   || CanUse("Sticks");}),
+                  EventPairing(&ButterflyFairy,   []{return ButterflyFairy   || CanUse(CanUseItem::Sticks);}),
                   EventPairing(&BugShrub,         []{return BugShrub         || CanCutShrubs;}),
                 }, {
                   //Locations
                   ItemLocationPairing(&ZR_MagicBeanSalesman,             []{return IsChild;}),
                   ItemLocationPairing(&ZR_FrogsOcarinaGame,              []{return IsChild && CanPlay(ZeldasLullaby) && CanPlay(SariasSong) && CanPlay(SunsSong) && CanPlay(EponasSong) && CanPlay(SongOfTime) && CanPlay(SongOfStorms);}),
                   ItemLocationPairing(&ZR_FrogsInTheRain,                []{return IsChild && CanPlay(SongOfStorms);}),
-                  ItemLocationPairing(&ZR_NearOpenGrottoFreestandingPoH, []{return IsChild || CanUse("Hover Boots") || (IsAdult && LogicZoraRiverLower);}),
-                  ItemLocationPairing(&ZR_NearDomainFreestandingPoH,     []{return IsChild || CanUse("Hover Boots") || (IsAdult && LogicZoraRiverUpper);}),
+                  ItemLocationPairing(&ZR_NearOpenGrottoFreestandingPoH, []{return IsChild || CanUse(CanUseItem::Hover_Boots) || (IsAdult && LogicZoraRiverLower);}),
+                  ItemLocationPairing(&ZR_NearDomainFreestandingPoH,     []{return IsChild || CanUse(CanUseItem::Hover_Boots) || (IsAdult && LogicZoraRiverUpper);}),
                   ItemLocationPairing(&ZR_GS_Ladder,                     []{return IsChild && AtNight && CanChildAttack;}),
-                  ItemLocationPairing(&ZR_GS_NearRaisedGrottos,          []{return CanUse("Hookshot") && AtNight;}),
-                  ItemLocationPairing(&ZR_GS_AboveBridge,                []{return CanUse("Hookshot") && AtNight;}),
+                  ItemLocationPairing(&ZR_GS_NearRaisedGrottos,          []{return CanUse(CanUseItem::Hookshot) && AtNight;}),
+                  ItemLocationPairing(&ZR_GS_AboveBridge,                []{return CanUse(CanUseItem::Hookshot) && AtNight;}),
                   //ZR Near Grottos Gossip Stone
                   //ZR Near Domain Gossip Stone
                 }, {
@@ -1412,7 +1412,7 @@ namespace Exits { //name, scene, hint, events, locations, exits
                   ExitPairing::Both(&ZR_Front,           []{return true;}),
                   ExitPairing::Both(&ZR_OpenGrotto,      []{return true;}),
                   ExitPairing::Both(&ZR_FairyGrotto,     []{return CanBlastOrSmash;}),
-                  ExitPairing::Both(&LW_Main,            []{return CanDive || CanUse("Iron Boots");}),
+                  ExitPairing::Both(&LW_Main,            []{return CanDive || CanUse(CanUseItem::Iron_Boots);}),
                   ExitPairing::Both(&ZR_StormsGrotto,    []{return CanOpenStormGrotto;}),
                   ExitPairing::Both(&ZR_BehindWaterfall, []{return CanPlay(ZeldasLullaby);})
   });
@@ -1461,7 +1461,7 @@ namespace Exits { //name, scene, hint, events, locations, exits
                 }, {
                   //Locations
                   ItemLocationPairing(&ZD_DivingMinigame,     []{return IsChild;}),
-                  ItemLocationPairing(&ZD_Chest,              []{return CanUse("Sticks");}),
+                  ItemLocationPairing(&ZD_Chest,              []{return CanUse(CanUseItem::Sticks);}),
                   ItemLocationPairing(&ZD_KingZoraThawed,     []{return KingZoraThawed;}),
                   ItemLocationPairing(&ZD_GS_FrozenWaterfall, []{return IsAdult && AtNight && (Hookshot || Bow || MagicMeter);}),
                   //ZD Gossip Stone
@@ -1506,14 +1506,14 @@ namespace Exits { //name, scene, hint, events, locations, exits
   Exit ZF_Main = Exit("Zoras Fountain", "Zoras Fountain", "Zora's Fountain", NO_DAY_NIGHT_CYCLE, {
                   //Events
                   EventPairing(&GossipStoneFairy, []{return GossipStoneFairy || CanSummonGossipFairyWithoutSuns;}),
-                  EventPairing(&ButterflyFairy,   []{return ButterflyFairy   || (CanUse("Sticks") && AtDay);}),
+                  EventPairing(&ButterflyFairy,   []{return ButterflyFairy   || (CanUse(CanUseItem::Sticks) && AtDay);}),
                 }, {
                   //Locations
                   ItemLocationPairing(&ZF_IcebergFreestandingPoH, []{return IsAdult;}),
-                  ItemLocationPairing(&ZF_BottomFreestandingPoH,  []{return IsAdult && IronBoots && (LogicFewerTunicRequirements || CanUse("Zora Tunic"));}),
+                  ItemLocationPairing(&ZF_BottomFreestandingPoH,  []{return IsAdult && IronBoots && (LogicFewerTunicRequirements || CanUse(CanUseItem::Zora_Tunic));}),
                   ItemLocationPairing(&ZF_GS_Tree,                []{return IsChild;}),
-                  ItemLocationPairing(&ZF_GS_AboveTheLog,         []{return CanUse("Boomerang") && AtNight;}),
-                  ItemLocationPairing(&ZF_GS_HiddenCave,          []{return CanUse("Silver Gauntlets") && CanBlastOrSmash && CanUse("Hookshot") && AtNight;}),
+                  ItemLocationPairing(&ZF_GS_AboveTheLog,         []{return CanUse(CanUseItem::Boomerang) && AtNight;}),
+                  ItemLocationPairing(&ZF_GS_HiddenCave,          []{return CanUse(CanUseItem::Silver_Gauntlets) && CanBlastOrSmash && CanUse(CanUseItem::Hookshot) && AtNight;}),
                   //ZF Fairy Gossip Stone
                   //ZF Jabu Gossip Stone
                 }, {
@@ -1541,8 +1541,8 @@ namespace Exits { //name, scene, hint, events, locations, exits
                   ItemLocationPairing(&SongFromMalon,      []{return IsChild && ZeldasLetter && Ocarina && AtDay;}),
                   ItemLocationPairing(&LLR_GS_Tree,        []{return IsChild;}),
                   ItemLocationPairing(&LLR_GS_RainShed,    []{return IsChild && AtNight;}),
-                  ItemLocationPairing(&LLR_GS_HouseWindow, []{return CanUse("Boomerang") && AtNight;}),
-                  ItemLocationPairing(&LLR_GS_BackWall,    []{return CanUse("Boomerang") && AtNight;}),
+                  ItemLocationPairing(&LLR_GS_HouseWindow, []{return CanUse(CanUseItem::Boomerang) && AtNight;}),
+                  ItemLocationPairing(&LLR_GS_BackWall,    []{return CanUse(CanUseItem::Boomerang) && AtNight;}),
                 }, {
                   //Exits
                   ExitPairing::Both(&HF_Main,         []{return true;}),
@@ -1596,7 +1596,7 @@ namespace Exits { //name, scene, hint, events, locations, exits
   Exit DekuTree_Lobby = Exit("Deku Tree Lobby", "Deku Tree", "Deku Tree", NO_DAY_NIGHT_CYCLE, {
                   //Events
                   EventPairing(&DekuBabaSticks, []{return DekuBabaSticks || (IsAdult || KokiriSword || Boomerang);}),
-                  EventPairing(&DekuBabaNuts,   []{return DekuBabaNuts   || (IsAdult || KokiriSword || Slingshot || Sticks || HasExplosives || CanUse("Dins Fire"));}),
+                  EventPairing(&DekuBabaNuts,   []{return DekuBabaNuts   || (IsAdult || KokiriSword || Slingshot || Sticks || HasExplosives || CanUse(CanUseItem::Dins_Fire));}),
                 }, {
                   //Locations
                   ItemLocationPairing(&DekuTree_MapChest,             []{return true;}),
@@ -1604,14 +1604,14 @@ namespace Exits { //name, scene, hint, events, locations, exits
                   ItemLocationPairing(&DekuTree_CompassRoomSideChest, []{return true;}),
                   ItemLocationPairing(&DekuTree_BasementChest,        []{return IsAdult || CanChildAttack || Nuts;}),
                   ItemLocationPairing(&DekuTree_GS_CompassRoom,       []{return IsAdult || CanChildAttack;}),
-                  ItemLocationPairing(&DekuTree_GS_BasementVines,     []{return CanUseProjectile || CanUse("Dins Fire") || (LogicDekuBasementGS && (IsAdult || Sticks || KokiriSword));}),
+                  ItemLocationPairing(&DekuTree_GS_BasementVines,     []{return CanUseProjectile || CanUse(CanUseItem::Dins_Fire) || (LogicDekuBasementGS && (IsAdult || Sticks || KokiriSword));}),
                   ItemLocationPairing(&DekuTree_GS_BasementGate,      []{return IsAdult || CanChildAttack;}),
-                  ItemLocationPairing(&DekuTree_GS_BasementBackRoom,  []{return ((HasFireSourceWithTorch || (LogicDekuB1WebsWithBow && CanUse("Bow"))) && (CanUse("Slingshot") || CanUse("Bow")) && CanBlastOrSmash && HookshotOrBoomerang) || ((LogicDekuB1Skip || IsAdult) && IsChild && HasExplosives && CanUse("Boomerang") && (Sticks || CanUse("Dins Fire")));}),
+                  ItemLocationPairing(&DekuTree_GS_BasementBackRoom,  []{return ((HasFireSourceWithTorch || (LogicDekuB1WebsWithBow && CanUse(CanUseItem::Bow))) && (CanUse(CanUseItem::Slingshot) || CanUse(CanUseItem::Bow)) && CanBlastOrSmash && HookshotOrBoomerang) || ((LogicDekuB1Skip || IsAdult) && IsChild && HasExplosives && CanUse(CanUseItem::Boomerang) && (Sticks || CanUse(CanUseItem::Dins_Fire)));}),
                 }, {
                   //Exits
                   ExitPairing::Both(&KF_OutsideDekuTree,       []{return true;}),
                   ExitPairing::Both(&DekuTree_SlingshotRoom,   []{return HasShield;}),
-                  ExitPairing::Both(&DekuTree_BossRoom,        []{return (HasFireSourceWithTorch || (LogicDekuB1WebsWithBow && CanUse("Bow"))) && (LogicDekuB1Skip || (IsAdult || CanUse("Slingshot")));})
+                  ExitPairing::Both(&DekuTree_BossRoom,        []{return (HasFireSourceWithTorch || (LogicDekuB1WebsWithBow && CanUse(CanUseItem::Bow))) && (LogicDekuB1Skip || (IsAdult || CanUse(CanUseItem::Slingshot)));})
   });
 
   Exit DekuTree_SlingshotRoom = Exit("Deku Tree Slingshot Room", "Deku Tree", "Deku Tree", NO_DAY_NIGHT_CYCLE, {}, {
@@ -1647,16 +1647,16 @@ namespace Exits { //name, scene, hint, events, locations, exits
                 }, {
                   //Locations
                   ItemLocationPairing(&DodongosCavern_MapChest,                      []{return true;}),
-                  ItemLocationPairing(&DodongosCavern_CompassChest,                  []{return IsAdult || Sticks || (CanUse("Dins Fire") && (Slingshot || HasExplosives || KokiriSword));}),
+                  ItemLocationPairing(&DodongosCavern_CompassChest,                  []{return IsAdult || Sticks || (CanUse(CanUseItem::Dins_Fire) && (Slingshot || HasExplosives || KokiriSword));}),
                   ItemLocationPairing(&DodongosCavern_GS_SideRoomNearLowerLizalfos,  []{return HasExplosives || IsAdult || Slingshot || Boomerang || Sticks || KokiriSword;}),
-                  ItemLocationPairing(&DodongosCavern_GS_Scarecrow,                  []{return CanUse("Scarecrow") || CanUse("Longshot") || (LogicDCScarecrowGS && (IsAdult || CanChildAttack));}),
+                  ItemLocationPairing(&DodongosCavern_GS_Scarecrow,                  []{return CanUse(CanUseItem::Scarecrow) || CanUse(CanUseItem::Longshot) || (LogicDCScarecrowGS && (IsAdult || CanChildAttack));}),
                   ItemLocationPairing(&DodongosCavern_DekuScrubSideRoomNearDodongos, []{return IsAdult || Slingshot || Sticks || HasExplosives || KokiriSword;}),
                   ItemLocationPairing(&DodongosCavern_DekuScrubLobby,                []{return true;}),
                   //Dodongos Cavern Gossip Stone
                 }, {
                   //Exits
                   ExitPairing::Both(&DodongosCavern_Beginning, []{return true;}),
-                  ExitPairing::Both(&DodongosCavern_Climb,     []{return (IsAdult || ((Sticks || CanUse("Dins Fire")) && (Slingshot || Sticks || HasExplosives || KokiriSword))) && (HasExplosives || GoronBracelet || CanUse("Dins Fire") ||(LogicDCStaircase && CanUse("Bow")));})
+                  ExitPairing::Both(&DodongosCavern_Climb,     []{return (IsAdult || ((Sticks || CanUse(CanUseItem::Dins_Fire)) && (Slingshot || Sticks || HasExplosives || KokiriSword))) && (HasExplosives || GoronBracelet || CanUse(CanUseItem::Dins_Fire) ||(LogicDCStaircase && CanUse(CanUseItem::Bow)));})
   });
 
   Exit DodongosCavern_Climb = Exit("Dodongos Cavern Climb", "Dodongos Cavern", "", NO_DAY_NIGHT_CYCLE, {}, {
@@ -1668,7 +1668,7 @@ namespace Exits { //name, scene, hint, events, locations, exits
                 }, {
                   //Exits
                   ExitPairing::Both(&DodongosCavern_Lobby,     []{return true;}),
-                  ExitPairing::Both(&DodongosCavern_FarBridge, []{return (IsChild && (Slingshot || (LogicDCSlingshotSkip && (Sticks || HasExplosives || KokiriSword)))) || (IsAdult && (Bow || HoverBoots || CanUse("Longshot") || LogicDCJump));})
+                  ExitPairing::Both(&DodongosCavern_FarBridge, []{return (IsChild && (Slingshot || (LogicDCSlingshotSkip && (Sticks || HasExplosives || KokiriSword)))) || (IsAdult && (Bow || HoverBoots || CanUse(CanUseItem::Longshot) || LogicDCJump));})
   });
 
   Exit DodongosCavern_FarBridge = Exit("Dodongos Cavern Far Bridge", "Dodongos Cavern", "", NO_DAY_NIGHT_CYCLE, {}, {
@@ -1711,12 +1711,12 @@ namespace Exits { //name, scene, hint, events, locations, exits
                   ItemLocationPairing(&JabuJabusBelly_GS_WaterSwitchRoom,    []{return true;}),
                   ItemLocationPairing(&JabuJabusBelly_GS_LobbyBasementLower, []{return HookshotOrBoomerang;}),
                   ItemLocationPairing(&JabuJabusBelly_GS_LobbyBasementUpper, []{return HookshotOrBoomerang;}),
-                  ItemLocationPairing(&JabuJabusBelly_DekuScrub,             []{return CanDive || IsChild || LogicJabuScrubJumpDive || CanUse("Iron Boots");}),
+                  ItemLocationPairing(&JabuJabusBelly_DekuScrub,             []{return CanDive || IsChild || LogicJabuScrubJumpDive || CanUse(CanUseItem::Iron_Boots);}),
                 }, {
                   //Exits
                   ExitPairing::Both(&JabuJabusBelly_Beginning, []{return true;}),
-                  ExitPairing::Both(&JabuJabusBelly_Depths,    []{return CanUse("Boomerang");}),
-                  ExitPairing::Both(&JabuJabusBelly_BossArea,  []{return LogicJabuBossGSAdult && CanUse("Hover Boots");}),
+                  ExitPairing::Both(&JabuJabusBelly_Depths,    []{return CanUse(CanUseItem::Boomerang);}),
+                  ExitPairing::Both(&JabuJabusBelly_BossArea,  []{return LogicJabuBossGSAdult && CanUse(CanUseItem::Hover_Boots);}),
   });
 
   Exit JabuJabusBelly_Depths = Exit("Jabu Jabus Belly Depths", "Jabu Jabus Belly", "", NO_DAY_NIGHT_CYCLE, {}, {
@@ -1734,8 +1734,8 @@ namespace Exits { //name, scene, hint, events, locations, exits
                   EventPairing(&NutPot, []{return true;}),
                 }, {
                   //Locations
-                  ItemLocationPairing(&JabuJabusBelly_BarinadeHeart, []{return CanUse("Boomerang");}),
-                  ItemLocationPairing(&Barinade,                     []{return CanUse("Boomerang");}),
+                  ItemLocationPairing(&JabuJabusBelly_BarinadeHeart, []{return CanUse(CanUseItem::Boomerang);}),
+                  ItemLocationPairing(&Barinade,                     []{return CanUse(CanUseItem::Boomerang);}),
                   ItemLocationPairing(&JabuJabusBelly_GS_NearBoss,   []{return true;}),
                 }, {
                   //Exits
@@ -1746,13 +1746,13 @@ namespace Exits { //name, scene, hint, events, locations, exits
                   //Locations
                   ItemLocationPairing(&ForestTemple_FirstRoomChest,    []{return true;}),
                   ItemLocationPairing(&ForestTemple_FirstStalfosChest, []{return IsAdult || KokiriSword;}),
-                  ItemLocationPairing(&ForestTemple_GS_FirstRoom,      []{return CanUse("Dins Fire") || CanUseProjectile;}),
+                  ItemLocationPairing(&ForestTemple_GS_FirstRoom,      []{return CanUse(CanUseItem::Dins_Fire) || CanUseProjectile;}),
                   ItemLocationPairing(&ForestTemple_GS_Lobby,          []{return HookshotOrBoomerang;}),
                 }, {
                   //Exits
                   ExitPairing::Both(&SFM_Main,                   []{return true;}),
                   ExitPairing::Both(&ForestTemple_NWOutdoors,    []{return CanPlay(SongOfTime) || IsChild;}),
-                  ExitPairing::Both(&ForestTemple_NEOutdoors,    []{return CanUse("Bow") || CanUse("Slingshot");}),
+                  ExitPairing::Both(&ForestTemple_NEOutdoors,    []{return CanUse(CanUseItem::Bow) || CanUse(CanUseItem::Slingshot);}),
                   ExitPairing::Both(&ForestTemple_BlockPushRoom, []{return SmallKeys(ForestTempleKeys, 1);}),
                   ExitPairing::Both(&ForestTemple_BossRegion,    []{return ForestTempleJoAndBeth && ForestTempleAmyAndMeg;})
   });
@@ -1760,27 +1760,27 @@ namespace Exits { //name, scene, hint, events, locations, exits
   Exit ForestTemple_NWOutdoors = Exit("Forest Temple NW Outdoors", "Forest Temple", "", NO_DAY_NIGHT_CYCLE, {
                   //Events
                   EventPairing(&DekuBabaSticks, []{return DekuBabaSticks || (IsAdult || KokiriSword || Boomerang);}),
-                  EventPairing(&DekuBabaNuts,   []{return DekuBabaNuts   || (IsAdult || KokiriSword || Slingshot || Sticks || HasExplosives || CanUse("Dins Fire"));}),
+                  EventPairing(&DekuBabaNuts,   []{return DekuBabaNuts   || (IsAdult || KokiriSword || Slingshot || Sticks || HasExplosives || CanUse(CanUseItem::Dins_Fire));}),
                 }, {
                   //Locations
-                  ItemLocationPairing(&ForestTemple_GS_LevelIslandCourtyard, []{return CanUse("Longshot") || ((ForestTemple_OutsideUpperLedge.dayAdult || ForestTemple_OutsideUpperLedge.nightAdult) && CanUse("Hookshot"));}),
+                  ItemLocationPairing(&ForestTemple_GS_LevelIslandCourtyard, []{return CanUse(CanUseItem::Longshot) || ((ForestTemple_OutsideUpperLedge.dayAdult || ForestTemple_OutsideUpperLedge.nightAdult) && CanUse(CanUseItem::Hookshot));}),
                 }, {
                   //Exits
-                  ExitPairing::Both(&ForestTemple_OutdoorsHighBalconies, []{return IsAdult || (HasExplosives || ((CanUse("Boomerang") || Nuts || DekuShield) && (Sticks || KokiriSword || CanUse("Slingshot"))));})
+                  ExitPairing::Both(&ForestTemple_OutdoorsHighBalconies, []{return IsAdult || (HasExplosives || ((CanUse(CanUseItem::Boomerang) || Nuts || DekuShield) && (Sticks || KokiriSword || CanUse(CanUseItem::Slingshot))));})
   });
 
   Exit ForestTemple_NEOutdoors = Exit("Forest Temple NE Outdoors", "Forest Temple", "", NO_DAY_NIGHT_CYCLE, {
                   //Events
                   EventPairing(&DekuBabaSticks, []{return DekuBabaSticks || (IsAdult || KokiriSword || Boomerang);}),
-                  EventPairing(&DekuBabaNuts,   []{return DekuBabaNuts   || (IsAdult || KokiriSword || Slingshot || Sticks || HasExplosives || CanUse("Dins Fire"));}),
+                  EventPairing(&DekuBabaNuts,   []{return DekuBabaNuts   || (IsAdult || KokiriSword || Slingshot || Sticks || HasExplosives || CanUse(CanUseItem::Dins_Fire));}),
                 }, {
                   //Locations
-                  ItemLocationPairing(&ForestTemple_RaisedIslandCourtyardChest, []{return CanUse("Hookshot");}),
-                  ItemLocationPairing(&ForestTemple_GS_RaisedIslandCourtyard,   []{return CanUse("Hookshot") || (LogicForestOutdoorEastGS && CanUse("Boomerang"));}),
+                  ItemLocationPairing(&ForestTemple_RaisedIslandCourtyardChest, []{return CanUse(CanUseItem::Hookshot);}),
+                  ItemLocationPairing(&ForestTemple_GS_RaisedIslandCourtyard,   []{return CanUse(CanUseItem::Hookshot) || (LogicForestOutdoorEastGS && CanUse(CanUseItem::Boomerang));}),
                 }, {
                   //Exits
-                  ExitPairing::Both(&ForestTemple_OutdoorsHighBalconies, []{return CanUse("Longshot");}),
-                  ExitPairing::Both(&ForestTemple_NWOutdoors,            []{return CanUse("Iron Boots") || ProgressiveScale >= 2;}),
+                  ExitPairing::Both(&ForestTemple_OutdoorsHighBalconies, []{return CanUse(CanUseItem::Longshot);}),
+                  ExitPairing::Both(&ForestTemple_NWOutdoors,            []{return CanUse(CanUseItem::Iron_Boots) || ProgressiveScale >= 2;}),
                   ExitPairing::Both(&ForestTemple_Lobby,                 []{return true;})
   });
 
@@ -1792,12 +1792,12 @@ namespace Exits { //name, scene, hint, events, locations, exits
                   //Exits
                   ExitPairing::Both(&ForestTemple_NWOutdoors,  []{return true;}),
                   ExitPairing::Both(&ForestTemple_NEOutdoors,  []{return true;}),
-                  ExitPairing::Both(&ForestTemple_FallingRoom, []{return LogicForestDoorFrame && CanUse("Hover Boots") && CanUse("Scarecrow");})
+                  ExitPairing::Both(&ForestTemple_FallingRoom, []{return LogicForestDoorFrame && CanUse(CanUseItem::Hover_Boots) && CanUse(CanUseItem::Scarecrow);})
   });
 
   Exit ForestTemple_FallingRoom = Exit("Forest Temple Falling Room", "Forest Temple", "", NO_DAY_NIGHT_CYCLE, {
                   //Events
-                  EventPairing(&ForestTempleAmyAndMeg, []{return ForestTempleAmyAndMeg || CanUse("Bow");}),
+                  EventPairing(&ForestTempleAmyAndMeg, []{return ForestTempleAmyAndMeg || CanUse(CanUseItem::Bow);}),
                 }, {
                   //Locations
                   ItemLocationPairing(&ForestTemple_FallingCeilingRoomChest, []{return true;})
@@ -1808,12 +1808,12 @@ namespace Exits { //name, scene, hint, events, locations, exits
 
   Exit ForestTemple_BlockPushRoom = Exit("Forest Temple Block Push Room", "Forest Temple", "", NO_DAY_NIGHT_CYCLE, {}, {
                   //Locations
-                  ItemLocationPairing(&ForestTemple_EyeSwitchChest, []{return GoronBracelet && (CanUse("Bow") || CanUse("Slingshot"));})
+                  ItemLocationPairing(&ForestTemple_EyeSwitchChest, []{return GoronBracelet && (CanUse(CanUseItem::Bow) || CanUse(CanUseItem::Slingshot));})
                 }, {
                   //Exits
-                  ExitPairing::Both(&ForestTemple_OutsideUpperLedge, []{return CanUse("Hover Boots") || (LogicForestOutsideBackdoor && IsAdult && GoronBracelet);}),
+                  ExitPairing::Both(&ForestTemple_OutsideUpperLedge, []{return CanUse(CanUseItem::Hover_Boots) || (LogicForestOutsideBackdoor && IsAdult && GoronBracelet);}),
                   ExitPairing::Both(&ForestTemple_BowRegion,         []{return GoronBracelet && SmallKeys(ForestTempleKeys, 3) && IsAdult;}),
-                  ExitPairing::Both(&ForestTemple_StraightenedHall,  []{return GoronBracelet && SmallKeys(ForestTempleKeys, 2) && CanUse("Bow") && IsAdult;})
+                  ExitPairing::Both(&ForestTemple_StraightenedHall,  []{return GoronBracelet && SmallKeys(ForestTempleKeys, 2) && CanUse(CanUseItem::Bow) && IsAdult;})
   });
 
   Exit ForestTemple_StraightenedHall = Exit("Forest Temple Straightened Hall", "Forest Temple", "", NO_DAY_NIGHT_CYCLE, {}, {
@@ -1834,15 +1834,15 @@ namespace Exits { //name, scene, hint, events, locations, exits
 
   Exit ForestTemple_BowRegion = Exit("Forest Temple Bow Region", "Forest Temple", "", NO_DAY_NIGHT_CYCLE, {
                   //Events
-                  EventPairing(&ForestTempleJoAndBeth, []{return ForestTempleJoAndBeth || CanUse("Bow");}),
+                  EventPairing(&ForestTempleJoAndBeth, []{return ForestTempleJoAndBeth || CanUse(CanUseItem::Bow);}),
                 }, {
                   //Locations
                   ItemLocationPairing(&ForestTemple_BowChest,     []{return true;}),
-                  ItemLocationPairing(&ForestTemple_RedPoeChest,  []{return CanUse("Bow");}),
-                  ItemLocationPairing(&ForestTemple_BluePoeChest, []{return CanUse("Bow");})
+                  ItemLocationPairing(&ForestTemple_RedPoeChest,  []{return CanUse(CanUseItem::Bow);}),
+                  ItemLocationPairing(&ForestTemple_BluePoeChest, []{return CanUse(CanUseItem::Bow);})
                 }, {
                   //Exits
-                  ExitPairing::Both(&ForestTemple_FallingRoom, []{return SmallKeys(ForestTempleKeys, 5) && (Bow || CanUse("Dins Fire"));})
+                  ExitPairing::Both(&ForestTemple_FallingRoom, []{return SmallKeys(ForestTempleKeys, 5) && (Bow || CanUse(CanUseItem::Dins_Fire));})
   });
 
   Exit ForestTemple_BossRegion = Exit("Forest Temple Boss Region", "Forest Temple", "", NO_DAY_NIGHT_CYCLE, {}, {
@@ -1856,23 +1856,23 @@ namespace Exits { //name, scene, hint, events, locations, exits
   //Fire Temple logic currently assumes that the lowest locked door is unlocked from the start
   Exit FireTemple_Lower = Exit("Fire Temple Lower", "Fire Temple", "", NO_DAY_NIGHT_CYCLE, {
                   //Events
-                  EventPairing(&FairyPot, []{return FairyPot || ((CanUse("Hover Boots") || CanUse("Hookshot")) && (LogicFewerTunicRequirements || CanUse("Goron Tunic")));}),
+                  EventPairing(&FairyPot, []{return FairyPot || ((CanUse(CanUseItem::Hover_Boots) || CanUse(CanUseItem::Hookshot)) && (LogicFewerTunicRequirements || CanUse(CanUseItem::Goron_Tunic)));}),
                 }, {
                   //Locations
-                  ItemLocationPairing(&FireTemple_NearBossChest,    []{return LogicFewerTunicRequirements || CanUse("Goron Tunic");}),
-                  ItemLocationPairing(&FireTemple_FlareDancerChest, []{return /*SmallKeys(FireTempleKeys, 8) &&*/ CanUse("Hammer");}),
-                  ItemLocationPairing(&FireTemple_BossKeyChest,     []{return /*SmallKeys(FireTempleKeys, 8) &&*/ CanUse("Hammer");}),
-                  ItemLocationPairing(&FireTemple_VolvagiaHeart,    []{return CanUse("Goron Tunic") && CanUse("Hammer") && BossKeyFireTemple &&
+                  ItemLocationPairing(&FireTemple_NearBossChest,    []{return LogicFewerTunicRequirements || CanUse(CanUseItem::Goron_Tunic);}),
+                  ItemLocationPairing(&FireTemple_FlareDancerChest, []{return /*SmallKeys(FireTempleKeys, 8) &&*/ CanUse(CanUseItem::Hammer);}),
+                  ItemLocationPairing(&FireTemple_BossKeyChest,     []{return /*SmallKeys(FireTempleKeys, 8) &&*/ CanUse(CanUseItem::Hammer);}),
+                  ItemLocationPairing(&FireTemple_VolvagiaHeart,    []{return CanUse(CanUseItem::Goron_Tunic) && CanUse(CanUseItem::Hammer) && BossKeyFireTemple &&
                                                                                 (LogicFireBossDoorJump || HoverBoots ||
                                                                                   (FireTemple_Upper.Adult() && (CanPlay(SongOfTime) || HasExplosives)));}),
-                  ItemLocationPairing(&Volvagia,                    []{return CanUse("Goron Tunic") && CanUse("Hammer") && BossKeyFireTemple &&
+                  ItemLocationPairing(&Volvagia,                    []{return CanUse(CanUseItem::Goron_Tunic) && CanUse(CanUseItem::Hammer) && BossKeyFireTemple &&
                                                                                 (LogicFireBossDoorJump || HoverBoots ||
                                                                                   (FireTemple_Upper.Adult() && (CanPlay(SongOfTime) || HasExplosives)));}),
-                  ItemLocationPairing(&FireTemple_GS_BossKeyLoop,   []{return /*SmallKeys(FireTempleKeys, 8) &&*/ CanUse("Hammer");}),
+                  ItemLocationPairing(&FireTemple_GS_BossKeyLoop,   []{return /*SmallKeys(FireTempleKeys, 8) &&*/ CanUse(CanUseItem::Hammer);}),
                 }, {
                   //Exits
                   ExitPairing::Both(&FireTemple_Entrance,    []{return true;}),
-                  ExitPairing::Both(&FireTemple_BigLavaRoom, []{return SmallKeys(FireTempleKeys, 1) && (LogicFewerTunicRequirements || CanUse("Goron Tunic"));}),
+                  ExitPairing::Both(&FireTemple_BigLavaRoom, []{return SmallKeys(FireTempleKeys, 1) && (LogicFewerTunicRequirements || CanUse(CanUseItem::Goron_Tunic));}),
   });
 
   Exit FireTemple_BigLavaRoom = Exit("Fire Temple Big Lava Room", "Fire Temple", "", NO_DAY_NIGHT_CYCLE, {}, {
@@ -1883,7 +1883,7 @@ namespace Exits { //name, scene, hint, events, locations, exits
                 }, {
                   //Exits
                   ExitPairing::Both(&FireTemple_Lower,  []{return true;}),
-                  ExitPairing::Both(&FireTemple_Middle, []{return CanUse("Goron Tunic") && SmallKeys(FireTempleKeys, 3) && (GoronBracelet || LogicFireStrength) && (HasExplosives || Bow || Hookshot);}),
+                  ExitPairing::Both(&FireTemple_Middle, []{return CanUse(CanUseItem::Goron_Tunic) && SmallKeys(FireTempleKeys, 3) && (GoronBracelet || LogicFireStrength) && (HasExplosives || Bow || Hookshot);}),
   });
 
   Exit FireTemple_Middle = Exit("Fire Temple Middle", "Fire Temple", "", NO_DAY_NIGHT_CYCLE, {}, {
@@ -1892,20 +1892,20 @@ namespace Exits { //name, scene, hint, events, locations, exits
                   ItemLocationPairing(&FireTemple_BoulderMazeUpperChest,    []{return SmallKeys(FireTempleKeys, 5);}),
                   ItemLocationPairing(&FireTemple_BoulderMazeSideRoomChest, []{return true;}),
                   ItemLocationPairing(&FireTemple_BoulderMazeShortcutChest, []{return SmallKeys(FireTempleKeys, 5) && HasExplosives;}),
-                  ItemLocationPairing(&FireTemple_ScarecrowChest,           []{return SmallKeys(FireTempleKeys, 5) && (CanUse("Scarecrow") || (LogicFireScarecrow && CanUse("Longshot")));}),
-                  ItemLocationPairing(&FireTemple_MapChest,                 []{return SmallKeys(FireTempleKeys, 5) || (SmallKeys(FireTempleKeys, 4) && CanUse("Bow"));}),
+                  ItemLocationPairing(&FireTemple_ScarecrowChest,           []{return SmallKeys(FireTempleKeys, 5) && (CanUse(CanUseItem::Scarecrow) || (LogicFireScarecrow && CanUse(CanUseItem::Longshot)));}),
+                  ItemLocationPairing(&FireTemple_MapChest,                 []{return SmallKeys(FireTempleKeys, 5) || (SmallKeys(FireTempleKeys, 4) && CanUse(CanUseItem::Bow));}),
                   ItemLocationPairing(&FireTemple_CompassChest,             []{return SmallKeys(FireTempleKeys, 5);}),
                   ItemLocationPairing(&FireTemple_GS_BoulderMaze,           []{return SmallKeys(FireTempleKeys, 4) && HasExplosives;}),
-                  ItemLocationPairing(&FireTemple_GS_ScarecrowClimb,        []{return SmallKeys(FireTempleKeys, 5) && (CanUse("Scarecrow") || (LogicFireScarecrow && CanUse("Longshot")));}),
-                  ItemLocationPairing(&FireTemple_GS_ScarecrowTop,          []{return SmallKeys(FireTempleKeys, 5) && (CanUse("Scarecrow") || (LogicFireScarecrow && CanUse("Longshot")));}),
+                  ItemLocationPairing(&FireTemple_GS_ScarecrowClimb,        []{return SmallKeys(FireTempleKeys, 5) && (CanUse(CanUseItem::Scarecrow) || (LogicFireScarecrow && CanUse(CanUseItem::Longshot)));}),
+                  ItemLocationPairing(&FireTemple_GS_ScarecrowTop,          []{return SmallKeys(FireTempleKeys, 5) && (CanUse(CanUseItem::Scarecrow) || (LogicFireScarecrow && CanUse(CanUseItem::Longshot)));}),
                 }, {
                   //Exits
-                  ExitPairing::Both(&FireTemple_Upper, []{return SmallKeys(FireTempleKeys, 7) || (SmallKeys(FireTempleKeys, 6) && ((CanUse("Hover Boots") && CanUse("Hammer")) || LogicFireFlameMaze));})
+                  ExitPairing::Both(&FireTemple_Upper, []{return SmallKeys(FireTempleKeys, 7) || (SmallKeys(FireTempleKeys, 6) && ((CanUse(CanUseItem::Hover_Boots) && CanUse(CanUseItem::Hammer)) || LogicFireFlameMaze));})
   });
 
   Exit FireTemple_Upper = Exit("Fire Temple Upper", "Fire Temple", "", NO_DAY_NIGHT_CYCLE, {}, {
                   //Locations
-                  ItemLocationPairing(&FireTemple_HighestGoronChest,  []{return CanUse("Hammer") && CanPlay(SongOfTime);}),
+                  ItemLocationPairing(&FireTemple_HighestGoronChest,  []{return CanUse(CanUseItem::Hammer) && CanPlay(SongOfTime);}),
                   ItemLocationPairing(&FireTemple_MegatonHammerChest, []{return HasExplosives;}),
   }, {});
 
@@ -1913,22 +1913,22 @@ namespace Exits { //name, scene, hint, events, locations, exits
   Exit WaterTemple_Lobby = Exit("Water Temple Lobby", "Water Temple", "", NO_DAY_NIGHT_CYCLE, {
                   //Events
                   EventPairing(&ChildWaterTemple, []{return IsChild;}),
-                  EventPairing(&RaiseWaterLevel,  []{return (IsAdult && ((Hookshot && (LogicWaterTempleUpperBoost && Bombs && (CanUse("Nayrus Love") || DamageMultiplier.IsNot(DAMAGEMULTIPLIER_OHKO)))) || HoverBoots || Bow)) || (HasFireSourceWithTorch && CanUseProjectile);}),
+                  EventPairing(&RaiseWaterLevel,  []{return (IsAdult && ((Hookshot && (LogicWaterTempleUpperBoost && Bombs && (CanUse(CanUseItem::Nayrus_Love) || DamageMultiplier.IsNot(DAMAGEMULTIPLIER_OHKO)))) || HoverBoots || Bow)) || (HasFireSourceWithTorch && CanUseProjectile);}),
                 }, {}, {
                   //Exits
                   ExitPairing::Both(&LH_Main,                       []{return true;}),
                   ExitPairing::Both(&WaterTemple_HighestWaterLevel, []{return RaiseWaterLevel;}),
-                  ExitPairing::Both(&WaterTemple_Dive,              []{return (CanUse("Zora Tunic") || LogicFewerTunicRequirements) && ((LogicWaterTempleTorchLongshot && CanUse("Longshot")) || CanUse("Iron Boots"));}),
+                  ExitPairing::Both(&WaterTemple_Dive,              []{return (CanUse(CanUseItem::Zora_Tunic) || LogicFewerTunicRequirements) && ((LogicWaterTempleTorchLongshot && CanUse(CanUseItem::Longshot)) || CanUse(CanUseItem::Iron_Boots));}),
   });
 
   Exit WaterTemple_HighestWaterLevel = Exit("Water Temple Highest Water Level", "Water Temple", "", NO_DAY_NIGHT_CYCLE, {
                   //Events
-                  EventPairing(&FairyPot,         []{return FairyPot           || CanUse("Longshot");}),
-                  EventPairing(&WaterTempleClear, []{return BossKeyWaterTemple && CanUse("Longshot");})
+                  EventPairing(&FairyPot,         []{return FairyPot           || CanUse(CanUseItem::Longshot);}),
+                  EventPairing(&WaterTempleClear, []{return BossKeyWaterTemple && CanUse(CanUseItem::Longshot);})
                 }, {
                   //Locations
-                  ItemLocationPairing(&Morpha,                  []{return BossKeyWaterTemple && CanUse("Longshot");}),
-                  ItemLocationPairing(&WaterTemple_MorphaHeart, []{return BossKeyWaterTemple && CanUse("Longshot");}),
+                  ItemLocationPairing(&Morpha,                  []{return BossKeyWaterTemple && CanUse(CanUseItem::Longshot);}),
+                  ItemLocationPairing(&WaterTemple_MorphaHeart, []{return BossKeyWaterTemple && CanUse(CanUseItem::Longshot);}),
                 }, {
                   //Exits
                   ExitPairing::Both(&WaterTemple_FallingPlatformRoom, []{return SmallKeys(WaterTempleKeys, 4);}),
@@ -1938,32 +1938,32 @@ namespace Exits { //name, scene, hint, events, locations, exits
   Exit WaterTemple_Dive = Exit("Water Temple Dive", "Water Temple", "", NO_DAY_NIGHT_CYCLE, {}, {
                   //Locations
                   ItemLocationPairing(&WaterTemple_MapChest,              []{return RaiseWaterLevel;}),
-                  ItemLocationPairing(&WaterTemple_CompassChest,          []{return (CanPlay(ZeldasLullaby) || IronBoots) && CanUse("Hookshot");}),
-                  ItemLocationPairing(&WaterTemple_TorchesChest,          []{return (Bow || CanUse("Dins Fire") || (ChildWaterTemple && Sticks && KokiriSword && MagicMeter)) && CanPlay(ZeldasLullaby);}),
-                  ItemLocationPairing(&WaterTemple_CentralBowTargetChest, []{return GoronBracelet && CanPlay(ZeldasLullaby) && ((Bow && (LogicWaterCentralBow || HoverBoots || CanUse("Longshot"))));}),
-                  ItemLocationPairing(&WaterTemple_GS_BehindGate,         []{return (CanUse("Hookshot") || CanUse("Hover Boots")) && (HasExplosives && CanPlay(ZeldasLullaby)) && (CanUse("Iron Boots") || CanDive);}),
+                  ItemLocationPairing(&WaterTemple_CompassChest,          []{return (CanPlay(ZeldasLullaby) || IronBoots) && CanUse(CanUseItem::Hookshot);}),
+                  ItemLocationPairing(&WaterTemple_TorchesChest,          []{return (Bow || CanUse(CanUseItem::Dins_Fire) || (ChildWaterTemple && Sticks && KokiriSword && MagicMeter)) && CanPlay(ZeldasLullaby);}),
+                  ItemLocationPairing(&WaterTemple_CentralBowTargetChest, []{return GoronBracelet && CanPlay(ZeldasLullaby) && ((Bow && (LogicWaterCentralBow || HoverBoots || CanUse(CanUseItem::Longshot))));}),
+                  ItemLocationPairing(&WaterTemple_GS_BehindGate,         []{return (CanUse(CanUseItem::Hookshot) || CanUse(CanUseItem::Hover_Boots)) && (HasExplosives && CanPlay(ZeldasLullaby)) && (CanUse(CanUseItem::Iron_Boots) || CanDive);}),
                   ItemLocationPairing(&WaterTemple_GS_CentralPillar,      []{return CanPlay(ZeldasLullaby) &&
-                                                                                      (((CanUse("Longshot") || (LogicWaterCentralGSFW && CanUse("Hookshot") && CanUse("Farores Wind"))) &&
-                                                                                        (SmallKeys(WaterTempleKeys, 5) || CanUse("Bow") || CanUse("Dins Fire"))) ||
-                                                                                      (LogicWaterCentralGSFW && ChildWaterTemple && Boomerang && CanUse("Farores Wind") &&
-                                                                                        (Sticks || CanUse("Dins Fire") ||
-                                                                                        (SmallKeys(WaterTempleKeys, 5) && (CanUse("Hover Boots") || CanUse("Bow"))))));}),
+                                                                                      (((CanUse(CanUseItem::Longshot) || (LogicWaterCentralGSFW && CanUse(CanUseItem::Hookshot) && CanUse(CanUseItem::Farores_Wind))) &&
+                                                                                        (SmallKeys(WaterTempleKeys, 5) || CanUse(CanUseItem::Bow) || CanUse(CanUseItem::Dins_Fire))) ||
+                                                                                      (LogicWaterCentralGSFW && ChildWaterTemple && Boomerang && CanUse(CanUseItem::Farores_Wind) &&
+                                                                                        (Sticks || CanUse(CanUseItem::Dins_Fire) ||
+                                                                                        (SmallKeys(WaterTempleKeys, 5) && (CanUse(CanUseItem::Hover_Boots) || CanUse(CanUseItem::Bow))))));}),
                 }, {
                   //Exits
-                  ExitPairing::Both(&WaterTemple_CrackedWall,      []{return CanPlay(ZeldasLullaby) && (CanUse("Hookshot") || CanUse("Hover Boots")) && (LogicWaterCrackedWallNothing || (LogicWaterCrackedWallHovers && CanUse("Hover Boots")));}),
-                  ExitPairing::Both(&WaterTemple_MiddleWaterLevel, []{return (Bow || CanUse("Dins Fire") || (SmallKeys(WaterTempleKeys, 5) && CanUse("Hookshot")) || (ChildWaterTemple && Sticks)) && CanPlay(ZeldasLullaby);}),
-                  ExitPairing::Both(&WaterTemple_NorthBasement,    []{return SmallKeys(WaterTempleKeys, 5) && (CanUse("Longshot") || (LogicWaterBossKeyRegion && CanUse("Hover Boots"))) && (CanUse("Iron Boots") || CanPlay(ZeldasLullaby));}),
+                  ExitPairing::Both(&WaterTemple_CrackedWall,      []{return CanPlay(ZeldasLullaby) && (CanUse(CanUseItem::Hookshot) || CanUse(CanUseItem::Hover_Boots)) && (LogicWaterCrackedWallNothing || (LogicWaterCrackedWallHovers && CanUse(CanUseItem::Hover_Boots)));}),
+                  ExitPairing::Both(&WaterTemple_MiddleWaterLevel, []{return (Bow || CanUse(CanUseItem::Dins_Fire) || (SmallKeys(WaterTempleKeys, 5) && CanUse(CanUseItem::Hookshot)) || (ChildWaterTemple && Sticks)) && CanPlay(ZeldasLullaby);}),
+                  ExitPairing::Both(&WaterTemple_NorthBasement,    []{return SmallKeys(WaterTempleKeys, 5) && (CanUse(CanUseItem::Longshot) || (LogicWaterBossKeyRegion && CanUse(CanUseItem::Hover_Boots))) && (CanUse(CanUseItem::Iron_Boots) || CanPlay(ZeldasLullaby));}),
                   ExitPairing::Both(&WaterTemple_DragonStatue,     []{return CanPlay(ZeldasLullaby) && GoronBracelet &&
-                                                                                ((IronBoots && CanUse("Hookshot")) ||
-                                                                                (LogicWaterDragonAdult && (HasBombchus || CanUse("Bow") || CanUse("Hookshot")) && (CanDive || IronBoots)));}),
+                                                                                ((IronBoots && CanUse(CanUseItem::Hookshot)) ||
+                                                                                (LogicWaterDragonAdult && (HasBombchus || CanUse(CanUseItem::Bow) || CanUse(CanUseItem::Hookshot)) && (CanDive || IronBoots)));}),
   });
 
   Exit WaterTemple_NorthBasement = Exit("Water Temple North Basement", "Water Temple", "", NO_DAY_NIGHT_CYCLE, {
                   //Events
-                  EventPairing(&FairyPot, []{return FairyPot || (SmallKeys(WaterTempleKeys, 5) && (LogicWaterBKJumpDive || CanUse("Iron Boots")) && (LogicWaterNorthBasementLedgeJump || (HasExplosives && GoronBracelet) || HoverBoots));}),
+                  EventPairing(&FairyPot, []{return FairyPot || (SmallKeys(WaterTempleKeys, 5) && (LogicWaterBKJumpDive || CanUse(CanUseItem::Iron_Boots)) && (LogicWaterNorthBasementLedgeJump || (HasExplosives && GoronBracelet) || HoverBoots));}),
                 }, {
                   //Locations
-                  ItemLocationPairing(&WaterTemple_BossKeyChest,        []{return SmallKeys(WaterTempleKeys, 5) && (LogicWaterBKJumpDive || CanUse("Iron Boots")) && (LogicWaterNorthBasementLedgeJump || (HasExplosives && GoronBracelet) || HoverBoots);}),
+                  ItemLocationPairing(&WaterTemple_BossKeyChest,        []{return SmallKeys(WaterTempleKeys, 5) && (LogicWaterBKJumpDive || CanUse(CanUseItem::Iron_Boots)) && (LogicWaterNorthBasementLedgeJump || (HasExplosives && GoronBracelet) || HoverBoots);}),
                   ItemLocationPairing(&WaterTemple_GS_NearBossKeyChest, []{return true;}),
   }, {});
 
@@ -1979,7 +1979,7 @@ namespace Exits { //name, scene, hint, events, locations, exits
 
   Exit WaterTemple_MiddleWaterLevel = Exit("Water Temple Middle Water Level", "Water Temple", "", NO_DAY_NIGHT_CYCLE, {}, {
                   //Locations
-                  ItemLocationPairing(&WaterTemple_CentralPillarChest, []{return CanUse("Zora Tunic") && CanUse("Hookshot") && ((SmallKeys(WaterTempleKeys, 5) || CanUse("Bow") || CanUse("Dins Fire")));}),
+                  ItemLocationPairing(&WaterTemple_CentralPillarChest, []{return CanUse(CanUseItem::Zora_Tunic) && CanUse(CanUseItem::Hookshot) && ((SmallKeys(WaterTempleKeys, 5) || CanUse(CanUseItem::Bow) || CanUse(CanUseItem::Dins_Fire)));}),
                 }, {
                   //Exits
                   ExitPairing::Both(&WaterTemple_CrackedWall, []{return true;}),
@@ -1987,10 +1987,10 @@ namespace Exits { //name, scene, hint, events, locations, exits
 
   Exit WaterTemple_FallingPlatformRoom = Exit("Water Temple Falling Platform Room", "Water Temple", "", NO_DAY_NIGHT_CYCLE, {}, {
                   //Locations
-                  ItemLocationPairing(&WaterTemple_GS_FallingPlatformRoom, []{return CanUse("Longshot") || (LogicWaterFallingPlatformGS && CanUse("Hookshot"));}),
+                  ItemLocationPairing(&WaterTemple_GS_FallingPlatformRoom, []{return CanUse(CanUseItem::Longshot) || (LogicWaterFallingPlatformGS && CanUse(CanUseItem::Hookshot));}),
                 }, {
                   //Exits
-                  ExitPairing::Both(&WaterTemple_DarkLinkRegion, []{return SmallKeys(WaterTempleKeys, 5) && CanUse("Hookshot");}),
+                  ExitPairing::Both(&WaterTemple_DarkLinkRegion, []{return SmallKeys(WaterTempleKeys, 5) && CanUse(CanUseItem::Hookshot);}),
   });
 
   Exit WaterTemple_DarkLinkRegion = Exit("Water Temple Dark Link Region", "Water Temple", "", NO_DAY_NIGHT_CYCLE, {
@@ -2000,10 +2000,10 @@ namespace Exits { //name, scene, hint, events, locations, exits
                   //Locations
                   ItemLocationPairing(&WaterTemple_LongshotChest,          []{return SmallKeys(WaterTempleKeys, 5);}),
                   ItemLocationPairing(&WaterTemple_RiverChest,             []{return SmallKeys(WaterTempleKeys, 5) && CanPlay(SongOfTime) && Bow;}),
-                  ItemLocationPairing(&WaterTemple_GS_River,               []{return CanPlay(SongOfTime) && SmallKeys(WaterTempleKeys, 5) && (IronBoots || (LogicWaterRiverGS && CanUse("Longshot") && (Bow || HasBombchus)));}),
+                  ItemLocationPairing(&WaterTemple_GS_River,               []{return CanPlay(SongOfTime) && SmallKeys(WaterTempleKeys, 5) && (IronBoots || (LogicWaterRiverGS && CanUse(CanUseItem::Longshot) && (Bow || HasBombchus)));}),
                 }, {
                   //Exits
-                  ExitPairing::Both(&WaterTemple_DragonStatue, []{return (CanUse("Zora Tunic") || LogicFewerTunicRequirements) &&
+                  ExitPairing::Both(&WaterTemple_DragonStatue, []{return (CanUse(CanUseItem::Zora_Tunic) || LogicFewerTunicRequirements) &&
                                                                          CanPlay(SongOfTime) && Bow &&
                                                                          (IronBoots || LogicWaterDragonJumpDive || LogicWaterDragonAdult);}),
   });
@@ -2012,7 +2012,7 @@ namespace Exits { //name, scene, hint, events, locations, exits
                   //Exits
                   ExitPairing::Both(&Colossus_Main,           []{return true;}),
                   ExitPairing::Both(&SpiritTemple_Child,      []{return IsChild;}),
-                  ExitPairing::Both(&SpiritTemple_EarlyAdult, []{return CanUse("Silver Gauntlets");}),
+                  ExitPairing::Both(&SpiritTemple_EarlyAdult, []{return CanUse(CanUseItem::Silver_Gauntlets);}),
   });
 
   Exit SpiritTemple_Child = Exit("Child Spirit Temple", "Spirit Temple", "", NO_DAY_NIGHT_CYCLE, {
@@ -2021,7 +2021,7 @@ namespace Exits { //name, scene, hint, events, locations, exits
                 }, {
                   //Locations
                   ItemLocationPairing(&SpiritTemple_ChildBridgeChest,       []{return (Boomerang || Slingshot || (HasExplosives && LogicSpiritChildBombchu)) && (Sticks || HasExplosives || ((Nuts || Boomerang) && (KokiriSword || Slingshot)));}),
-                  ItemLocationPairing(&SpiritTemple_ChildEarlyTorchesChest, []{return (Boomerang || Slingshot || (HasExplosives && LogicSpiritChildBombchu)) && (Sticks || HasExplosives || ((Nuts || Boomerang) && (KokiriSword || Slingshot))) && (Sticks || CanUse("Dins Fire"));}),
+                  ItemLocationPairing(&SpiritTemple_ChildEarlyTorchesChest, []{return (Boomerang || Slingshot || (HasExplosives && LogicSpiritChildBombchu)) && (Sticks || HasExplosives || ((Nuts || Boomerang) && (KokiriSword || Slingshot))) && (Sticks || CanUse(CanUseItem::Dins_Fire));}),
                   ItemLocationPairing(&SpiritTemple_GS_MetalFence,          []{return (Boomerang || Slingshot || (HasExplosives && LogicSpiritChildBombchu)) && (Sticks || HasExplosives || ((Nuts || Boomerang) && (KokiriSword || Slingshot)));}),
                 }, {
                   //Exits
@@ -2030,9 +2030,9 @@ namespace Exits { //name, scene, hint, events, locations, exits
 
   Exit SpiritTemple_ChildClimb = Exit("Child Spirit Temple Climb", "Spirit Temple", "", NO_DAY_NIGHT_CYCLE, {}, {
                   //Locations
-                  ItemLocationPairing(&SpiritTemple_ChildClimbNorthChest, []{return HasProjectile("Both") || ((SmallKeys(SpiritTempleKeys, 3) || (SmallKeys(SpiritTempleKeys, 2) && BombchusInLogic && !ShuffleDungeonEntrances)) && CanUse("Silver Gauntlets") && HasProjectile("Adult")) || (SmallKeys(SpiritTempleKeys, 5) && IsChild && HasProjectile("Child"));}),
-                  ItemLocationPairing(&SpiritTemple_ChildClimbEastChest,  []{return HasProjectile("Both") || ((SmallKeys(SpiritTempleKeys, 3) || (SmallKeys(SpiritTempleKeys, 2) && BombchusInLogic && !ShuffleDungeonEntrances)) && CanUse("Silver Gauntlets") && HasProjectile("Adult")) || (SmallKeys(SpiritTempleKeys, 5) && IsChild && HasProjectile("Child"));}),
-                  ItemLocationPairing(&SpiritTemple_GS_SunOnFloorRoom,    []{return HasProjectile("Both") || CanUse("Dins Fire") || ((DamageMultiplier.IsNot(DAMAGEMULTIPLIER_OHKO) || Fairy || CanUse("Nayrus Love")) && (Sticks || KokiriSword || HasProjectile("Child"))) || (IsChild && SmallKeys(SpiritTempleKeys, 5) && HasProjectile("Child")) || ((SmallKeys(SpiritTempleKeys, 3) || (SmallKeys(SpiritTempleKeys, 2) && BombchusInLogic && !ShuffleDungeonEntrances)) && CanUse("Silver Gauntlets") && (HasProjectile("Adult") || DamageMultiplier.IsNot(DAMAGEMULTIPLIER_OHKO) || Fairy || CanUse("Nayrus Love")));}),
+                  ItemLocationPairing(&SpiritTemple_ChildClimbNorthChest, []{return HasProjectile("Both") || ((SmallKeys(SpiritTempleKeys, 3) || (SmallKeys(SpiritTempleKeys, 2) && BombchusInLogic && !ShuffleDungeonEntrances)) && CanUse(CanUseItem::Silver_Gauntlets) && HasProjectile("Adult")) || (SmallKeys(SpiritTempleKeys, 5) && IsChild && HasProjectile("Child"));}),
+                  ItemLocationPairing(&SpiritTemple_ChildClimbEastChest,  []{return HasProjectile("Both") || ((SmallKeys(SpiritTempleKeys, 3) || (SmallKeys(SpiritTempleKeys, 2) && BombchusInLogic && !ShuffleDungeonEntrances)) && CanUse(CanUseItem::Silver_Gauntlets) && HasProjectile("Adult")) || (SmallKeys(SpiritTempleKeys, 5) && IsChild && HasProjectile("Child"));}),
+                  ItemLocationPairing(&SpiritTemple_GS_SunOnFloorRoom,    []{return HasProjectile("Both") || CanUse(CanUseItem::Dins_Fire) || ((DamageMultiplier.IsNot(DAMAGEMULTIPLIER_OHKO) || Fairy || CanUse(CanUseItem::Nayrus_Love)) && (Sticks || KokiriSword || HasProjectile("Child"))) || (IsChild && SmallKeys(SpiritTempleKeys, 5) && HasProjectile("Child")) || ((SmallKeys(SpiritTempleKeys, 3) || (SmallKeys(SpiritTempleKeys, 2) && BombchusInLogic && !ShuffleDungeonEntrances)) && CanUse(CanUseItem::Silver_Gauntlets) && (HasProjectile("Adult") || DamageMultiplier.IsNot(DAMAGEMULTIPLIER_OHKO) || Fairy || CanUse(CanUseItem::Nayrus_Love)));}),
                 }, {
                   //Exits
                   ExitPairing::Both(&SpiritTemple_CentralChamber, []{return HasExplosives;}),
@@ -2040,7 +2040,7 @@ namespace Exits { //name, scene, hint, events, locations, exits
 
   Exit SpiritTemple_EarlyAdult = Exit("Early Adult Spirit Temple", "Spirit Temple", "", NO_DAY_NIGHT_CYCLE, {}, {
                   //Locations
-                  ItemLocationPairing(&SpiritTemple_CompassChest,          []{return CanUse("Hookshot") && CanPlay(ZeldasLullaby);}),
+                  ItemLocationPairing(&SpiritTemple_CompassChest,          []{return CanUse(CanUseItem::Hookshot) && CanPlay(ZeldasLullaby);}),
                   ItemLocationPairing(&SpiritTemple_EarlyAdultRightChest,  []{return Bow || Hookshot || HasBombchus || (Bombs && LogicSpiritLowerAdultSwitch);}),
                   ItemLocationPairing(&SpiritTemple_FirstMirrorLeftChest,  []{return SmallKeys(SpiritTempleKeys, 3);}),
                   ItemLocationPairing(&SpiritTemple_FirstMirrorRightChest, []{return SmallKeys(SpiritTempleKeys, 3);}),
@@ -2052,36 +2052,36 @@ namespace Exits { //name, scene, hint, events, locations, exits
 
   Exit SpiritTemple_CentralChamber = Exit("Spirit Temple Central Chamber", "Spirit Temple", "", NO_DAY_NIGHT_CYCLE, {}, {
                   //Locations
-                  ItemLocationPairing(&SpiritTemple_MapChest,                 []{return ((HasExplosives || SmallKeys(SpiritTempleKeys, 3) || (SmallKeys(SpiritTempleKeys, 2) && BombchusInLogic && !ShuffleDungeonEntrances)) && (CanUse("Dins Fire") || (((MagicMeter && FireArrows) || LogicSpiritMapChest) && Bow && Sticks))) || (SmallKeys(SpiritTempleKeys, 5) && HasExplosives && CanUse("Sticks")) || (SmallKeys(SpiritTempleKeys, 3) && (CanUse("Fire Arrows") || (LogicSpiritMapChest && Bow)) && CanUse("Silver Gauntlets"));}),
-                  ItemLocationPairing(&SpiritTemple_SunBlockRoomChest,        []{return ((HasExplosives || SmallKeys(SpiritTempleKeys, 3) || (SmallKeys(SpiritTempleKeys, 2) && BombchusInLogic && !ShuffleDungeonEntrances)) && (CanUse("Dins Fire") || (((MagicMeter && FireArrows) || LogicSpiritMapChest) && Bow && Sticks))) || (SmallKeys(SpiritTempleKeys, 5) && HasExplosives && CanUse("Sticks")) || (SmallKeys(SpiritTempleKeys, 3) && (CanUse("Fire Arrows") || (LogicSpiritMapChest && Bow)) && CanUse("Silver Gauntlets"));}),
-                  ItemLocationPairing(&SpiritTemple_StatueRoomHandChest,      []{return SmallKeys(SpiritTempleKeys, 3) && CanUse("Silver Gauntlets") && CanPlay(ZeldasLullaby);}),
-                  ItemLocationPairing(&SpiritTemple_StatueRoomNortheastChest, []{return SmallKeys(SpiritTempleKeys, 3) && CanUse("Silver Gauntlets") && CanPlay(ZeldasLullaby) && (Hookshot || HoverBoots);}),
-                  ItemLocationPairing(&SpiritTemple_GS_HallAfterSunBlockRoom, []{return (HasExplosives && Boomerang && Hookshot) || (CanUse("Boomerang") && SmallKeys(SpiritTempleKeys, 5) && HasExplosives) || (Hookshot && CanUse("Silver Gauntlets") && (SmallKeys(SpiritTempleKeys, 3) || (SmallKeys(SpiritTempleKeys, 2) && Boomerang && BombchusInLogic && !ShuffleDungeonEntrances)));}),
-                  ItemLocationPairing(&SpiritTemple_GS_Lobby,                 []{return ((HasExplosives || SmallKeys(SpiritTempleKeys, 3) || (SmallKeys(SpiritTempleKeys, 2) && BombchusInLogic && !ShuffleDungeonEntrances)) && LogicSpiritLobbyGS && Boomerang && (Hookshot || HoverBoots)) || (LogicSpiritLobbyGS && SmallKeys(SpiritTempleKeys, 5) && HasExplosives && CanUse("Boomerang")) || (SmallKeys(SpiritTempleKeys, 3) && CanUse("Silver Gauntlets") && (Hookshot || HoverBoots));}),
+                  ItemLocationPairing(&SpiritTemple_MapChest,                 []{return ((HasExplosives || SmallKeys(SpiritTempleKeys, 3) || (SmallKeys(SpiritTempleKeys, 2) && BombchusInLogic && !ShuffleDungeonEntrances)) && (CanUse(CanUseItem::Dins_Fire) || (((MagicMeter && FireArrows) || LogicSpiritMapChest) && Bow && Sticks))) || (SmallKeys(SpiritTempleKeys, 5) && HasExplosives && CanUse(CanUseItem::Sticks)) || (SmallKeys(SpiritTempleKeys, 3) && (CanUse(CanUseItem::Fire_Arrows) || (LogicSpiritMapChest && Bow)) && CanUse(CanUseItem::Silver_Gauntlets));}),
+                  ItemLocationPairing(&SpiritTemple_SunBlockRoomChest,        []{return ((HasExplosives || SmallKeys(SpiritTempleKeys, 3) || (SmallKeys(SpiritTempleKeys, 2) && BombchusInLogic && !ShuffleDungeonEntrances)) && (CanUse(CanUseItem::Dins_Fire) || (((MagicMeter && FireArrows) || LogicSpiritMapChest) && Bow && Sticks))) || (SmallKeys(SpiritTempleKeys, 5) && HasExplosives && CanUse(CanUseItem::Sticks)) || (SmallKeys(SpiritTempleKeys, 3) && (CanUse(CanUseItem::Fire_Arrows) || (LogicSpiritMapChest && Bow)) && CanUse(CanUseItem::Silver_Gauntlets));}),
+                  ItemLocationPairing(&SpiritTemple_StatueRoomHandChest,      []{return SmallKeys(SpiritTempleKeys, 3) && CanUse(CanUseItem::Silver_Gauntlets) && CanPlay(ZeldasLullaby);}),
+                  ItemLocationPairing(&SpiritTemple_StatueRoomNortheastChest, []{return SmallKeys(SpiritTempleKeys, 3) && CanUse(CanUseItem::Silver_Gauntlets) && CanPlay(ZeldasLullaby) && (Hookshot || HoverBoots);}),
+                  ItemLocationPairing(&SpiritTemple_GS_HallAfterSunBlockRoom, []{return (HasExplosives && Boomerang && Hookshot) || (CanUse(CanUseItem::Boomerang) && SmallKeys(SpiritTempleKeys, 5) && HasExplosives) || (Hookshot && CanUse(CanUseItem::Silver_Gauntlets) && (SmallKeys(SpiritTempleKeys, 3) || (SmallKeys(SpiritTempleKeys, 2) && Boomerang && BombchusInLogic && !ShuffleDungeonEntrances)));}),
+                  ItemLocationPairing(&SpiritTemple_GS_Lobby,                 []{return ((HasExplosives || SmallKeys(SpiritTempleKeys, 3) || (SmallKeys(SpiritTempleKeys, 2) && BombchusInLogic && !ShuffleDungeonEntrances)) && LogicSpiritLobbyGS && Boomerang && (Hookshot || HoverBoots)) || (LogicSpiritLobbyGS && SmallKeys(SpiritTempleKeys, 5) && HasExplosives && CanUse(CanUseItem::Boomerang)) || (SmallKeys(SpiritTempleKeys, 3) && CanUse(CanUseItem::Silver_Gauntlets) && (Hookshot || HoverBoots));}),
                 }, {
                   //Exits
                   ExitPairing::Both(&SpiritTemple_OutdoorHands,            []{return true;}),
-                  ExitPairing::Both(&SpiritTemple_BeyondCentralLockedDoor, []{return SmallKeys(SpiritTempleKeys, 4) && CanUse("Silver Gauntlets");}),
+                  ExitPairing::Both(&SpiritTemple_BeyondCentralLockedDoor, []{return SmallKeys(SpiritTempleKeys, 4) && CanUse(CanUseItem::Silver_Gauntlets);}),
                   ExitPairing::Both(&SpiritTemple_ChildClimb,              []{return true;}),
   });
 
   Exit SpiritTemple_OutdoorHands = Exit("Spirit Temple Outdoor Hands", "Spirit Temple", "", NO_DAY_NIGHT_CYCLE, {}, {
                   //Locations
                   ItemLocationPairing(&SpiritTemple_SilverGauntletsChest, []{return (SmallKeys(SpiritTempleKeys, 3) && Longshot && HasExplosives) || SmallKeys(SpiritTempleKeys, 5);}),
-                  ItemLocationPairing(&SpiritTemple_MirrorShieldChest,    []{return SmallKeys(SpiritTempleKeys, 4) && CanUse("Silver Gauntlets") && HasExplosives;}),
+                  ItemLocationPairing(&SpiritTemple_MirrorShieldChest,    []{return SmallKeys(SpiritTempleKeys, 4) && CanUse(CanUseItem::Silver_Gauntlets) && HasExplosives;}),
                 }, {
                   //Exits
-                  ExitPairing::Both(&Colossus_Main, []{return (IsChild && SmallKeys(SpiritTempleKeys, 5)) || (CanUse("Silver Gauntlets") && ((SmallKeys(SpiritTempleKeys, 3) && HasExplosives) || SmallKeys(SpiritTempleKeys, 5)));}),
+                  ExitPairing::Both(&Colossus_Main, []{return (IsChild && SmallKeys(SpiritTempleKeys, 5)) || (CanUse(CanUseItem::Silver_Gauntlets) && ((SmallKeys(SpiritTempleKeys, 3) && HasExplosives) || SmallKeys(SpiritTempleKeys, 5)));}),
   });
 
   Exit SpiritTemple_BeyondCentralLockedDoor = Exit("Spirit Temple Beyond Central Locked Door", "Spirit Temple", "", NO_DAY_NIGHT_CYCLE, {}, {
                   //Locations
                   ItemLocationPairing(&SpiritTemple_NearFourArmosChest,         []{return MirrorShield && HasExplosives;}),
-                  ItemLocationPairing(&SpiritTemple_HallwayLeftInvisibleChest,  []{return (LogicLensSpirit || CanUse("Lens of Truth")) && HasExplosives;}),
-                  ItemLocationPairing(&SpiritTemple_HallwayRightInvisibleChest, []{return (LogicLensSpirit || CanUse("Lens of Truth")) && HasExplosives;}),
+                  ItemLocationPairing(&SpiritTemple_HallwayLeftInvisibleChest,  []{return (LogicLensSpirit || CanUse(CanUseItem::Lens_of_Truth)) && HasExplosives;}),
+                  ItemLocationPairing(&SpiritTemple_HallwayRightInvisibleChest, []{return (LogicLensSpirit || CanUse(CanUseItem::Lens_of_Truth)) && HasExplosives;}),
                 }, {
                   //Exits
-                  ExitPairing::Both(&SpiritTemple_BeyondFinalLockedDoor, []{return SmallKeys(SpiritTempleKeys, 5) && (LogicSpiritWall || CanUse("Longshot") || HasBombchus || ((Bombs || Nuts || CanUse("Dins Fire")) && (Bow || CanUse("Hookshot") || Hammer)));}),
+                  ExitPairing::Both(&SpiritTemple_BeyondFinalLockedDoor, []{return SmallKeys(SpiritTempleKeys, 5) && (LogicSpiritWall || CanUse(CanUseItem::Longshot) || HasBombchus || ((Bombs || Nuts || CanUse(CanUseItem::Dins_Fire)) && (Bow || CanUse(CanUseItem::Hookshot) || Hammer)));}),
   });
 
   Exit SpiritTemple_BeyondFinalLockedDoor = Exit("Spirit Temple Beyond Final Locked Door", "Spirit Temple", "", NO_DAY_NIGHT_CYCLE, {}, {
@@ -2095,7 +2095,7 @@ namespace Exits { //name, scene, hint, events, locations, exits
   Exit ShadowTemple_Entryway = Exit("Shadow Temple Entryway", "Shadow Temple", "", NO_DAY_NIGHT_CYCLE, {}, {}, {
                   //Exits
                   ExitPairing::Both(&GY_WarpPadRegion,       []{return true;}),
-                  ExitPairing::Both(&ShadowTemple_Beginning, []{return (LogicLensShadow || CanUse("Lens of Truth")) && (CanUse("Hover Boots") || CanUse("Hookshot"));}),
+                  ExitPairing::Both(&ShadowTemple_Beginning, []{return (LogicLensShadow || CanUse(CanUseItem::Lens_of_Truth)) && (CanUse(CanUseItem::Hover_Boots) || CanUse(CanUseItem::Hookshot));}),
   });
 
   Exit ShadowTemple_Beginning = Exit("Shadow Temple Beginning", "Shadow Temple", "", NO_DAY_NIGHT_CYCLE, {
@@ -2130,14 +2130,14 @@ namespace Exits { //name, scene, hint, events, locations, exits
                   ItemLocationPairing(&ShadowTemple_FallingSpikesLowerChest,       []{return true;}),
                   ItemLocationPairing(&ShadowTemple_FallingSpikesUpperChest,       []{return LogicShadowUmbrella || GoronBracelet;}),
                   ItemLocationPairing(&ShadowTemple_FallingSpikesSwitchChest,      []{return LogicShadowUmbrella || GoronBracelet;}),
-                  ItemLocationPairing(&ShadowTemple_InvisibleSpikesChest,          []{return SmallKeys(ShadowTempleKeys, 2) && (LogicLensShadowBack || CanUse("Lens of Truth"));}),
-                  ItemLocationPairing(&ShadowTemple_FreestandingKey,               []{return SmallKeys(ShadowTempleKeys, 2) && (LogicLensShadowBack || CanUse("Lens of Truth")) && Hookshot && (Bombs || GoronBracelet || (LogicShadowFreestandingKey && HasBombchus));}),
+                  ItemLocationPairing(&ShadowTemple_InvisibleSpikesChest,          []{return SmallKeys(ShadowTempleKeys, 2) && (LogicLensShadowBack || CanUse(CanUseItem::Lens_of_Truth));}),
+                  ItemLocationPairing(&ShadowTemple_FreestandingKey,               []{return SmallKeys(ShadowTempleKeys, 2) && (LogicLensShadowBack || CanUse(CanUseItem::Lens_of_Truth)) && Hookshot && (Bombs || GoronBracelet || (LogicShadowFreestandingKey && HasBombchus));}),
                   ItemLocationPairing(&ShadowTemple_GS_LikeLikeRoom,               []{return true;}),
                   ItemLocationPairing(&ShadowTemple_GS_FallingSpikesRoom,          []{return Hookshot;}),
-                  ItemLocationPairing(&ShadowTemple_GS_SingleGiantPot,             []{return SmallKeys(ShadowTempleKeys, 2) && (LogicLensShadowBack || CanUse("Lens of Truth")) && Hookshot;}),
+                  ItemLocationPairing(&ShadowTemple_GS_SingleGiantPot,             []{return SmallKeys(ShadowTempleKeys, 2) && (LogicLensShadowBack || CanUse(CanUseItem::Lens_of_Truth)) && Hookshot;}),
                 }, {
                   //Exits
-                  ExitPairing::Both(&ShadowTemple_WindTunnel, []{return (LogicLensShadowBack || CanUse("Lens of Truth")) && Hookshot && SmallKeys(ShadowTempleKeys, 3);}),
+                  ExitPairing::Both(&ShadowTemple_WindTunnel, []{return (LogicLensShadowBack || CanUse(CanUseItem::Lens_of_Truth)) && Hookshot && SmallKeys(ShadowTempleKeys, 3);}),
   });
 
   Exit ShadowTemple_WindTunnel = Exit("Shadow Temple Wind Tunnel", "Shadow Temple", "", NO_DAY_NIGHT_CYCLE, {}, {
@@ -2145,7 +2145,7 @@ namespace Exits { //name, scene, hint, events, locations, exits
                   ItemLocationPairing(&ShadowTemple_WindHintChest,        []{return true;}),
                   ItemLocationPairing(&ShadowTemple_AfterWindEnemyChest,  []{return true;}),
                   ItemLocationPairing(&ShadowTemple_AfterWindHiddenChest, []{return true;}),
-                  ItemLocationPairing(&ShadowTemple_GS_NearShip,          []{return CanUse("Longshot") && SmallKeys(ShadowTempleKeys, 4);}),
+                  ItemLocationPairing(&ShadowTemple_GS_NearShip,          []{return CanUse(CanUseItem::Longshot) && SmallKeys(ShadowTempleKeys, 4);}),
                 }, {
                   //Exits
                   ExitPairing::Both(&ShadowTemple_BeyondBoat, []{return CanPlay(ZeldasLullaby) && SmallKeys(ShadowTempleKeys, 4);}),
@@ -2153,11 +2153,11 @@ namespace Exits { //name, scene, hint, events, locations, exits
 
   Exit ShadowTemple_BeyondBoat = Exit("Shadow Temple Beyond Boat", "Shadow Temple", "", NO_DAY_NIGHT_CYCLE, {}, {
                   //Locations
-                  ItemLocationPairing(&ShadowTemple_SpikeWallsLeftChest,       []{return CanUse("Dins Fire");}),
-                  ItemLocationPairing(&ShadowTemple_BossKeyChest,              []{return CanUse("Dins Fire");}),
+                  ItemLocationPairing(&ShadowTemple_SpikeWallsLeftChest,       []{return CanUse(CanUseItem::Dins_Fire);}),
+                  ItemLocationPairing(&ShadowTemple_BossKeyChest,              []{return CanUse(CanUseItem::Dins_Fire);}),
                   ItemLocationPairing(&ShadowTemple_InvisibleFloormasterChest, []{return true;}),
-                  ItemLocationPairing(&ShadowTemple_BongoBongoHeart,           []{return SmallKeys(ShadowTempleKeys, 5) && BossKeyShadowTemple && (Bow || CanUse("Distant Scarecrow") || (LogicShadowStatue && HasBombchus));}),
-                  ItemLocationPairing(&BongoBongo,                             []{return SmallKeys(ShadowTempleKeys, 5) && BossKeyShadowTemple && (Bow || CanUse("Distant Scarecrow") || (LogicShadowStatue && HasBombchus));}),
+                  ItemLocationPairing(&ShadowTemple_BongoBongoHeart,           []{return SmallKeys(ShadowTempleKeys, 5) && BossKeyShadowTemple && (Bow || CanUse(CanUseItem::Distant_Scarecrow) || (LogicShadowStatue && HasBombchus));}),
+                  ItemLocationPairing(&BongoBongo,                             []{return SmallKeys(ShadowTempleKeys, 5) && BossKeyShadowTemple && (Bow || CanUse(CanUseItem::Distant_Scarecrow) || (LogicShadowStatue && HasBombchus));}),
                   ItemLocationPairing(&ShadowTemple_GS_TripleGiantPot,         []{return true;}),
   }, {});
 
@@ -2173,23 +2173,23 @@ namespace Exits { //name, scene, hint, events, locations, exits
                   EventPairing(&NutPot,   []{return true;}),
                 }, {
                   //Locations
-                  ItemLocationPairing(&BottomOfTheWell_FrontLeftFakeWallChest,   []{return LogicLensBotw || CanUse("Lens of Truth");}),
+                  ItemLocationPairing(&BottomOfTheWell_FrontLeftFakeWallChest,   []{return LogicLensBotw || CanUse(CanUseItem::Lens_of_Truth);}),
                   ItemLocationPairing(&BottomOfTheWell_FrontCenterBombableChest, []{return HasExplosives;}),
-                  ItemLocationPairing(&BottomOfTheWell_RightBottomFakeWallChest, []{return LogicLensBotw || CanUse("Lens of Truth");}),
-                  ItemLocationPairing(&BottomOfTheWell_CompassChest,             []{return LogicLensBotw || CanUse("Lens of Truth");}),
-                  ItemLocationPairing(&BottomOfTheWell_CenterSkulltulaChest,     []{return LogicLensBotw || CanUse("Lens of Truth");}),
-                  ItemLocationPairing(&BottomOfTheWell_BackLeftBombableChest,    []{return (LogicLensBotw || CanUse("Lens of Truth")) && HasExplosives;}),
-                  ItemLocationPairing(&BottomOfTheWell_FreestandingKey,          []{return Sticks || CanUse("Dins Fire");}),
+                  ItemLocationPairing(&BottomOfTheWell_RightBottomFakeWallChest, []{return LogicLensBotw || CanUse(CanUseItem::Lens_of_Truth);}),
+                  ItemLocationPairing(&BottomOfTheWell_CompassChest,             []{return LogicLensBotw || CanUse(CanUseItem::Lens_of_Truth);}),
+                  ItemLocationPairing(&BottomOfTheWell_CenterSkulltulaChest,     []{return LogicLensBotw || CanUse(CanUseItem::Lens_of_Truth);}),
+                  ItemLocationPairing(&BottomOfTheWell_BackLeftBombableChest,    []{return (LogicLensBotw || CanUse(CanUseItem::Lens_of_Truth)) && HasExplosives;}),
+                  ItemLocationPairing(&BottomOfTheWell_FreestandingKey,          []{return Sticks || CanUse(CanUseItem::Dins_Fire);}),
                   ItemLocationPairing(&BottomOfTheWell_LensOfTruthChest,         []{return CanPlay(ZeldasLullaby) && (KokiriSword || (Sticks && LogicChildDeadhand));}),
-                  ItemLocationPairing(&BottomOfTheWell_InvisibleChest,           []{return CanPlay(ZeldasLullaby) && (LogicLensBotw || CanUse("Lens of Truth"));}),
+                  ItemLocationPairing(&BottomOfTheWell_InvisibleChest,           []{return CanPlay(ZeldasLullaby) && (LogicLensBotw || CanUse(CanUseItem::Lens_of_Truth));}),
                   ItemLocationPairing(&BottomOfTheWell_UnderwaterFrontChest,     []{return CanPlay(ZeldasLullaby);}),
                   ItemLocationPairing(&BottomOfTheWell_UnderwaterLeftChest,      []{return CanPlay(ZeldasLullaby);}),
-                  ItemLocationPairing(&BottomOfTheWell_MapChest,                 []{return HasExplosives || (((SmallKeys(BottomOfTheWellKeys, 3) && (LogicLensBotw || CanUse("Lens of Truth"))) || CanUse("Dins Fire")) && GoronBracelet);}),
-                  ItemLocationPairing(&BottomOfTheWell_FireKeeseChest,           []{return SmallKeys(BottomOfTheWellKeys, 3) && (LogicLensBotw || CanUse("Lens of Truth"));}),
-                  ItemLocationPairing(&BottomOfTheWell_LikeLikeChest,            []{return SmallKeys(BottomOfTheWellKeys, 3) && (LogicLensBotw || CanUse("Lens of Truth"));}),
-                  ItemLocationPairing(&BottomOfTheWell_GS_WestInnerRoom,         []{return Boomerang && (LogicLensBotw || CanUse("Lens of Truth")) && SmallKeys(BottomOfTheWellKeys, 3);}),
-                  ItemLocationPairing(&BottomOfTheWell_GS_EastInnerRoom,         []{return Boomerang && (LogicLensBotw || CanUse("Lens of Truth")) && SmallKeys(BottomOfTheWellKeys, 3);}),
-                  ItemLocationPairing(&BottomOfTheWell_GS_LikeLikeCage,          []{return SmallKeys(BottomOfTheWellKeys, 3) && (LogicLensBotw || CanUse("Lens of Truth")) && Boomerang;}),
+                  ItemLocationPairing(&BottomOfTheWell_MapChest,                 []{return HasExplosives || (((SmallKeys(BottomOfTheWellKeys, 3) && (LogicLensBotw || CanUse(CanUseItem::Lens_of_Truth))) || CanUse(CanUseItem::Dins_Fire)) && GoronBracelet);}),
+                  ItemLocationPairing(&BottomOfTheWell_FireKeeseChest,           []{return SmallKeys(BottomOfTheWellKeys, 3) && (LogicLensBotw || CanUse(CanUseItem::Lens_of_Truth));}),
+                  ItemLocationPairing(&BottomOfTheWell_LikeLikeChest,            []{return SmallKeys(BottomOfTheWellKeys, 3) && (LogicLensBotw || CanUse(CanUseItem::Lens_of_Truth));}),
+                  ItemLocationPairing(&BottomOfTheWell_GS_WestInnerRoom,         []{return Boomerang && (LogicLensBotw || CanUse(CanUseItem::Lens_of_Truth)) && SmallKeys(BottomOfTheWellKeys, 3);}),
+                  ItemLocationPairing(&BottomOfTheWell_GS_EastInnerRoom,         []{return Boomerang && (LogicLensBotw || CanUse(CanUseItem::Lens_of_Truth)) && SmallKeys(BottomOfTheWellKeys, 3);}),
+                  ItemLocationPairing(&BottomOfTheWell_GS_LikeLikeCage,          []{return SmallKeys(BottomOfTheWellKeys, 3) && (LogicLensBotw || CanUse(CanUseItem::Lens_of_Truth)) && Boomerang;}),
                 }, {
                   //Exits
                   ExitPairing::Both(&BottomOfTheWell, []{return true;}),
@@ -2198,7 +2198,7 @@ namespace Exits { //name, scene, hint, events, locations, exits
   Exit IceCavern_Beginning = Exit("Ice Cavern Beginning", "Ice Cavern", "", NO_DAY_NIGHT_CYCLE, {}, {}, {
                   //Exits
                   ExitPairing::Both(&ZF_Main,        []{return true;}),
-                  ExitPairing::Both(&IceCavern_Main, []{return IsAdult || HasExplosives || CanUse("Dins Fire");}),
+                  ExitPairing::Both(&IceCavern_Main, []{return IsAdult || HasExplosives || CanUse(CanUseItem::Dins_Fire);}),
   });
 
   Exit IceCavern_Main = Exit("Ice Cavern", "Ice Cavern", "", NO_DAY_NIGHT_CYCLE, {
@@ -2208,8 +2208,8 @@ namespace Exits { //name, scene, hint, events, locations, exits
                   //Locations
                   ItemLocationPairing(&IceCavern_MapChest,              []{return BlueFire && IsAdult;}),
                   ItemLocationPairing(&IceCavern_CompassChest,          []{return BlueFire;}),
-                  ItemLocationPairing(&IceCavern_IronBootsChest,        []{return BlueFire && (IsAdult || Slingshot || Sticks || KokiriSword || CanUse("Dins Fire"));}),
-                  ItemLocationPairing(&SheikInIceCavern,                []{return BlueFire && (IsAdult || Slingshot || Sticks || KokiriSword || CanUse("Dins Fire"));}),
+                  ItemLocationPairing(&IceCavern_IronBootsChest,        []{return BlueFire && (IsAdult || Slingshot || Sticks || KokiriSword || CanUse(CanUseItem::Dins_Fire));}),
+                  ItemLocationPairing(&SheikInIceCavern,                []{return BlueFire && (IsAdult || Slingshot || Sticks || KokiriSword || CanUse(CanUseItem::Dins_Fire));}),
                   ItemLocationPairing(&IceCavern_FreestandingPoH,       []{return BlueFire;}),
                   ItemLocationPairing(&IceCavern_GS_SpinningScytheRoom, []{return HookshotOrBoomerang;}),
                   ItemLocationPairing(&IceCavern_GS_HeartPieceRoom,     []{return BlueFire && HookshotOrBoomerang;}),
@@ -2218,21 +2218,21 @@ namespace Exits { //name, scene, hint, events, locations, exits
 
   Exit GerudoTrainingGrounds_Lobby = Exit ("Gerudo Training Grounds Lobby", "Gerudo Training Grounds", "", NO_DAY_NIGHT_CYCLE, {}, {
                   //Locations
-                  ItemLocationPairing(&GerudoTrainingGrounds_LobbyLeftChest,  []{return CanUse("Bow") || CanUse("Slingshot");}),
-                  ItemLocationPairing(&GerudoTrainingGrounds_LobbyRightChest, []{return CanUse("Bow") || CanUse("Slingshot");}),
+                  ItemLocationPairing(&GerudoTrainingGrounds_LobbyLeftChest,  []{return CanUse(CanUseItem::Bow) || CanUse(CanUseItem::Slingshot);}),
+                  ItemLocationPairing(&GerudoTrainingGrounds_LobbyRightChest, []{return CanUse(CanUseItem::Bow) || CanUse(CanUseItem::Slingshot);}),
                   ItemLocationPairing(&GerudoTrainingGrounds_StalfosChest,    []{return IsAdult || KokiriSword;}),
                   ItemLocationPairing(&GerudoTrainingGrounds_BeamosChest,     []{return HasExplosives && (IsAdult || KokiriSword);}),
                 }, {
                   //Exits
                   ExitPairing::Both(&GF_Main,                              []{return true;}),
-                  ExitPairing::Both(&GerudoTrainingGrounds_HeavyBlockRoom, []{return (IsAdult || KokiriSword) && (CanUse("Hookshot") || LogicGtgWithoutHookshot);}),
+                  ExitPairing::Both(&GerudoTrainingGrounds_HeavyBlockRoom, []{return (IsAdult || KokiriSword) && (CanUse(CanUseItem::Hookshot) || LogicGtgWithoutHookshot);}),
                   ExitPairing::Both(&GerudoTrainingGrounds_LavaRoom,       []{return (IsAdult || KokiriSword) && HasExplosives;}),
                   ExitPairing::Both(&GerudoTrainingGrounds_CentralMaze,    []{return true;}),
   });
 
   Exit GerudoTrainingGrounds_CentralMaze = Exit ("Gerudo Training Grounds Central Maze", "Gerudo Training Grounds", "", NO_DAY_NIGHT_CYCLE, {}, {
                   //Locations
-                  ItemLocationPairing(&GerudoTrainingGrounds_HiddenCeilingChest,  []{return SmallKeys(GerudoTrainingGroundsKeys, 3) && (LogicLensGtg || CanUse("Lens of Truth"));}),
+                  ItemLocationPairing(&GerudoTrainingGrounds_HiddenCeilingChest,  []{return SmallKeys(GerudoTrainingGroundsKeys, 3) && (LogicLensGtg || CanUse(CanUseItem::Lens_of_Truth));}),
                   ItemLocationPairing(&GerudoTrainingGrounds_MazePathFirstChest,  []{return SmallKeys(GerudoTrainingGroundsKeys, 4);}),
                   ItemLocationPairing(&GerudoTrainingGrounds_MazePathSecondChest, []{return SmallKeys(GerudoTrainingGroundsKeys, 6);}),
                   ItemLocationPairing(&GerudoTrainingGrounds_MazePathThirdChest,  []{return SmallKeys(GerudoTrainingGroundsKeys, 7);}),
@@ -2249,32 +2249,32 @@ namespace Exits { //name, scene, hint, events, locations, exits
                   ItemLocationPairing(&GerudoTrainingGrounds_FreestandingKey,       []{return true;}),
                 }, {
                   //Exits
-                  ExitPairing::Both(&GerudoTrainingGrounds_HammerRoom, []{return CanUse("Hookshot");}),
+                  ExitPairing::Both(&GerudoTrainingGrounds_HammerRoom, []{return CanUse(CanUseItem::Hookshot);}),
                   ExitPairing::Both(&GerudoTrainingGrounds_LavaRoom,   []{return true;}),
   });
 
   Exit GerudoTrainingGrounds_LavaRoom = Exit("Gerudo Training Grounds Lava Room", "Gerudo Training Grounds", "", NO_DAY_NIGHT_CYCLE, {}, {
                   //Locations
-                  ItemLocationPairing(&GerudoTrainingGrounds_UnderwaterSilverRupeeChest, []{return CanUse("Hookshot") && CanPlay(SongOfTime) && IronBoots && (LogicFewerTunicRequirements || CanUse("Zora Tunic"));}),
+                  ItemLocationPairing(&GerudoTrainingGrounds_UnderwaterSilverRupeeChest, []{return CanUse(CanUseItem::Hookshot) && CanPlay(SongOfTime) && IronBoots && (LogicFewerTunicRequirements || CanUse(CanUseItem::Zora_Tunic));}),
                 }, {
                   //Exits
                   ExitPairing::Both(&GerudoTrainingGrounds_CentralMazeRight, []{return CanPlay(SongOfTime) || IsChild;}),
-                  ExitPairing::Both(&GerudoTrainingGrounds_HammerRoom,       []{return CanUse("Longshot")  || (CanUse("Hover Boots") && CanUse("Hookshot"));}),
+                  ExitPairing::Both(&GerudoTrainingGrounds_HammerRoom,       []{return CanUse(CanUseItem::Longshot)  || (CanUse(CanUseItem::Hover_Boots) && CanUse(CanUseItem::Hookshot));}),
   });
 
   Exit GerudoTrainingGrounds_HammerRoom = Exit("Gerudo Training Grounds Hammer Room", "Gerudo Training Grounds", "", NO_DAY_NIGHT_CYCLE, {}, {
                   //Locations
                   ItemLocationPairing(&GerudoTrainingGrounds_HammerRoomClearChest,  []{return true;}),
-                  ItemLocationPairing(&GerudoTrainingGrounds_HammerRoomSwitchChest, []{return CanUse("Hammer");})
+                  ItemLocationPairing(&GerudoTrainingGrounds_HammerRoomSwitchChest, []{return CanUse(CanUseItem::Hammer);})
                 }, {
                   //Exits
-                  ExitPairing::Both(&GerudoTrainingGrounds_EyeStatueLower, []{return CanUse("Hammer") && Bow;}),
+                  ExitPairing::Both(&GerudoTrainingGrounds_EyeStatueLower, []{return CanUse(CanUseItem::Hammer) && Bow;}),
                   ExitPairing::Both(&GerudoTrainingGrounds_LavaRoom,       []{return true;}),
   });
 
   Exit GerudoTrainingGrounds_EyeStatueLower = Exit("Gerudo Training Grounds Eye Statue Lower", "Gerudo Training Grounds", "", NO_DAY_NIGHT_CYCLE, {}, {
                   //Locations
-                  ItemLocationPairing(&GerudoTrainingGrounds_EyeStatueChest, []{return CanUse("Bow");}),
+                  ItemLocationPairing(&GerudoTrainingGrounds_EyeStatueChest, []{return CanUse(CanUseItem::Bow);}),
                 }, {
                   //Exits
                   ExitPairing::Both(&GerudoTrainingGrounds_HammerRoom, []{return true;}),
@@ -2282,7 +2282,7 @@ namespace Exits { //name, scene, hint, events, locations, exits
 
   Exit GerudoTrainingGrounds_EyeStatueUpper = Exit("Gerudo Training Grounds Eye Statue Upper", "Gerudo Training Grounds", "", NO_DAY_NIGHT_CYCLE, {}, {
                   //Locations
-                  ItemLocationPairing(&GerudoTrainingGrounds_NearScarecrowChest, []{return CanUse("Bow");})
+                  ItemLocationPairing(&GerudoTrainingGrounds_NearScarecrowChest, []{return CanUse(CanUseItem::Bow);})
                 }, {
                   //Exits
                   ExitPairing::Both(&GerudoTrainingGrounds_EyeStatueLower, []{return true;}),
@@ -2293,8 +2293,8 @@ namespace Exits { //name, scene, hint, events, locations, exits
                   ItemLocationPairing(&GerudoTrainingGrounds_BeforeHeavyBlockChest, []{return true;})
                 }, {
                   //Exits
-                  ExitPairing::Both(&GerudoTrainingGrounds_EyeStatueUpper, []{return (LogicLensGtg || CanUse("Lens of Truth")) && (CanUse("Hookshot") || (LogicGtgFakeWall && CanUse("Hover Boots")));}),
-                  ExitPairing::Both(&GerudoTrainingGrounds_LikeLikeRoom,   []{return (LogicLensGtg || CanUse("Lens of Truth")) && (CanUse("Hookshot") || (LogicGtgFakeWall && CanUse("Hover Boots"))) && CanUse("Silver Gauntlets");}),
+                  ExitPairing::Both(&GerudoTrainingGrounds_EyeStatueUpper, []{return (LogicLensGtg || CanUse(CanUseItem::Lens_of_Truth)) && (CanUse(CanUseItem::Hookshot) || (LogicGtgFakeWall && CanUse(CanUseItem::Hover_Boots)));}),
+                  ExitPairing::Both(&GerudoTrainingGrounds_LikeLikeRoom,   []{return (LogicLensGtg || CanUse(CanUseItem::Lens_of_Truth)) && (CanUse(CanUseItem::Hookshot) || (LogicGtgFakeWall && CanUse(CanUseItem::Hover_Boots))) && CanUse(CanUseItem::Silver_Gauntlets);}),
   });
 
   Exit GerudoTrainingGrounds_LikeLikeRoom = Exit("Gerudo Training Grounds Like Like Room", "Gerudo Training Grounds", "", NO_DAY_NIGHT_CYCLE, {}, {
@@ -2313,14 +2313,14 @@ namespace Exits { //name, scene, hint, events, locations, exits
                   ExitPairing::Both(&GanonsCastle_WaterTrial,  []{return true;}),
                   ExitPairing::Both(&GanonsCastle_ShadowTrial, []{return true;}),
                   ExitPairing::Both(&GanonsCastle_SpiritTrial, []{return true;}),
-                  ExitPairing::Both(&GanonsCastle_LightTrial,  []{return CanUse("Golden Gauntlets");}),
+                  ExitPairing::Both(&GanonsCastle_LightTrial,  []{return CanUse(CanUseItem::Golden_Gauntlets);}),
                   ExitPairing::Both(&GanonsCastle_Tower,       []{return (ForestTrialClear || ForestTrialSkip) &&
                                                                          (FireTrialClear   || FireTrialSkip)   &&
                                                                          (WaterTrialClear  || WaterTrialSkip)  &&
                                                                          (ShadowTrialClear || ShadowTrialSkip) &&
                                                                          (SpiritTrialClear || SpiritTrialSkip) &&
                                                                          (LightTrialClear  || LightTrialSkip);}),
-                  ExitPairing::Both(&GanonsCastle_DekuScrubs,  []{return LogicLensCastle || CanUse("Lens of Truth");}),
+                  ExitPairing::Both(&GanonsCastle_DekuScrubs,  []{return LogicLensCastle || CanUse(CanUseItem::Lens_of_Truth);}),
   });
 
   Exit GanonsCastle_DekuScrubs = Exit("Ganon's Castle Deku Scrubs", "Ganon's Castle", "", NO_DAY_NIGHT_CYCLE, {
@@ -2336,7 +2336,7 @@ namespace Exits { //name, scene, hint, events, locations, exits
 
   Exit GanonsCastle_ForestTrial = Exit("Ganon's Castle Forest Trial", "Ganon's Castle", "", NO_DAY_NIGHT_CYCLE, {
                   //Events
-                  EventPairing(&ForestTrialClear, []{return CanUse("Light Arrows") && (FireArrows || DinsFire);}),
+                  EventPairing(&ForestTrialClear, []{return CanUse(CanUseItem::Light_Arrows) && (FireArrows || DinsFire);}),
                 }, {
                   //Locations
                   ItemLocationPairing(&GanonsCastle_ForestTrialChest, []{return true;}),
@@ -2344,14 +2344,14 @@ namespace Exits { //name, scene, hint, events, locations, exits
 
   Exit GanonsCastle_FireTrial = Exit("Ganon's Castle Fire Trial", "Ganon's Castle", "", NO_DAY_NIGHT_CYCLE, {
                   //Events
-                  EventPairing(&FireTrialClear, []{return CanUse("Goron Tunic") && CanUse("Golden Gauntlets") && CanUse("Light Arrows") && CanUse("Longshot");}),
+                  EventPairing(&FireTrialClear, []{return CanUse(CanUseItem::Goron_Tunic) && CanUse(CanUseItem::Golden_Gauntlets) && CanUse(CanUseItem::Light_Arrows) && CanUse(CanUseItem::Longshot);}),
   }, {}, {});
 
   Exit GanonsCastle_WaterTrial = Exit("Ganon's Castle Water Trial", "Ganon's Castle", "", NO_DAY_NIGHT_CYCLE, {
                   //Events
                   EventPairing(&BlueFireAccess,  []{return BlueFireAccess || HasBottle;}),
                   EventPairing(&FairyPot,        []{return FairyPot || BlueFire;}),
-                  EventPairing(&WaterTrialClear, []{return BlueFire && Hammer && CanUse("Light Arrows");}),
+                  EventPairing(&WaterTrialClear, []{return BlueFire && Hammer && CanUse(CanUseItem::Light_Arrows);}),
                 }, {
                   //Locations
                   ItemLocationPairing(&GanonsCastle_WaterTrialLeftChest,  []{return true;}),
@@ -2360,26 +2360,26 @@ namespace Exits { //name, scene, hint, events, locations, exits
 
   Exit GanonsCastle_ShadowTrial = Exit("Ganon's Castle Shadow Trial", "Ganon's Castle", "", NO_DAY_NIGHT_CYCLE, {
                   //Events
-                  EventPairing(&ShadowTrialClear, []{return CanUse("Light Arrows") && Hammer && ((FireArrows && (LogicLensCastle || CanUse("Lens of Truth"))) || (CanUse("Longshot") && (HoverBoots || (DinsFire && (LogicLensCastle || CanUse("Lens of Truth"))))));}),
+                  EventPairing(&ShadowTrialClear, []{return CanUse(CanUseItem::Light_Arrows) && Hammer && ((FireArrows && (LogicLensCastle || CanUse(CanUseItem::Lens_of_Truth))) || (CanUse(CanUseItem::Longshot) && (HoverBoots || (DinsFire && (LogicLensCastle || CanUse(CanUseItem::Lens_of_Truth))))));}),
                 }, {
                   //Locations
-                  ItemLocationPairing(&GanonsCastle_ShadowTrialFrontChest,           []{return CanUse("Fire Arrows") || Hookshot || HoverBoots || CanPlay(SongOfTime);}),
-                  ItemLocationPairing(&GanonsCastle_ShadowTrialGoldenGauntletsChest, []{return CanUse("Fire Arrows") || (CanUse("Longshot") && (HoverBoots || CanUse("Dins Fire")));}),
+                  ItemLocationPairing(&GanonsCastle_ShadowTrialFrontChest,           []{return CanUse(CanUseItem::Fire_Arrows) || Hookshot || HoverBoots || CanPlay(SongOfTime);}),
+                  ItemLocationPairing(&GanonsCastle_ShadowTrialGoldenGauntletsChest, []{return CanUse(CanUseItem::Fire_Arrows) || (CanUse(CanUseItem::Longshot) && (HoverBoots || CanUse(CanUseItem::Dins_Fire)));}),
   }, {});
 
   Exit GanonsCastle_SpiritTrial = Exit("Ganon's Castle Spirit Trial", "Ganon's Castle", "", NO_DAY_NIGHT_CYCLE, {
                   //Events
                   EventPairing(&NutPot,           []{return NutPot || ((LogicSpiritTrialHookshot || Hookshot) && HasBombchus && Bow && MirrorShield);}),
-                  EventPairing(&SpiritTrialClear, []{return CanUse("Light Arrows")  && MirrorShield && HasBombchus && (LogicSpiritTrialHookshot || Hookshot);}),
+                  EventPairing(&SpiritTrialClear, []{return CanUse(CanUseItem::Light_Arrows)  && MirrorShield && HasBombchus && (LogicSpiritTrialHookshot || Hookshot);}),
                 }, {
                   //Locations
                   ItemLocationPairing(&GanonsCastle_SpiritTrialCrystalSwitchChest, []{return LogicSpiritTrialHookshot || Hookshot;}),
-                  ItemLocationPairing(&GanonsCastle_SpiritTrialInvisibleChest,     []{return (LogicSpiritTrialHookshot || Hookshot) && HasBombchus && (LogicLensCastle || CanUse("Lens of Truth"));}),
+                  ItemLocationPairing(&GanonsCastle_SpiritTrialInvisibleChest,     []{return (LogicSpiritTrialHookshot || Hookshot) && HasBombchus && (LogicLensCastle || CanUse(CanUseItem::Lens_of_Truth));}),
   }, {});
 
   Exit GanonsCastle_LightTrial = Exit("Ganon's Castle Light Trial", "Ganon's Castle", "", NO_DAY_NIGHT_CYCLE, {
                   //Events
-                  EventPairing(&LightTrialClear, []{return CanUse("Light Arrows") && Hookshot && SmallKeys(GanonsCastleKeys, 2) && (LogicLensCastle || CanUse("Lens of Truth"));}),
+                  EventPairing(&LightTrialClear, []{return CanUse(CanUseItem::Light_Arrows) && Hookshot && SmallKeys(GanonsCastleKeys, 2) && (LogicLensCastle || CanUse(CanUseItem::Lens_of_Truth));}),
                 }, {
                   //Locations
                   ItemLocationPairing(&GanonsCastle_LightTrialFirstLeftChest,        []{return true;}),
@@ -2388,7 +2388,7 @@ namespace Exits { //name, scene, hint, events, locations, exits
                   ItemLocationPairing(&GanonsCastle_LightTrialFirstRightChest,       []{return true;}),
                   ItemLocationPairing(&GanonsCastle_LightTrialSecondRightChest,      []{return true;}),
                   ItemLocationPairing(&GanonsCastle_LightTrialThirdRightChest,       []{return true;}),
-                  ItemLocationPairing(&GanonsCastle_LightTrialInvisibleEnemiesChest, []{return LogicLensCastle || CanUse("Lens of Truth");}),
+                  ItemLocationPairing(&GanonsCastle_LightTrialInvisibleEnemiesChest, []{return LogicLensCastle || CanUse(CanUseItem::Lens_of_Truth);}),
                   ItemLocationPairing(&GanonsCastle_LightTrialLullabyChest,          []{return CanPlay(ZeldasLullaby) && SmallKeys(GanonsCastleKeys, 1);}),
   }, {});
 
@@ -2396,7 +2396,7 @@ namespace Exits { //name, scene, hint, events, locations, exits
                   //Locations
                   ItemLocationPairing(&GanonsCastle_BossKeyChest, []{return true;}),
                   //Ganondorf Hint
-                  ItemLocationPairing(&Ganon, []{return BossKeyGanonsCastle && CanUse("Light Arrows");}),
+                  ItemLocationPairing(&Ganon, []{return BossKeyGanonsCastle && CanUse(CanUseItem::Light_Arrows);}),
   }, {});
 
   /*---------------------------
@@ -2406,26 +2406,26 @@ namespace Exits { //name, scene, hint, events, locations, exits
   Exit DekuTree_MQ_Lobby = Exit("Deku Tree MQ Lobby", "Deku Tree", "", NO_DAY_NIGHT_CYCLE, {
     //Events
     EventPairing(&DekuBabaSticks, []{return DekuBabaSticks || (IsAdult || KokiriSword || Boomerang);}),
-    EventPairing(&DekuBabaNuts,   []{return DekuBabaNuts   || (IsAdult || KokiriSword || Slingshot || Sticks || HasExplosives || CanUse("Dins Fire"));}),
+    EventPairing(&DekuBabaNuts,   []{return DekuBabaNuts   || (IsAdult || KokiriSword || Slingshot || Sticks || HasExplosives || CanUse(CanUseItem::Dins_Fire));}),
   }, {
     //Locations
     ItemLocationPairing(&DekuTree_MQ_MapChest,               []{return true;}),
     ItemLocationPairing(&DekuTree_MQ_SlingshotChest,         []{return IsAdult || CanChildAttack;}),
-    ItemLocationPairing(&DekuTree_MQ_SlingshotRoomBackChest, []{return HasFireSourceWithTorch || CanUse("Bow");}),
-    ItemLocationPairing(&DekuTree_MQ_BasementChest,          []{return HasFireSourceWithTorch || CanUse("Bow");}),
+    ItemLocationPairing(&DekuTree_MQ_SlingshotRoomBackChest, []{return HasFireSourceWithTorch || CanUse(CanUseItem::Bow);}),
+    ItemLocationPairing(&DekuTree_MQ_BasementChest,          []{return HasFireSourceWithTorch || CanUse(CanUseItem::Bow);}),
     ItemLocationPairing(&DekuTree_MQ_GS_Lobby,               []{return IsAdult || CanChildAttack;}),
   }, {
     //Exits
     ExitPairing(&KF_OutsideDekuTree,            []{return true;}),
-    ExitPairing(&DekuTree_MQ_CompassRoom,       []{return (CanUse("Slingshot") || CanUse("Bow")) && (HasFireSourceWithTorch || CanUse("Bow"));}),
-    ExitPairing(&DekuTree_MQ_BasementWaterRoom, []{return (CanUse("Slingshot") || CanUse("Bow")) && HasFireSourceWithTorch;}),
+    ExitPairing(&DekuTree_MQ_CompassRoom,       []{return (CanUse(CanUseItem::Slingshot) || CanUse(CanUseItem::Bow)) && (HasFireSourceWithTorch || CanUse(CanUseItem::Bow));}),
+    ExitPairing(&DekuTree_MQ_BasementWaterRoom, []{return (CanUse(CanUseItem::Slingshot) || CanUse(CanUseItem::Bow)) && HasFireSourceWithTorch;}),
     ExitPairing(&DekuTree_MQ_BasementLedge,     []{return LogicDekuB1Skip || IsAdult;}),
   });
 
   Exit DekuTree_MQ_CompassRoom = Exit("Deku Tree MQ Compass Room", "Deku Tree", "", NO_DAY_NIGHT_CYCLE, {}, {
     //Locations
     ItemLocationPairing(&DekuTree_MQ_CompassChest, []{return true;}),
-    ItemLocationPairing(&DekuTree_MQ_GS_CompassRoom, []{return (CanUse("Hookshot") || CanUse("Boomerang")) && (HasBombchus || (Bombs && (IsAdult || CanPlay(SongOfTime))));}),
+    ItemLocationPairing(&DekuTree_MQ_GS_CompassRoom, []{return (CanUse(CanUseItem::Hookshot) || CanUse(CanUseItem::Boomerang)) && (HasBombchus || (Bombs && (IsAdult || CanPlay(SongOfTime))));}),
   }, {
     //Exits
     ExitPairing(&DekuTree_MQ_Lobby, []{return true;}),
@@ -2443,12 +2443,12 @@ namespace Exits { //name, scene, hint, events, locations, exits
 
   Exit DekuTree_MQ_BasementBackRoom = Exit("Deku Tree MQ Basement Back Room", "Deku Tree", "", NO_DAY_NIGHT_CYCLE, {}, {
     //Locations
-    ItemLocationPairing(&DekuTree_MQ_GS_BasementGravesRoom, []{return CanUse("Longshot") || (CanPlay(SongOfTime) && HookshotOrBoomerang);}),
+    ItemLocationPairing(&DekuTree_MQ_GS_BasementGravesRoom, []{return CanUse(CanUseItem::Longshot) || (CanPlay(SongOfTime) && HookshotOrBoomerang);}),
     ItemLocationPairing(&DekuTree_MQ_GS_BasementBackRoom,   []{return HasFireSourceWithTorch && HookshotOrBoomerang;})
   }, {
     //Exits
     ExitPairing(&DekuTree_MQ_BasementLedge,     []{return IsChild;}),
-    ExitPairing(&DekuTree_MQ_BasementWaterRoom, []{return CanUse("Kokiri Sword") || CanUseProjectile || (Nuts && CanUse("Sticks"));}),
+    ExitPairing(&DekuTree_MQ_BasementWaterRoom, []{return CanUse(CanUseItem::Kokiri_Sword) || CanUseProjectile || (Nuts && CanUse(CanUseItem::Sticks));}),
   });
 
   Exit DekuTree_MQ_BasementLedge = Exit("Deku Tree MQ Basement Ledge", "Deku Tree", "", NO_DAY_NIGHT_CYCLE, {
@@ -2479,10 +2479,10 @@ namespace Exits { //name, scene, hint, events, locations, exits
     //Locations
     ItemLocationPairing(&DodongosCavern_MQ_MapChest,               []{return true;}),
     ItemLocationPairing(&DodongosCavern_MQ_CompassChest,           []{return IsAdult || CanChildAttack || Nuts;}),
-    ItemLocationPairing(&DodongosCavern_MQ_LarvaeRoomChest,        []{return CanUse("Sticks") || HasFireSource;}),
-    ItemLocationPairing(&DodongosCavern_MQ_TorchPuzzleRoomChest,   []{return CanBlastOrSmash || CanUse("Sticks") || CanUse("Dins Fire") || (IsAdult && (LogicDCJump || HoverBoots || Hookshot));}),
+    ItemLocationPairing(&DodongosCavern_MQ_LarvaeRoomChest,        []{return CanUse(CanUseItem::Sticks) || HasFireSource;}),
+    ItemLocationPairing(&DodongosCavern_MQ_TorchPuzzleRoomChest,   []{return CanBlastOrSmash || CanUse(CanUseItem::Sticks) || CanUse(CanUseItem::Dins_Fire) || (IsAdult && (LogicDCJump || HoverBoots || Hookshot));}),
     ItemLocationPairing(&DodongosCavern_MQ_GS_SongOfTimeBlockRoom, []{return CanPlay(SongOfTime) && (CanChildAttack || IsAdult);}),
-    ItemLocationPairing(&DodongosCavern_MQ_GS_LarvaeRoom,          []{return CanUse("Sticks") || HasFireSource;}),
+    ItemLocationPairing(&DodongosCavern_MQ_GS_LarvaeRoom,          []{return CanUse(CanUseItem::Sticks) || HasFireSource;}),
     ItemLocationPairing(&DodongosCavern_MQ_GS_LizalfosRoom,        []{return CanBlastOrSmash;}),
     ItemLocationPairing(&DodongosCavern_MQ_DekuScrubLobbyRear,     []{return CanStunDeku;}),
     ItemLocationPairing(&DodongosCavern_MQ_DekuScrubLobbyFront,    []{return CanStunDeku;}),
@@ -2490,11 +2490,11 @@ namespace Exits { //name, scene, hint, events, locations, exits
     //Dodongos Cavern Gossip Stone
   }, {
     //Exits
-    ExitPairing::Both(&DodongosCavern_MQ_LowerRightSide,  []{return CanBlastOrSmash || ((CanUse("Sticks") || CanUse("Dins Fire")) && DamageMultiplier.IsNot(DAMAGEMULTIPLIER_OHKO));}),
+    ExitPairing::Both(&DodongosCavern_MQ_LowerRightSide,  []{return CanBlastOrSmash || ((CanUse(CanUseItem::Sticks) || CanUse(CanUseItem::Dins_Fire)) && DamageMultiplier.IsNot(DAMAGEMULTIPLIER_OHKO));}),
     ExitPairing::Both(&DodongosCavern_MQ_BombBagArea,     []{return IsAdult || HasExplosives;}),
       //Trick: IsAdult || HasExplosives || (LogicDCMQChildBombs && (KokiriSword || Sticks) && DamageMultiplier.IsNot(DAMAGEMULTIPLIER_OHKO))
     ExitPairing::Both(&DodongosCavern_MQ_BossArea,        []{return HasExplosives;}),
-      //Trick: HasExplosives || (LogicDCMQEyes && GoronBracelet && (IsAdult || LogicDCMQChildBack) && (CanUse("Sticks") || CanUse("Dins Fire") || (IsAdult && (LogicDCJump || Hammer || HoverBoots || Hookshot))))
+      //Trick: HasExplosives || (LogicDCMQEyes && GoronBracelet && (IsAdult || LogicDCMQChildBack) && (CanUse(CanUseItem::Sticks) || CanUse(CanUseItem::Dins_Fire) || (IsAdult && (LogicDCJump || Hammer || HoverBoots || Hookshot))))
   });
 
   Exit DodongosCavern_MQ_LowerRightSide = Exit("Dodongos Cavern MQ Lower Right Side", "Dodongos Cavern", "", NO_DAY_NIGHT_CYCLE, {}, {
@@ -2502,13 +2502,13 @@ namespace Exits { //name, scene, hint, events, locations, exits
     ItemLocationPairing(&DodongosCavern_MQ_DekuScrubSideRoomNearLowerLizalfos, []{return CanStunDeku;}),
   }, {
     //Exits
-    ExitPairing::Both(&DodongosCavern_MQ_BombBagArea, []{return (CanUse("Bow") || GoronBracelet || CanUse("Dins Fire") || HasExplosives) && CanUse("Slingshot");}),
+    ExitPairing::Both(&DodongosCavern_MQ_BombBagArea, []{return (CanUse(CanUseItem::Bow) || GoronBracelet || CanUse(CanUseItem::Dins_Fire) || HasExplosives) && CanUse(CanUseItem::Slingshot);}),
   });
 
   Exit DodongosCavern_MQ_BombBagArea = Exit("Dodongos Cavern MQ Bomb Bag Area", "Dodongos Cavern", "", NO_DAY_NIGHT_CYCLE, {}, {
     //Locations
     ItemLocationPairing(&DodongosCavern_MQ_BombBagChest, []{return true;}),
-    ItemLocationPairing(&DodongosCavern_MQ_GS_ScrubRoom, []{return (CanUse("Bow") ||  GoronBracelet || CanUse("Dins Fire") || HasExplosives) && (CanUse("Hookshot") || CanUse("Boomerang"));}),
+    ItemLocationPairing(&DodongosCavern_MQ_GS_ScrubRoom, []{return (CanUse(CanUseItem::Bow) ||  GoronBracelet || CanUse(CanUseItem::Dins_Fire) || HasExplosives) && (CanUse(CanUseItem::Hookshot) || CanUse(CanUseItem::Boomerang));}),
   }, {
     //Exits
     ExitPairing::Both(&DodongosCavern_MQ_LowerRightSide, []{return true;}),
@@ -2532,39 +2532,39 @@ namespace Exits { //name, scene, hint, events, locations, exits
   }, {
     //Locations
     ItemLocationPairing(&JabuJabusBelly_MQ_MapChest,           []{return CanBlastOrSmash;}),
-    ItemLocationPairing(&JabuJabusBelly_MQ_FirstRoomSideChest, []{return CanUse("Slingshot");}),
+    ItemLocationPairing(&JabuJabusBelly_MQ_FirstRoomSideChest, []{return CanUse(CanUseItem::Slingshot);}),
   }, {
     //Exits
     ExitPairing::Both(&ZF_Main,                []{return true;}),
-    ExitPairing::Both(&JabuJabusBelly_MQ_Main, []{return IsChild && CanUse("Slingshot");}),
+    ExitPairing::Both(&JabuJabusBelly_MQ_Main, []{return IsChild && CanUse(CanUseItem::Slingshot);}),
   });
 
   Exit JabuJabusBelly_MQ_Main = Exit("Jabu Jabus Belly MQ Main", "Jabu Jabus Belly", "", NO_DAY_NIGHT_CYCLE, {}, {
     //Locations
     ItemLocationPairing(&JabuJabusBelly_MQ_SecondRoomLowerChest,      []{return true;}),
-    ItemLocationPairing(&JabuJabusBelly_MQ_SecondRoomUpperChest,      []{return CanUse("Hover Boots") || CanUse("Hookshot") || JabuJabusBelly_MQ_BossArea.Adult();}),
+    ItemLocationPairing(&JabuJabusBelly_MQ_SecondRoomUpperChest,      []{return CanUse(CanUseItem::Hover_Boots) || CanUse(CanUseItem::Hookshot) || JabuJabusBelly_MQ_BossArea.Adult();}),
     ItemLocationPairing(&JabuJabusBelly_MQ_CompassChest,              []{return true;}),
     ItemLocationPairing(&JabuJabusBelly_MQ_BasementNearVinesChest,    []{return true;}),
     ItemLocationPairing(&JabuJabusBelly_MQ_BasementNearSwitchesChest, []{return true;}),
     ItemLocationPairing(&JabuJabusBelly_MQ_BoomerangRoomSmallChest,   []{return true;}),
     ItemLocationPairing(&JabuJabusBelly_MQ_BoomerangChest,            []{return true;}),
     ItemLocationPairing(&JabuJabusBelly_MQ_GS_BoomerangChestRoom,     []{return CanPlay(SongOfTime);}),
-      //Trick: CanPlay(SongOfTime) || (LogicJabuMQSoTGS && CanUse("Boomerang"))
+      //Trick: CanPlay(SongOfTime) || (LogicJabuMQSoTGS && CanUse(CanUseItem::Boomerang))
   }, {
     //Exits
     ExitPairing::Both(&JabuJabusBelly_MQ_Beginning, []{return true;}),
-    ExitPairing::Both(&JabuJabusBelly_MQ_Depths,    []{return HasExplosives && CanUse("Boomerang");}),
+    ExitPairing::Both(&JabuJabusBelly_MQ_Depths,    []{return HasExplosives && CanUse(CanUseItem::Boomerang);}),
   });
 
   Exit JabuJabusBelly_MQ_Depths = Exit("Jabu Jabus Belly MQ Depths", "Jabu Jabus Belly", "", NO_DAY_NIGHT_CYCLE, {}, {
     //Locations
     ItemLocationPairing(&JabuJabusBelly_MQ_FallingLikeLikeRoomChest, []{return true;}),
-    ItemLocationPairing(&JabuJabusBelly_MQ_GS_TailPasaranRoom,       []{return Sticks || CanUse("Dins Fire");}),
-    ItemLocationPairing(&JabuJabusBelly_MQ_GS_InvisibleEnemiesRoom,  []{return (LogicLensJabuMQ || CanUse("Lens of Truth")) || (JabuJabusBelly_MQ_Main.Adult() && CanUse("Hover Boots") && CanUse("Hookshot"));}),
+    ItemLocationPairing(&JabuJabusBelly_MQ_GS_TailPasaranRoom,       []{return Sticks || CanUse(CanUseItem::Dins_Fire);}),
+    ItemLocationPairing(&JabuJabusBelly_MQ_GS_InvisibleEnemiesRoom,  []{return (LogicLensJabuMQ || CanUse(CanUseItem::Lens_of_Truth)) || (JabuJabusBelly_MQ_Main.Adult() && CanUse(CanUseItem::Hover_Boots) && CanUse(CanUseItem::Hookshot));}),
   }, {
     //Exits
     ExitPairing::Both(&JabuJabusBelly_MQ_Main,     []{return true;}),
-    ExitPairing::Both(&JabuJabusBelly_MQ_BossArea, []{return Sticks || (CanUse("Dins Fire") && KokiriSword);}),
+    ExitPairing::Both(&JabuJabusBelly_MQ_BossArea, []{return Sticks || (CanUse(CanUseItem::Dins_Fire) && KokiriSword);}),
   });
 
   Exit JabuJabusBelly_MQ_BossArea = Exit("Jabu Jabus Belly MQ Boss Area", "Jabu Jabus Belly", "", NO_DAY_NIGHT_CYCLE, {
@@ -2584,8 +2584,8 @@ namespace Exits { //name, scene, hint, events, locations, exits
 
   Exit ForestTemple_MQ_Lobby = Exit("Forest Temple MQ Lobby", "Forest Temple", "", NO_DAY_NIGHT_CYCLE, {}, {
     //Locations
-    ItemLocationPairing(&ForestTemple_MQ_FirstRoomChest,  []{return IsAdult || Bombs || CanUse("Sticks") || Nuts || CanUse("Boomerang") || CanUse("Dins Fire") || KokiriSword || CanUse("Slingshot");}),
-    ItemLocationPairing(&ForestTemple_MQ_GS_FirstHallway, []{return CanUse("Hookshot") || CanUse("Boomerang");}),
+    ItemLocationPairing(&ForestTemple_MQ_FirstRoomChest,  []{return IsAdult || Bombs || CanUse(CanUseItem::Sticks) || Nuts || CanUse(CanUseItem::Boomerang) || CanUse(CanUseItem::Dins_Fire) || KokiriSword || CanUse(CanUseItem::Slingshot);}),
+    ItemLocationPairing(&ForestTemple_MQ_GS_FirstHallway, []{return CanUse(CanUseItem::Hookshot) || CanUse(CanUseItem::Boomerang);}),
   }, {
     //Exits
     ExitPairing::Both(&SFM_Main,                    []{return true;}),
@@ -2597,16 +2597,16 @@ namespace Exits { //name, scene, hint, events, locations, exits
     EventPairing(&FairyPot, []{return true;}),
   }, {
     //Locations
-    ItemLocationPairing(&ForestTemple_MQ_WolfosChest,      []{return (CanPlay(SongOfTime) || IsChild) && (IsAdult || CanUse("Dins Fire") || CanUse("Sticks") || CanUse("Slingshot") || KokiriSword);}),
+    ItemLocationPairing(&ForestTemple_MQ_WolfosChest,      []{return (CanPlay(SongOfTime) || IsChild) && (IsAdult || CanUse(CanUseItem::Dins_Fire) || CanUse(CanUseItem::Sticks) || CanUse(CanUseItem::Slingshot) || KokiriSword);}),
     ItemLocationPairing(&ForestTemple_MQ_GS_BlockPushRoom, []{return IsAdult || KokiriSword;}),
   }, {
     //Exits
-    ExitPairing::Both(&ForestTemple_MQ_NWOutdoors,       []{return CanUse("Bow") || CanUse("Slingshot");}),
-    ExitPairing::Both(&ForestTemple_MQ_NEOutdoors,       []{return CanUse("Bow") || CanUse("Slingshot");}), //This is as far as child can get
+    ExitPairing::Both(&ForestTemple_MQ_NWOutdoors,       []{return CanUse(CanUseItem::Bow) || CanUse(CanUseItem::Slingshot);}),
+    ExitPairing::Both(&ForestTemple_MQ_NEOutdoors,       []{return CanUse(CanUseItem::Bow) || CanUse(CanUseItem::Slingshot);}), //This is as far as child can get
     ExitPairing::Both(&ForestTemple_MQ_AfterBlockPuzzle, []{return IsAdult && GoronBracelet;}),
-      //Trick: IsAdult && (GoronBracelet || (LogicForestMQBlockPuzzle && HasBombchus && CanUse("Hookshot")))
+      //Trick: IsAdult && (GoronBracelet || (LogicForestMQBlockPuzzle && HasBombchus && CanUse(CanUseItem::Hookshot)))
     ExitPairing::Both(&ForestTemple_MQ_OutdoorLedge,     []{return false;}),
-      //Trick: (LogicForestMQHallwaySwitchJumpslash && CanUse("Hover Boots")) || (LogicForestMQHallwaySwitchHookshot && CanUse("Hookshot"))
+      //Trick: (LogicForestMQHallwaySwitchJumpslash && CanUse(CanUseItem::Hover_Boots)) || (LogicForestMQHallwaySwitchHookshot && CanUse(CanUseItem::Hookshot))
     ExitPairing::Both(&ForestTemple_MQ_BossRegion,       []{return ForestTempleJoAndBeth && ForestTempleAmyAndMeg;}),
   });
 
@@ -2617,7 +2617,7 @@ namespace Exits { //name, scene, hint, events, locations, exits
     //Exits
     ExitPairing::Both(&ForestTemple_MQ_BowRegion,    []{return SmallKeys(ForestTempleKeys, 4);}),
     ExitPairing::Both(&ForestTemple_MQ_OutdoorLedge, []{return SmallKeys(ForestTempleKeys, 3);}),
-      //Trick: SmallKeys(ForestTempleKeys, 3) || (LogicForestMQHallwaySwitchJumpslash && (CanUse("Hookshot") || LogicForestOutsideBackdoor))
+      //Trick: SmallKeys(ForestTempleKeys, 3) || (LogicForestMQHallwaySwitchJumpslash && (CanUse(CanUseItem::Hookshot) || LogicForestOutsideBackdoor))
     ExitPairing::Both(&ForestTemple_MQ_NWOutdoors,   []{return SmallKeys(ForestTempleKeys, 2);}),
   });
 
@@ -2634,24 +2634,24 @@ namespace Exits { //name, scene, hint, events, locations, exits
     ItemLocationPairing(&ForestTemple_MQ_GS_LevelIslandCourtyard, []{return true;}),
   }, {
     //Exits
-    ExitPairing::Both(&ForestTemple_MQ_NEOutdoors,        []{return CanUse("Iron Boots") || CanUse("Longshot") || ProgressiveScale >= 2;}),
-      //Trick: CanUse("Iron Boots") || CanUse("Longshot") || ProgressiveScale >= 2 || (LogicForestMQWellSwim && CanUse("Hookshot"))
-    ExitPairing::Both(&ForestTemple_MQ_OutdoorsTopLedges, []{return CanUse("FireArrows");}),
+    ExitPairing::Both(&ForestTemple_MQ_NEOutdoors,        []{return CanUse(CanUseItem::Iron_Boots) || CanUse(CanUseItem::Longshot) || ProgressiveScale >= 2;}),
+      //Trick: CanUse(CanUseItem::Iron_Boots) || CanUse(CanUseItem::Longshot) || ProgressiveScale >= 2 || (LogicForestMQWellSwim && CanUse(CanUseItem::Hookshot))
+    ExitPairing::Both(&ForestTemple_MQ_OutdoorsTopLedges, []{return CanUse(CanUseItem::Fire_Arrows);}),
   });
 
   Exit ForestTemple_MQ_NEOutdoors = Exit("Forest Temple MQ NE Outdoors", "Forest Temple", "", NO_DAY_NIGHT_CYCLE, {
     //Events
     EventPairing(&DekuBabaSticks, []{return DekuBabaSticks || (IsAdult || KokiriSword || Boomerang);}),
-    EventPairing(&DekuBabaNuts,   []{return DekuBabaNuts   || (IsAdult || KokiriSword || Slingshot || Sticks || HasExplosives || CanUse("Dins Fire"));}),
+    EventPairing(&DekuBabaNuts,   []{return DekuBabaNuts   || (IsAdult || KokiriSword || Slingshot || Sticks || HasExplosives || CanUse(CanUseItem::Dins_Fire));}),
   }, {
     //Locations
-    ItemLocationPairing(&ForestTemple_MQ_WellChest,                []{return CanUse("Bow") || CanUse("Slingshot");}),
-    ItemLocationPairing(&ForestTemple_MQ_GS_RaisedIslandCourtyard, []{return CanUse("Hookshot") || CanUse("Boomerang") || (CanUse("Fire Arrows") && (CanPlay(SongOfTime) || (CanUse("HoverBoots") && LogicForestDoorFrame)));}),
-    ItemLocationPairing(&ForestTemple_MQ_GS_Well,                  []{return (CanUse("Iron Boots") && CanUse("Hookshot")) || CanUse("Bow") || CanUse("Slingshot");}),
+    ItemLocationPairing(&ForestTemple_MQ_WellChest,                []{return CanUse(CanUseItem::Bow) || CanUse(CanUseItem::Slingshot);}),
+    ItemLocationPairing(&ForestTemple_MQ_GS_RaisedIslandCourtyard, []{return CanUse(CanUseItem::Hookshot) || CanUse(CanUseItem::Boomerang) || (CanUse(CanUseItem::Fire_Arrows) && (CanPlay(SongOfTime) || (CanUse(CanUseItem::Hover_Boots) && LogicForestDoorFrame)));}),
+    ItemLocationPairing(&ForestTemple_MQ_GS_Well,                  []{return (CanUse(CanUseItem::Iron_Boots) && CanUse(CanUseItem::Hookshot)) || CanUse(CanUseItem::Bow) || CanUse(CanUseItem::Slingshot);}),
   }, {
     //Exits
-    ExitPairing::Both(&ForestTemple_MQ_OutdoorsTopLedges, []{return CanUse("Hookshot") && (CanUse("Longshot") || CanUse("Hover Boots") || CanPlay(SongOfTime));}),
-    ExitPairing::Both(&ForestTemple_MQ_NEOutdoorsLedge,   []{return CanUse("Longshot");}),
+    ExitPairing::Both(&ForestTemple_MQ_OutdoorsTopLedges, []{return CanUse(CanUseItem::Hookshot) && (CanUse(CanUseItem::Longshot) || CanUse(CanUseItem::Hover_Boots) || CanPlay(SongOfTime));}),
+    ExitPairing::Both(&ForestTemple_MQ_NEOutdoorsLedge,   []{return CanUse(CanUseItem::Longshot);}),
   });
 
   Exit ForestTemple_MQ_OutdoorsTopLedges = Exit("Forest Temple MQ Outdoors Top Ledges", "Forest Temple", "", NO_DAY_NIGHT_CYCLE, {}, {
@@ -2661,7 +2661,7 @@ namespace Exits { //name, scene, hint, events, locations, exits
     //Exits
     ExitPairing::Both(&ForestTemple_MQ_NEOutdoors,      []{return true;}),
     ExitPairing::Both(&ForestTemple_MQ_NEOutdoorsLedge, []{return false;}),
-      //Trick: LogicForestOutdoorsLedge && CanUse("Hover Boots")
+      //Trick: LogicForestOutdoorsLedge && CanUse(CanUseItem::Hover_Boots)
   });
 
   Exit ForestTemple_MQ_NEOutdoorsLedge = Exit("Forest Temple MQ NE Outdoors Ledge", "Forest Temple", "", NO_DAY_NIGHT_CYCLE, {}, {
@@ -2675,20 +2675,20 @@ namespace Exits { //name, scene, hint, events, locations, exits
 
   Exit ForestTemple_MQ_BowRegion = Exit("Forest Temple MQ Bow Region", "Forest Temple", "", NO_DAY_NIGHT_CYCLE, {
     //Events 
-    EventPairing(&ForestTempleJoAndBeth, []{return ForestTempleJoAndBeth || CanUse("Bow");}),
+    EventPairing(&ForestTempleJoAndBeth, []{return ForestTempleJoAndBeth || CanUse(CanUseItem::Bow);}),
   }, {
     //Locations
     ItemLocationPairing(&ForestTemple_MQ_BowChest,     []{return true;}),
-    ItemLocationPairing(&ForestTemple_MQ_MapChest,     []{return CanUse("Bow");}),
-    ItemLocationPairing(&ForestTemple_MQ_CompassChest, []{return CanUse("Bow");}),
+    ItemLocationPairing(&ForestTemple_MQ_MapChest,     []{return CanUse(CanUseItem::Bow);}),
+    ItemLocationPairing(&ForestTemple_MQ_CompassChest, []{return CanUse(CanUseItem::Bow);}),
   }, {
     //Exits
-    ExitPairing::Both(&ForestTemple_MQ_FallingRoom, []{return SmallKeys(ForestTempleKeys, 5) && (CanUse("Bow") || CanUse("Dins Fire"));}),
+    ExitPairing::Both(&ForestTemple_MQ_FallingRoom, []{return SmallKeys(ForestTempleKeys, 5) && (CanUse(CanUseItem::Bow) || CanUse(CanUseItem::Dins_Fire));}),
   });
 
   Exit ForestTemple_MQ_FallingRoom = Exit("Forest Temple MQ Falling Room", "Forest Temple", "", NO_DAY_NIGHT_CYCLE, {
     //Events 
-    EventPairing(&ForestTempleAmyAndMeg, []{return ForestTempleAmyAndMeg || (CanUse("Bow") && SmallKeys(ForestTempleKeys, 6));}),
+    EventPairing(&ForestTempleAmyAndMeg, []{return ForestTempleAmyAndMeg || (CanUse(CanUseItem::Bow) && SmallKeys(ForestTempleKeys, 6));}),
   }, {
     //Locations
     ItemLocationPairing(&ForestTemple_MQ_FallingCeilingRoomChest, []{return true;}),
@@ -2706,15 +2706,15 @@ namespace Exits { //name, scene, hint, events, locations, exits
 
   Exit FireTemple_MQ_Lower = Exit("Fire Temple MQ Lower", "Fire Temple", "", NO_DAY_NIGHT_CYCLE, {}, {
     //Locations
-    ItemLocationPairing(&FireTemple_MQ_MapRoomSideChest, []{return IsAdult || KokiriSword || Sticks || Slingshot || Bombs || CanUse("Dins Fire");}),
-    ItemLocationPairing(&FireTemple_MQ_NearBossChest,    []{return (LogicFewerTunicRequirements || CanUse("Goron Tunic")) && (CanUse("Hover Boots") || (CanUse("Hookshot") && (CanUse("Fire Arrows") || (CanUse("Dins Fire") && ((DamageMultiplier.IsNot(DAMAGEMULTIPLIER_OHKO) && DamageMultiplier.IsNot(DAMAGEMULTIPLIER_QUADRUPLE)) || CanUse("Goron Tunic") || CanUse("Bow") || CanUse("Longshot"))))));}),
-      //Trick: (LogicFewerTunicRequirements || CanUse("Goron Tunic")) && (((CanUse("Hover Boots") || (LogicFireMQNearBoss && CanUse("Bow"))) && HasFireSource) || (CanUse("Hookshot") && CanUse("Fire Arrows") || (CanUse("Dins Fire") && ((DamageMultiplier.IsNot(DAMAGEMULTIPLIER_OHKO) && DamageMultiplier.IsNot(DAMAGEMULTIPLIER_QUADRUPLE)) || CanUse("Goron Tunic") || CanUse("Bow") || CanUse("Longshot")))))
+    ItemLocationPairing(&FireTemple_MQ_MapRoomSideChest, []{return IsAdult || KokiriSword || Sticks || Slingshot || Bombs || CanUse(CanUseItem::Dins_Fire);}),
+    ItemLocationPairing(&FireTemple_MQ_NearBossChest,    []{return (LogicFewerTunicRequirements || CanUse(CanUseItem::Goron_Tunic)) && (CanUse(CanUseItem::Hover_Boots) || (CanUse(CanUseItem::Hookshot) && (CanUse(CanUseItem::Fire_Arrows) || (CanUse(CanUseItem::Dins_Fire) && ((DamageMultiplier.IsNot(DAMAGEMULTIPLIER_OHKO) && DamageMultiplier.IsNot(DAMAGEMULTIPLIER_QUADRUPLE)) || CanUse(CanUseItem::Goron_Tunic) || CanUse(CanUseItem::Bow) || CanUse(CanUseItem::Longshot))))));}),
+      //Trick: (LogicFewerTunicRequirements || CanUse(CanUseItem::Goron_Tunic)) && (((CanUse(CanUseItem::Hover_Boots) || (LogicFireMQNearBoss && CanUse(CanUseItem::Bow))) && HasFireSource) || (CanUse(CanUseItem::Hookshot) && CanUse(CanUseItem::Fire_Arrows) || (CanUse(CanUseItem::Dins_Fire) && ((DamageMultiplier.IsNot(DAMAGEMULTIPLIER_OHKO) && DamageMultiplier.IsNot(DAMAGEMULTIPLIER_QUADRUPLE)) || CanUse(CanUseItem::Goron_Tunic) || CanUse(CanUseItem::Bow) || CanUse(CanUseItem::Longshot)))))
   }, {
     //Exits
     ExitPairing::Both(&FireTemple_Entrance,           []{return true;}),
-    ExitPairing::Both(&FireTemple_MQ_BossRoom,        []{return CanUse("Goron Tunic") && CanUse("Hammer") && BossKeyFireTemple && ((HasFireSource && (LogicFireBossDoorJump || HoverBoots)) || FireTemple_MQ_Upper.Adult());}),
+    ExitPairing::Both(&FireTemple_MQ_BossRoom,        []{return CanUse(CanUseItem::Goron_Tunic) && CanUse(CanUseItem::Hammer) && BossKeyFireTemple && ((HasFireSource && (LogicFireBossDoorJump || HoverBoots)) || FireTemple_MQ_Upper.Adult());}),
     ExitPairing::Both(&FireTemple_MQ_LowerLockedDoor, []{return SmallKeys(FireTempleKeys, 5) && (IsAdult || KokiriSword);}),
-    ExitPairing::Both(&FireTemple_MQ_BigLavaRoom,     []{return (LogicFewerTunicRequirements || CanUse("Goron Tunic")) && CanUse("Hammer");}),
+    ExitPairing::Both(&FireTemple_MQ_BigLavaRoom,     []{return (LogicFewerTunicRequirements || CanUse(CanUseItem::Goron_Tunic)) && CanUse(CanUseItem::Hammer);}),
   });
 
   Exit FireTemple_MQ_LowerLockedDoor = Exit("Fire Temple MQ Lower Locked Door", "Fire Temple", "", NO_DAY_NIGHT_CYCLE, {
@@ -2723,24 +2723,24 @@ namespace Exits { //name, scene, hint, events, locations, exits
   }, {
     //Locations
     ItemLocationPairing(&FireTemple_MQ_MegatonHammerChest, []{return IsAdult && (HasExplosives || Hammer || Hookshot);}),
-    ItemLocationPairing(&FireTemple_MQ_MapChest,           []{return CanUse("Hammer");}),
+    ItemLocationPairing(&FireTemple_MQ_MapChest,           []{return CanUse(CanUseItem::Hammer);}),
   }, {});
 
   Exit FireTemple_MQ_BigLavaRoom = Exit("Fire Temple MQ Big Lava Room", "Fire Temple", "", NO_DAY_NIGHT_CYCLE, {
     //Events
-    EventPairing(&FairyPot, []{return FairyPot || (HasFireSource && Bow && (CanUse("Hookshot") || LogicFireSongOfTime));}),
-      //Trick: HasFireSource && (Bow || LogicFireMQBKChest) && (CanUse("Hookshot") || LogicFireSongOfTime)
+    EventPairing(&FairyPot, []{return FairyPot || (HasFireSource && Bow && (CanUse(CanUseItem::Hookshot) || LogicFireSongOfTime));}),
+      //Trick: HasFireSource && (Bow || LogicFireMQBKChest) && (CanUse(CanUseItem::Hookshot) || LogicFireSongOfTime)
   }, {
     //Locations
-    ItemLocationPairing(&FireTemple_MQ_BossKeyChest,                []{return HasFireSource && Bow && CanUse("Hookshot");}),
-      //Trick: HasFireSource && (Bow || LogicFireMQBKChest) && CanUse("Hookshot")
-    ItemLocationPairing(&FireTemple_MQ_BigLavaRoomBlockedDoorChest, []{return HasFireSource && HasExplosives && CanUse("Hookshot");}),
-      //Trick: HasFireSource && HasExplosives && (CanUse("Hookshot") || LogicFireMQBlockedChest)
+    ItemLocationPairing(&FireTemple_MQ_BossKeyChest,                []{return HasFireSource && Bow && CanUse(CanUseItem::Hookshot);}),
+      //Trick: HasFireSource && (Bow || LogicFireMQBKChest) && CanUse(CanUseItem::Hookshot)
+    ItemLocationPairing(&FireTemple_MQ_BigLavaRoomBlockedDoorChest, []{return HasFireSource && HasExplosives && CanUse(CanUseItem::Hookshot);}),
+      //Trick: HasFireSource && HasExplosives && (CanUse(CanUseItem::Hookshot) || LogicFireMQBlockedChest)
     ItemLocationPairing(&FireTemple_MQ_GS_BigLavaRoomOpenDoor,      []{return true;}),
   }, {
     //Exits
-    ExitPairing::Both(&FireTemple_MQ_LowerMaze, []{return CanUse("Goron Tunic") && SmallKeys(FireTempleKeys, 2) && HasFireSource;}),
-      //Trick: CanUse("Goron Tunic") && SmallKeys(FireTempleKeys, 2) && (HasFireSource || (LogicFireMQClimb && HoverBoots))
+    ExitPairing::Both(&FireTemple_MQ_LowerMaze, []{return CanUse(CanUseItem::Goron_Tunic) && SmallKeys(FireTempleKeys, 2) && HasFireSource;}),
+      //Trick: CanUse(CanUseItem::Goron_Tunic) && SmallKeys(FireTempleKeys, 2) && (HasFireSource || (LogicFireMQClimb && HoverBoots))
   });
 
   Exit FireTemple_MQ_LowerMaze = Exit("Fire Temple MQ Lower Maze", "Fire Temple", "", NO_DAY_NIGHT_CYCLE, {}, {
@@ -2750,35 +2750,35 @@ namespace Exits { //name, scene, hint, events, locations, exits
       //Trick: HasExplosives && (LogicFireMQMazeSideRoom || FireTemple_MQ_UpperMaze.Adult())
    }, {
     //Exits
-    ExitPairing::Both(&FireTemple_MQ_UpperMaze, []{return HasExplosives && CanUse("Hookshot");}),
-      //Trick: (HasExplosives && CanUse("Hookshot")) || (LogicFireMQMazeHovers && CanUse("Hover Boots")) || LogicFireMQMazeJump
+    ExitPairing::Both(&FireTemple_MQ_UpperMaze, []{return HasExplosives && CanUse(CanUseItem::Hookshot);}),
+      //Trick: (HasExplosives && CanUse(CanUseItem::Hookshot)) || (LogicFireMQMazeHovers && CanUse(CanUseItem::Hover_Boots)) || LogicFireMQMazeJump
   });
 
   Exit FireTemple_MQ_UpperMaze = Exit("Fire Temple MQ Upper Maze", "Fire Temple", "", NO_DAY_NIGHT_CYCLE, {
     //Events
-    //EventPairing(&WallFairy, []{return WallFairy || ((CanPlay(SongOfTime) && CanUse("Hookshot") && HasExplosives) || CanUse("Longshot"));}),
+    //EventPairing(&WallFairy, []{return WallFairy || ((CanPlay(SongOfTime) && CanUse(CanUseItem::Hookshot) && HasExplosives) || CanUse(CanUseItem::Longshot));}),
     EventPairing(&FairyPot,  []{return SmallKeys(FireTempleKeys, 3);}),
   }, {
     //Locations
     ItemLocationPairing(&FireTemple_MQ_LizalfosMazeUpperChest, []{return true;}),
     ItemLocationPairing(&FireTemple_MQ_CompassChest,           []{return HasExplosives;}),
-    ItemLocationPairing(&FireTemple_MQ_GS_SkullOnFire,         []{return (CanPlay(SongOfTime) && CanUse("Hookshot") && HasExplosives) || CanUse("Longshot");}),
+    ItemLocationPairing(&FireTemple_MQ_GS_SkullOnFire,         []{return (CanPlay(SongOfTime) && CanUse(CanUseItem::Hookshot) && HasExplosives) || CanUse(CanUseItem::Longshot);}),
   }, {
     //Exits
-    ExitPairing::Both(&FireTemple_MQ_Upper, []{return SmallKeys(FireTempleKeys, 3) && ((CanUse("Bow") && CanUse("Hookshot")) || CanUse("Fire Arrows"));}),
+    ExitPairing::Both(&FireTemple_MQ_Upper, []{return SmallKeys(FireTempleKeys, 3) && ((CanUse(CanUseItem::Bow) && CanUse(CanUseItem::Hookshot)) || CanUse(CanUseItem::Fire_Arrows));}),
   });
 
   Exit FireTemple_MQ_Upper = Exit("Fire Temple MQ Upper", "Fire Temple", "", NO_DAY_NIGHT_CYCLE, {}, {
     //Locations
-    ItemLocationPairing(&FireTemple_MQ_FreestandingKey,         []{return CanUse("Hookshot");}),
-      //Trick: CanUse("Hookshot") || LogicFireMQFlameMaze
-    ItemLocationPairing(&FireTemple_MQ_ChestOnFire,             []{return CanUse("Hookshot") && SmallKeys(FireTempleKeys, 4);}),
-      //Trick: (CanUse("Hookshot") || LogicFireMQFlameMaze) && SmallKeys(FireTempleKeys, 4)
+    ItemLocationPairing(&FireTemple_MQ_FreestandingKey,         []{return CanUse(CanUseItem::Hookshot);}),
+      //Trick: CanUse(CanUseItem::Hookshot) || LogicFireMQFlameMaze
+    ItemLocationPairing(&FireTemple_MQ_ChestOnFire,             []{return CanUse(CanUseItem::Hookshot) && SmallKeys(FireTempleKeys, 4);}),
+      //Trick: (CanUse(CanUseItem::Hookshot) || LogicFireMQFlameMaze) && SmallKeys(FireTempleKeys, 4)
     ItemLocationPairing(&FireTemple_MQ_GS_FireWallMazeSideRoom, []{return CanPlay(SongOfTime) || HoverBoots;}),
       //Trick: CanPlay(SongOfTime) || HoverBoots || LogicFireMQFlameMaze
     ItemLocationPairing(&FireTemple_MQ_GS_FireWallMazeCenter,   []{return HasExplosives;}),
-    ItemLocationPairing(&FireTemple_MQ_GS_AboveFireWallMaze,    []{return CanUse("Hookshot") && SmallKeys(FireTempleKeys, 5);}),
-      //Trick: (CanUse("Hookshot") && SmallKeys(FireTempleKeys, 5)) || (LogicFireMQAboveMazeGS && CanUse("Longshot"))
+    ItemLocationPairing(&FireTemple_MQ_GS_AboveFireWallMaze,    []{return CanUse(CanUseItem::Hookshot) && SmallKeys(FireTempleKeys, 5);}),
+      //Trick: (CanUse(CanUseItem::Hookshot) && SmallKeys(FireTempleKeys, 5)) || (LogicFireMQAboveMazeGS && CanUse(CanUseItem::Longshot))
   }, {});
 
   Exit FireTemple_MQ_BossRoom = Exit("Fire Temple MQ Boss Room", "Fire Temple", "", NO_DAY_NIGHT_CYCLE, {}, {
@@ -2789,23 +2789,23 @@ namespace Exits { //name, scene, hint, events, locations, exits
 
   Exit WaterTemple_MQ_Lobby = Exit("Water Temple MQ Lobby", "Water Temple", "", NO_DAY_NIGHT_CYCLE, {
     //Events 
-    EventPairing(&WaterTempleClear, []{return BossKeyWaterTemple && CanUse("Longshot");}),
+    EventPairing(&WaterTempleClear, []{return BossKeyWaterTemple && CanUse(CanUseItem::Longshot);}),
   }, {
     //Locations
-    ItemLocationPairing(&WaterTemple_MorphaHeart, []{return BossKeyWaterTemple && CanUse("Longshot");}),
-    ItemLocationPairing(&Morpha,                  []{return BossKeyWaterTemple && CanUse("Longshot");}),
+    ItemLocationPairing(&WaterTemple_MorphaHeart, []{return BossKeyWaterTemple && CanUse(CanUseItem::Longshot);}),
+    ItemLocationPairing(&Morpha,                  []{return BossKeyWaterTemple && CanUse(CanUseItem::Longshot);}),
   }, {
     //Exits
     ExitPairing::Both(&LH_Main,                       []{return true;}),
-    ExitPairing::Both(&WaterTemple_MQ_Dive,           []{return (CanUse("Zora Tunic") || LogicFewerTunicRequirements) && CanUse("Iron Boots");}),
-    ExitPairing::Both(&WaterTemple_MQ_DarkLinkRegion, []{return SmallKeys(WaterTempleKeys, 1) && CanUse("Longshot");}),
+    ExitPairing::Both(&WaterTemple_MQ_Dive,           []{return (CanUse(CanUseItem::Zora_Tunic) || LogicFewerTunicRequirements) && CanUse(CanUseItem::Iron_Boots);}),
+    ExitPairing::Both(&WaterTemple_MQ_DarkLinkRegion, []{return SmallKeys(WaterTempleKeys, 1) && CanUse(CanUseItem::Longshot);}),
   });
 
   Exit WaterTemple_MQ_Dive = Exit("Water Temple MQ Dive", "Water Temple", "", NO_DAY_NIGHT_CYCLE, {}, {
     //Locations
-    ItemLocationPairing(&WaterTemple_MQ_MapChest,           []{return HasFireSource && CanUse("Hookshot");}),
-    ItemLocationPairing(&WaterTemple_MQ_CentralPillarChest, []{return CanUse("Zora Tunic") && CanUse("Hookshot") && (CanUse("Dins Fire") && CanPlay(SongOfTime));}),
-      //Trick: CanUse("Zora Tunic") && CanUse("Hookshot") && ((LogicWaterMQCentralPillar && CanUse("Fire Arrows")) || (CanUse("Dins Fire") && CanPlay(SongOfTime)))
+    ItemLocationPairing(&WaterTemple_MQ_MapChest,           []{return HasFireSource && CanUse(CanUseItem::Hookshot);}),
+    ItemLocationPairing(&WaterTemple_MQ_CentralPillarChest, []{return CanUse(CanUseItem::Zora_Tunic) && CanUse(CanUseItem::Hookshot) && (CanUse(CanUseItem::Dins_Fire) && CanPlay(SongOfTime));}),
+      //Trick: CanUse(CanUseItem::Zora_Tunic) && CanUse(CanUseItem::Hookshot) && ((LogicWaterMQCentralPillar && CanUse(CanUseItem::Fire_Arrows)) || (CanUse(CanUseItem::Dins_Fire) && CanPlay(SongOfTime)))
   }, {
     //Exits
     ExitPairing::Both(&WaterTemple_MQ_LoweredWaterLevels, []{return CanPlay(ZeldasLullaby);}),
@@ -2813,10 +2813,10 @@ namespace Exits { //name, scene, hint, events, locations, exits
 
   Exit WaterTemple_MQ_LoweredWaterLevels = Exit("Water Temple MQ Lowered Water Levels", "Water Temple", "", NO_DAY_NIGHT_CYCLE, {}, {
     //Locations
-    ItemLocationPairing(&WaterTemple_MQ_CompassChest,              []{return CanUse("Bow") || CanUse("Dins Fire") || (WaterTemple_MQ_Lobby.Child() && CanUse("Sticks") && HasExplosives);}),
-    ItemLocationPairing(&WaterTemple_MQ_LongshotChest,             []{return CanUse("Hookshot");}),
-    ItemLocationPairing(&WaterTemple_MQ_GS_LizalfosHallway,        []{return CanUse("Dins Fire");}),
-    ItemLocationPairing(&WaterTemple_MQ_GS_BeforeUpperWaterSwitch, []{return CanUse("Longshot");}),
+    ItemLocationPairing(&WaterTemple_MQ_CompassChest,              []{return CanUse(CanUseItem::Bow) || CanUse(CanUseItem::Dins_Fire) || (WaterTemple_MQ_Lobby.Child() && CanUse(CanUseItem::Sticks) && HasExplosives);}),
+    ItemLocationPairing(&WaterTemple_MQ_LongshotChest,             []{return CanUse(CanUseItem::Hookshot);}),
+    ItemLocationPairing(&WaterTemple_MQ_GS_LizalfosHallway,        []{return CanUse(CanUseItem::Dins_Fire);}),
+    ItemLocationPairing(&WaterTemple_MQ_GS_BeforeUpperWaterSwitch, []{return CanUse(CanUseItem::Longshot);}),
   }, {});
 
   Exit WaterTemple_MQ_DarkLinkRegion = Exit("Water Temple MQ Dark Link Region", "Water Temple", "", NO_DAY_NIGHT_CYCLE, {
@@ -2825,31 +2825,31 @@ namespace Exits { //name, scene, hint, events, locations, exits
     EventPairing(&NutPot,   []{return true;}),
   }, {
     //Locations
-    ItemLocationPairing(&WaterTemple_MQ_BossKeyChest, []{return (CanUse("Zora Tunic") || LogicFewerTunicRequirements) && CanUse("Dins Fire") && (LogicWaterDragonJumpDive || CanDive || CanUse("Iron Boots"));}),
+    ItemLocationPairing(&WaterTemple_MQ_BossKeyChest, []{return (CanUse(CanUseItem::Zora_Tunic) || LogicFewerTunicRequirements) && CanUse(CanUseItem::Dins_Fire) && (LogicWaterDragonJumpDive || CanDive || CanUse(CanUseItem::Iron_Boots));}),
     ItemLocationPairing(&WaterTemple_MQ_GS_River,     []{return true;}),
   }, {
     //Exits
-    ExitPairing::Both(&WaterTemple_MQ_BasementGatedAreas, []{return (CanUse("Zora Tunic") || LogicFewerTunicRequirements) && CanUse("Dins Fire") && CanUse("Iron Boots");}),
+    ExitPairing::Both(&WaterTemple_MQ_BasementGatedAreas, []{return (CanUse(CanUseItem::Zora_Tunic) || LogicFewerTunicRequirements) && CanUse(CanUseItem::Dins_Fire) && CanUse(CanUseItem::Iron_Boots);}),
   });
 
   Exit WaterTemple_MQ_BasementGatedAreas = Exit("Water Temple MQ Basement Gated Areas", "Water Temple", "", NO_DAY_NIGHT_CYCLE, {}, {
     //Locations
-    ItemLocationPairing(&WaterTemple_MQ_FreestandingKey,        []{return HoverBoots || CanUse("Scarecrow") || LogicWaterNorthBasementLedgeJump;}),
-    ItemLocationPairing(&WaterTemple_MQ_GS_TripleWallTorch,     []{return CanUse("Fire Arrows") && (HoverBoots || CanUse("Scarecrow"));}),
-    ItemLocationPairing(&WaterTemple_MQ_GS_FreestandingKeyArea, []{return SmallKeys(WaterTempleKeys, 2) && (HoverBoots || CanUse("Scarecrow") || LogicWaterNorthBasementLedgeJump);}),
-      //Trick: LogicWaterMQLockedGS || (SmallKeys(WaterTempleKeys, 2) && (HoverBoots || CanUse("Scarecrow") || LogicWaterNorthBasementLedgeJump))
+    ItemLocationPairing(&WaterTemple_MQ_FreestandingKey,        []{return HoverBoots || CanUse(CanUseItem::Scarecrow) || LogicWaterNorthBasementLedgeJump;}),
+    ItemLocationPairing(&WaterTemple_MQ_GS_TripleWallTorch,     []{return CanUse(CanUseItem::Fire_Arrows) && (HoverBoots || CanUse(CanUseItem::Scarecrow));}),
+    ItemLocationPairing(&WaterTemple_MQ_GS_FreestandingKeyArea, []{return SmallKeys(WaterTempleKeys, 2) && (HoverBoots || CanUse(CanUseItem::Scarecrow) || LogicWaterNorthBasementLedgeJump);}),
+      //Trick: LogicWaterMQLockedGS || (SmallKeys(WaterTempleKeys, 2) && (HoverBoots || CanUse(CanUseItem::Scarecrow) || LogicWaterNorthBasementLedgeJump))
   }, {});
 
   Exit SpiritTemple_MQ_Lobby = Exit("Spirit Temple MQ Lobby", "Spirit Temple", "", NO_DAY_NIGHT_CYCLE, {}, {
     //Locations
     ItemLocationPairing(&SpiritTemple_MQ_EntranceFrontLeftChest, []{return true;}),
-    ItemLocationPairing(&SpiritTemple_MQ_EntranceBackLeftChest,  []{return CanBlastOrSmash && (CanUse("Slingshot") || CanUse("Bow"));}),
-    ItemLocationPairing(&SpiritTemple_MQ_EntranceBackRightChest, []{return HasBombchus || CanUse("Bow") || CanUse("Hookshot") || CanUse("Slingshot") || CanUse("Boomerang");}),
+    ItemLocationPairing(&SpiritTemple_MQ_EntranceBackLeftChest,  []{return CanBlastOrSmash && (CanUse(CanUseItem::Slingshot) || CanUse(CanUseItem::Bow));}),
+    ItemLocationPairing(&SpiritTemple_MQ_EntranceBackRightChest, []{return HasBombchus || CanUse(CanUseItem::Bow) || CanUse(CanUseItem::Hookshot) || CanUse(CanUseItem::Slingshot) || CanUse(CanUseItem::Boomerang);}),
   }, {
     //Exits
     ExitPairing::Both(&Colossus_Main,         []{return true;}),
     ExitPairing::Both(&SpiritTemple_MQ_Child, []{return IsChild;}),
-    ExitPairing::Both(&SpiritTemple_MQ_Adult, []{return HasBombchus && CanUse("Longshot") && CanUse("Silver Gauntlets");}),
+    ExitPairing::Both(&SpiritTemple_MQ_Adult, []{return HasBombchus && CanUse(CanUseItem::Longshot) && CanUse(CanUseItem::Silver_Gauntlets);}),
   });
 
   Exit SpiritTemple_MQ_Child = Exit("Spirit Temple MQ Child", "Spirit Temple", "", NO_DAY_NIGHT_CYCLE, {
@@ -2858,10 +2858,10 @@ namespace Exits { //name, scene, hint, events, locations, exits
   }, {
     //Locations
     ItemLocationPairing(&SpiritTemple_MQ_ChildHammerSwitchChest, []{return SpiritTemple_MQ_Adult.Adult() && SmallKeys(SpiritTempleKeys, 7) && Hammer;}),
-    ItemLocationPairing(&SpiritTemple_MQ_MapRoomEnemyChest, []{return (Sticks || KokiriSword) && HasBombchus && Slingshot && CanUse("Dins Fire");}),
+    ItemLocationPairing(&SpiritTemple_MQ_MapRoomEnemyChest, []{return (Sticks || KokiriSword) && HasBombchus && Slingshot && CanUse(CanUseItem::Dins_Fire);}),
     ItemLocationPairing(&SpiritTemple_MQ_MapChest, []{return Sticks || KokiriSword || Bombs;}),
-    ItemLocationPairing(&SpiritTemple_MQ_SilverBlockHallwayChest, []{return HasBombchus && SmallKeys(SpiritTempleKeys, 7) && Slingshot && (CanUse("Dins Fire") || (SpiritTemple_MQ_Adult.Adult() && CanUse("Fire Arrows")));}),
-      //Trick: HasBombchus && SmallKeys(SpiritTempleKeys, 7) && Slingshot && (CanUse("Dins Fire") || (SpiritTemple_MQ_Adult.Adult() && (CanUse("Fire Arrows") || (LogicSpiritMQFrozenEye && CanUse("Bow") && CanPlay(SongOfTime)))))
+    ItemLocationPairing(&SpiritTemple_MQ_SilverBlockHallwayChest, []{return HasBombchus && SmallKeys(SpiritTempleKeys, 7) && Slingshot && (CanUse(CanUseItem::Dins_Fire) || (SpiritTemple_MQ_Adult.Adult() && CanUse(CanUseItem::Fire_Arrows)));}),
+      //Trick: HasBombchus && SmallKeys(SpiritTempleKeys, 7) && Slingshot && (CanUse(CanUseItem::Dins_Fire) || (SpiritTemple_MQ_Adult.Adult() && (CanUse(CanUseItem::Fire_Arrows) || (LogicSpiritMQFrozenEye && CanUse(CanUseItem::Bow) && CanPlay(SongOfTime)))))
   }, {
     //Exits
     ExitPairing::Both(&SpiritTemple_MQ_Shared, []{return HasBombchus && SmallKeys(SpiritTempleKeys, 2);}),
@@ -2871,7 +2871,7 @@ namespace Exits { //name, scene, hint, events, locations, exits
     //Locations
     ItemLocationPairing(&SpiritTemple_MQ_ChildClimbSouthChest,     []{return SmallKeys(SpiritTempleKeys, 7);}),
     ItemLocationPairing(&SpiritTemple_MQ_StatueRoomLullabyChest,   []{return CanPlay(ZeldasLullaby);}),
-    ItemLocationPairing(&SpiritTemple_MQ_StatueRoomInvisibleChest, []{return (LogicLensSpiritMQ || CanUse("Lens of Truth"));}),
+    ItemLocationPairing(&SpiritTemple_MQ_StatueRoomInvisibleChest, []{return (LogicLensSpiritMQ || CanUse(CanUseItem::Lens_of_Truth));}),
     ItemLocationPairing(&SpiritTemple_MQ_BeamosRoomChest,          []{return SmallKeys(SpiritTempleKeys, 5);}),
     ItemLocationPairing(&SpiritTemple_MQ_ChestSwitchChest,         []{return SmallKeys(SpiritTempleKeys, 5) && CanPlay(SongOfTime);}),
     ItemLocationPairing(&SpiritTemple_MQ_BossKeyChest,             []{return SmallKeys(SpiritTempleKeys, 5) && CanPlay(SongOfTime) && MirrorShield;}),
@@ -2879,27 +2879,27 @@ namespace Exits { //name, scene, hint, events, locations, exits
     ItemLocationPairing(&SpiritTemple_MQ_GS_NineThronesRoomNorth,  []{return SmallKeys(SpiritTempleKeys, 7);}),
   }, {
     //Exits
-    ExitPairing::Both(&SpiritTemple_MQ_LowerAdult,       []{return MirrorShield && CanUse("Fire Arrows");}),
-      //Trick: MirrorShield && (CanUse("Fire Arrows") || (LogicSpiritMQLowerAdult && CanUse("Dins Fire") && Bow)) 
+    ExitPairing::Both(&SpiritTemple_MQ_LowerAdult,       []{return MirrorShield && CanUse(CanUseItem::Fire_Arrows);}),
+      //Trick: MirrorShield && (CanUse(CanUseItem::Fire_Arrows) || (LogicSpiritMQLowerAdult && CanUse(CanUseItem::Dins_Fire) && Bow)) 
     ExitPairing::Both(&SpiritTemple_MQ_Shared,           []{return true;}),
     ExitPairing::Both(&SpiritTemple_MQ_BossArea,         []{return SmallKeys(SpiritTempleKeys, 6) && CanPlay(ZeldasLullaby) && Hammer;}),
-    ExitPairing::Both(&SpiritTemple_MQ_MirrorShieldHand, []{return SmallKeys(SpiritTempleKeys, 5) && CanPlay(SongOfTime) && (LogicLensSpiritMQ || CanUse("Lens of Truth"));}),
+    ExitPairing::Both(&SpiritTemple_MQ_MirrorShieldHand, []{return SmallKeys(SpiritTempleKeys, 5) && CanPlay(SongOfTime) && (LogicLensSpiritMQ || CanUse(CanUseItem::Lens_of_Truth));}),
   });
 
   Exit SpiritTemple_MQ_Shared = Exit("Spirit Temple MQ Shared", "Spirit Temple", "", NO_DAY_NIGHT_CYCLE, {}, {
     //Locations
     ItemLocationPairing(&SpiritTemple_MQ_ChildClimbNorthChest, []{return SmallKeys(SpiritTempleKeys, 6);}),
-    ItemLocationPairing(&SpiritTemple_MQ_CompassChest,         []{return (CanUse("Slingshot") && SmallKeys(SpiritTempleKeys, 7)) || CanUse("Bow") || (Bow && Slingshot);}),
+    ItemLocationPairing(&SpiritTemple_MQ_CompassChest,         []{return (CanUse(CanUseItem::Slingshot) && SmallKeys(SpiritTempleKeys, 7)) || CanUse(CanUseItem::Bow) || (Bow && Slingshot);}),
     ItemLocationPairing(&SpiritTemple_MQ_SunBlockRoomChest,    []{return CanPlay(SongOfTime) || IsAdult;}),
       //Trick: CanPlay(SongOfTime) || LogicSpiritMQSunBlockSoT || IsAdult
     ItemLocationPairing(&SpiritTemple_MQ_GS_SunBlockRoom,      []{return IsAdult;}),
       //Trick: (LogicSpiritMQSunBlockGS && Boomerange && (CanPlay(SongOfTime) || LogicSpiritMQSunBlockSoT)) || IsAdult
    }, {
     //Exits
-    ExitPairing::Both(&SpiritTemple_MQ_SilverGauntletsHand, []{return (SmallKeys(SpiritTempleKeys, 7) && (CanPlay(SongOfTime) || IsAdult)) || (SmallKeys(SpiritTempleKeys, 4) && CanPlay(SongOfTime) && (LogicLensSpiritMQ || CanUse("Lens of Truth")));}),
-      //Trick: (SmallKeys(SpiritTempleKeys, 7) && (CanPlay(SongOfTime) || LogicSpiritMQSunBlockSoT || IsAdult)) || (SmallKeys(SpiritTempleKeys, 4) && CanPlay(SongOfTime) && (LogicLensSpiritMQ || CanUse("Lens of Truth")))
-    ExitPairing::Both(&Colossus_Main,                       []{return (SmallKeys(SpiritTempleKeys, 7) && (CanPlay(SongOfTime) || IsAdult)) || (SmallKeys(SpiritTempleKeys, 4) && CanPlay(SongOfTime) && (LogicLensSpiritMQ || CanUse("Lens of Truth")) && IsAdult);}),
-      //Trick: (SmallKeys(SpiritTempleKeys, 7) && (CanPlay(SongOfTime) || LogicSpiritMQSunBlockSoT || IsAdult)) || (SmallKeys(SpiritTempleKeys, 4) && CanPlay(SongOfTime) && (LogicLensSpiritMQ || CanUse("Lens of Truth")) && IsAdult)
+    ExitPairing::Both(&SpiritTemple_MQ_SilverGauntletsHand, []{return (SmallKeys(SpiritTempleKeys, 7) && (CanPlay(SongOfTime) || IsAdult)) || (SmallKeys(SpiritTempleKeys, 4) && CanPlay(SongOfTime) && (LogicLensSpiritMQ || CanUse(CanUseItem::Lens_of_Truth)));}),
+      //Trick: (SmallKeys(SpiritTempleKeys, 7) && (CanPlay(SongOfTime) || LogicSpiritMQSunBlockSoT || IsAdult)) || (SmallKeys(SpiritTempleKeys, 4) && CanPlay(SongOfTime) && (LogicLensSpiritMQ || CanUse(CanUseItem::Lens_of_Truth)))
+    ExitPairing::Both(&Colossus_Main,                       []{return (SmallKeys(SpiritTempleKeys, 7) && (CanPlay(SongOfTime) || IsAdult)) || (SmallKeys(SpiritTempleKeys, 4) && CanPlay(SongOfTime) && (LogicLensSpiritMQ || CanUse(CanUseItem::Lens_of_Truth)) && IsAdult);}),
+      //Trick: (SmallKeys(SpiritTempleKeys, 7) && (CanPlay(SongOfTime) || LogicSpiritMQSunBlockSoT || IsAdult)) || (SmallKeys(SpiritTempleKeys, 4) && CanPlay(SongOfTime) && (LogicLensSpiritMQ || CanUse(CanUseItem::Lens_of_Truth)) && IsAdult)
   });
 
   Exit SpiritTemple_MQ_LowerAdult = Exit("Spirit Temple MQ Lower Adult", "Spirit Temple", "", NO_DAY_NIGHT_CYCLE, {}, {
@@ -2913,7 +2913,7 @@ namespace Exits { //name, scene, hint, events, locations, exits
 
   Exit SpiritTemple_MQ_BossArea = Exit("Spirit Temple MQ Boss Area", "Spirit Temple", "", NO_DAY_NIGHT_CYCLE, {}, {
     //Locations
-    ItemLocationPairing(&SpiritTemple_MQ_MirrorPuzzleInvisibleChest, []{return LogicLensSpiritMQ || CanUse("Lens of Truth");}),
+    ItemLocationPairing(&SpiritTemple_MQ_MirrorPuzzleInvisibleChest, []{return LogicLensSpiritMQ || CanUse(CanUseItem::Lens_of_Truth);}),
     ItemLocationPairing(&SpiritTemple_TwinrovaHeart,                 []{return MirrorShield && BossKeySpiritTemple;}),
     ItemLocationPairing(&Twinrova,                                   []{return MirrorShield && BossKeySpiritTemple;}),
   }, {});
@@ -2931,14 +2931,14 @@ namespace Exits { //name, scene, hint, events, locations, exits
   Exit ShadowTemple_MQ_Entryway = Exit("Shadow Temple MQ Entryway", "Shadow Temple", "", NO_DAY_NIGHT_CYCLE, {}, {}, {
     //Exits
     ExitPairing::Both(&GY_WarpPadRegion,          []{return true;}),
-    ExitPairing::Both(&ShadowTemple_MQ_Beginning, []{return (LogicLensShadowMQ || CanUse("Lens of Truth")) && (CanUse("Hover Boots") || CanUse("Hookshot"));}),
+    ExitPairing::Both(&ShadowTemple_MQ_Beginning, []{return (LogicLensShadowMQ || CanUse(CanUseItem::Lens_of_Truth)) && (CanUse(CanUseItem::Hover_Boots) || CanUse(CanUseItem::Hookshot));}),
   });
 
   Exit ShadowTemple_MQ_Beginning = Exit("Shadow Temple MQ Beginning", "Shadow Temple", "", NO_DAY_NIGHT_CYCLE, {}, {}, {
     //Exits
     ExitPairing::Both(&ShadowTemple_MQ_Entryway,     []{return true;}),
-    ExitPairing::Both(&ShadowTemple_MQ_FirstBeamos,  []{return CanUse("Fire Arrows") || HoverBoots;}),
-      //Trick: CanUse("Fire Arrows") || HoverBoots || (LogicShadowMQGap && CanUse("Longshot"))
+    ExitPairing::Both(&ShadowTemple_MQ_FirstBeamos,  []{return CanUse(CanUseItem::Fire_Arrows) || HoverBoots;}),
+      //Trick: CanUse(CanUseItem::Fire_Arrows) || HoverBoots || (LogicShadowMQGap && CanUse(CanUseItem::Longshot))
     ExitPairing::Both(&ShadowTemple_MQ_DeadHandArea, []{return HasExplosives && SmallKeys(ShadowTempleKeys, 6);}),
   });
 
@@ -2972,16 +2972,16 @@ namespace Exits { //name, scene, hint, events, locations, exits
 
   Exit ShadowTemple_MQ_LowerHugePit = Exit("Shadow Temple MQ Lower Huge Pit", "Shadow Temple", "", NO_DAY_NIGHT_CYCLE, {}, {
     //Locations
-    ItemLocationPairing(&ShadowTemple_MQ_BeamosSilverRupeesChest,  []{return CanUse("Longshot");}),
+    ItemLocationPairing(&ShadowTemple_MQ_BeamosSilverRupeesChest,  []{return CanUse(CanUseItem::Longshot);}),
     ItemLocationPairing(&ShadowTemple_MQ_FallingSpikesLowerChest,  []{return true;}),
     ItemLocationPairing(&ShadowTemple_MQ_FallingSpikesUpperChest,  []{return (LogicShadowUmbrella && HoverBoots) || GoronBracelet;}),
     ItemLocationPairing(&ShadowTemple_MQ_FallingSpikesSwitchChest, []{return (LogicShadowUmbrella && HoverBoots) || GoronBracelet;}),
-    ItemLocationPairing(&ShadowTemple_MQ_InvisibleSpikesChest,     []{return HoverBoots && SmallKeys(ShadowTempleKeys, 3) && (LogicLensShadowMQBack || CanUse("Lens of Truth"));}),
-    ItemLocationPairing(&ShadowTemple_MQ_StalfosRoomChest,         []{return HoverBoots && SmallKeys(ShadowTempleKeys, 3) && Hookshot && (LogicLensShadowMQBack || CanUse("Lens of Truth"));}),
+    ItemLocationPairing(&ShadowTemple_MQ_InvisibleSpikesChest,     []{return HoverBoots && SmallKeys(ShadowTempleKeys, 3) && (LogicLensShadowMQBack || CanUse(CanUseItem::Lens_of_Truth));}),
+    ItemLocationPairing(&ShadowTemple_MQ_StalfosRoomChest,         []{return HoverBoots && SmallKeys(ShadowTempleKeys, 3) && Hookshot && (LogicLensShadowMQBack || CanUse(CanUseItem::Lens_of_Truth));}),
     ItemLocationPairing(&ShadowTemple_MQ_GS_FallingSpikesRoom,     []{return Hookshot;}),
   }, {
     //Exits
-    ExitPairing::Both(&ShadowTemple_MQ_WindTunnel, []{return HoverBoots && (LogicLensShadowMQBack || CanUse("Lens of Truth")) && Hookshot && SmallKeys(ShadowTempleKeys, 4);}),
+    ExitPairing::Both(&ShadowTemple_MQ_WindTunnel, []{return HoverBoots && (LogicLensShadowMQBack || CanUse(CanUseItem::Lens_of_Truth)) && Hookshot && SmallKeys(ShadowTempleKeys, 4);}),
   });
 
   Exit ShadowTemple_MQ_WindTunnel = Exit("Shadow Temple MQ Wind Tunnel", "Shadow Temple", "", NO_DAY_NIGHT_CYCLE, {
@@ -3007,13 +3007,13 @@ namespace Exits { //name, scene, hint, events, locations, exits
     ItemLocationPairing(&ShadowTemple_MQ_GS_NearBoss,  []{return Bow || (LogicShadowStatue && HasBombchus);}),
   }, {
     //Exits
-    ExitPairing::Both(&ShadowTemple_MQ_InvisibleMaze, []{return Bow && CanPlay(SongOfTime) && CanUse("Longshot");}),
+    ExitPairing::Both(&ShadowTemple_MQ_InvisibleMaze, []{return Bow && CanPlay(SongOfTime) && CanUse(CanUseItem::Longshot);}),
   });
 
   Exit ShadowTemple_MQ_InvisibleMaze = Exit("Shadow Temple MQ Invisible Maze", "Shadow Temple", "", NO_DAY_NIGHT_CYCLE, {}, {
     //Locations
-    ItemLocationPairing(&ShadowTemple_MQ_SpikeWallsLeftChest, []{return CanUse("Dins Fire") && SmallKeys(ShadowTempleKeys, 6);}),
-    ItemLocationPairing(&ShadowTemple_MQ_BossKeyChest,        []{return CanUse("Dins Fire") && SmallKeys(ShadowTempleKeys, 6);}),
+    ItemLocationPairing(&ShadowTemple_MQ_SpikeWallsLeftChest, []{return CanUse(CanUseItem::Dins_Fire) && SmallKeys(ShadowTempleKeys, 6);}),
+    ItemLocationPairing(&ShadowTemple_MQ_BossKeyChest,        []{return CanUse(CanUseItem::Dins_Fire) && SmallKeys(ShadowTempleKeys, 6);}),
     ItemLocationPairing(&ShadowTemple_MQ_BombFlowerChest,     []{return true;}),
     ItemLocationPairing(&ShadowTemple_MQ_FreestandingKey,     []{return true;}),
   }, {});
@@ -3059,7 +3059,7 @@ namespace Exits { //name, scene, hint, events, locations, exits
   }, {}, {
     //Exits
     ExitPairing::Both(&ZF_Main,                      []{return true;}),
-    ExitPairing::Both(&IceCavern_MQ_MapRoom,         []{return IsAdult || CanUse("Dins Fire") || (HasExplosives && (CanUse("Sticks") || CanUse("Slingshot") || KokiriSword));}),
+    ExitPairing::Both(&IceCavern_MQ_MapRoom,         []{return IsAdult || CanUse(CanUseItem::Dins_Fire) || (HasExplosives && (CanUse(CanUseItem::Sticks) || CanUse(CanUseItem::Slingshot) || KokiriSword));}),
     ExitPairing::Both(&IceCavern_MQ_CompassRoom,     []{return IsAdult && BlueFire;}),
     ExitPairing::Both(&IceCavern_MQ_IronBootsRegion, []{return BlueFire;}),
   });
@@ -3069,7 +3069,7 @@ namespace Exits { //name, scene, hint, events, locations, exits
     EventPairing(&BlueFireAccess,  []{return BlueFireAccess || HasBottle;}),
   }, {
     //Locations
-    ItemLocationPairing(&IceCavern_MQ_MapChest, []{return BlueFire && (IsAdult || CanUse("Sticks") || KokiriSword || CanUseProjectile);}),
+    ItemLocationPairing(&IceCavern_MQ_MapChest, []{return BlueFire && (IsAdult || CanUse(CanUseItem::Sticks) || KokiriSword || CanUseProjectile);}),
   }, {});
 
   Exit IceCavern_MQ_IronBootsRegion = Exit("Ice Cavern MQ Iron Boots Region", "Ice Cavern", "", NO_DAY_NIGHT_CYCLE, {}, {
@@ -3077,8 +3077,8 @@ namespace Exits { //name, scene, hint, events, locations, exits
     ItemLocationPairing(&IceCavern_MQ_IronBootsChest, []{return IsAdult;}),
     ItemLocationPairing(&SheikInIceCavern,            []{return IsAdult;}),
     ItemLocationPairing(&IceCavern_MQ_GS_IceBlock,    []{return IsAdult || CanChildAttack;}),
-    ItemLocationPairing(&IceCavern_MQ_GS_Scarecrow,   []{return CanUse("Scarecrow") || (HoverBoots && CanUse("Longshot"));}),
-      //Tricks: CanUse("Scarecrow") || (HoverBoots && CanUse("Longshot")) || (LogicIceMQScarecrow && IsAdult)
+    ItemLocationPairing(&IceCavern_MQ_GS_Scarecrow,   []{return CanUse(CanUseItem::Scarecrow) || (HoverBoots && CanUse(CanUseItem::Longshot));}),
+      //Tricks: CanUse(CanUseItem::Scarecrow) || (HoverBoots && CanUse(CanUseItem::Longshot)) || (LogicIceMQScarecrow && IsAdult)
   }, {});
 
   Exit IceCavern_MQ_CompassRoom = Exit("Ice Cavern MQ Compass Room", "Ice Cavern", "", NO_DAY_NIGHT_CYCLE, {}, {
@@ -3093,7 +3093,7 @@ namespace Exits { //name, scene, hint, events, locations, exits
     //Locations
     ItemLocationPairing(&GerudoTrainingGrounds_MQ_LobbyLeftChest,      []{return true;}),
     ItemLocationPairing(&GerudoTrainingGrounds_MQ_LobbyRightChest,     []{return true;}),
-    ItemLocationPairing(&GerudoTrainingGrounds_MQ_HiddenCeilingChest,  []{return LogicLensGtgMQ || CanUse("Lens of Truth");}),
+    ItemLocationPairing(&GerudoTrainingGrounds_MQ_HiddenCeilingChest,  []{return LogicLensGtgMQ || CanUse(CanUseItem::Lens_of_Truth);}),
     ItemLocationPairing(&GerudoTrainingGrounds_MQ_MazePathFirstChest,  []{return true;}),
     ItemLocationPairing(&GerudoTrainingGrounds_MQ_MazePathSecondChest, []{return true;}),
     ItemLocationPairing(&GerudoTrainingGrounds_MQ_MazePathThirdChest,  []{return SmallKeys(GerudoTrainingGroundsKeys, 1);}),
@@ -3101,23 +3101,23 @@ namespace Exits { //name, scene, hint, events, locations, exits
     //Exits
     ExitPairing::Both(&GF_Main,                            []{return true;}),
     ExitPairing::Both(&GerudoTrainingGrounds_MQ_LeftSide,  []{return HasFireSource;}),
-    ExitPairing::Both(&GerudoTrainingGrounds_MQ_RightSide, []{return CanUse("Bow") || CanUse("Slingshot");}),
+    ExitPairing::Both(&GerudoTrainingGrounds_MQ_RightSide, []{return CanUse(CanUseItem::Bow) || CanUse(CanUseItem::Slingshot);}),
   });
 
   Exit GerudoTrainingGrounds_MQ_RightSide = Exit("Gerudo Training Grounds MQ Right Side", "Gerudo Training Grounds", "", NO_DAY_NIGHT_CYCLE, {
     //Events
-    //EventPairing(&WallFairy, []{return WallFairy || CanUse("Bow");}),
+    //EventPairing(&WallFairy, []{return WallFairy || CanUse(CanUseItem::Bow);}),
   }, {
     //Locations
     ItemLocationPairing(&GerudoTrainingGrounds_MQ_DinolfosChest, []{return IsAdult;}),
   }, {
     //Exits
-    ExitPairing::Both(&GerudoTrainingGrounds_MQ_Underwater, []{return (Bow || CanUse("Longshot")) && CanUse("Hover Boots");}),
+    ExitPairing::Both(&GerudoTrainingGrounds_MQ_Underwater, []{return (Bow || CanUse(CanUseItem::Longshot)) && CanUse(CanUseItem::Hover_Boots);}),
   });
 
   Exit GerudoTrainingGrounds_MQ_Underwater = Exit("Gerudo Training Grounds MQ Underwater", "Gerudo Training Grounds", "", NO_DAY_NIGHT_CYCLE, {}, {
     //Locations
-    ItemLocationPairing(&GerudoTrainingGrounds_MQ_UnderwaterSilverRupeeChest, []{return HasFireSource && CanUse("Iron Boots") && (LogicFewerTunicRequirements || CanUse("Zora Tunic")) && DamageMultiplier.IsNot(DAMAGEMULTIPLIER_OHKO);}),
+    ItemLocationPairing(&GerudoTrainingGrounds_MQ_UnderwaterSilverRupeeChest, []{return HasFireSource && CanUse(CanUseItem::Iron_Boots) && (LogicFewerTunicRequirements || CanUse(CanUseItem::Zora_Tunic)) && DamageMultiplier.IsNot(DAMAGEMULTIPLIER_OHKO);}),
   }, {});
 
   Exit GerudoTrainingGrounds_MQ_LeftSide = Exit("Gerudo Training Grounds MQ Left Side", "Gerudo Training Grounds", "", NO_DAY_NIGHT_CYCLE, {}, {
@@ -3125,8 +3125,8 @@ namespace Exits { //name, scene, hint, events, locations, exits
     ItemLocationPairing(&GerudoTrainingGrounds_MQ_FirstIronKnuckleChest, []{return IsAdult || KokiriSword || HasExplosives;}),
   }, {
     //Exits
-    ExitPairing::Both(&GerudoTrainingGrounds_MQ_StalfosRoom, []{return CanUse("Longshot");}),
-      //Trick: CanUse("Longshot") || LogicGtgMQWithoutHookshot || (LogicGtgMQWithHookshot && CanUse("Hookshot"))
+    ExitPairing::Both(&GerudoTrainingGrounds_MQ_StalfosRoom, []{return CanUse(CanUseItem::Longshot);}),
+      //Trick: CanUse(CanUseItem::Longshot) || LogicGtgMQWithoutHookshot || (LogicGtgMQWithHookshot && CanUse(CanUseItem::Hookshot))
   });
 
   Exit GerudoTrainingGrounds_MQ_StalfosRoom = Exit("Gerudo Training Grounds MQ Stalfos Room", "Gerudo Training Grounds", "", NO_DAY_NIGHT_CYCLE, {
@@ -3135,22 +3135,22 @@ namespace Exits { //name, scene, hint, events, locations, exits
   }, {
     //Locations
     ItemLocationPairing(&GerudoTrainingGrounds_MQ_BeforeHeavyBlockChest, []{return IsAdult;}),
-    ItemLocationPairing(&GerudoTrainingGrounds_MQ_HeavyBlockChest,       []{return CanUse("Silver Gauntlets");}),
+    ItemLocationPairing(&GerudoTrainingGrounds_MQ_HeavyBlockChest,       []{return CanUse(CanUseItem::Silver_Gauntlets);}),
   }, {
     //Exits
-    ExitPairing::Both(&GerudoTrainingGrounds_MQ_BackAreas, []{return IsAdult && (LogicLensGtgMQ || CanUse("Lens of Truth")) && BlueFire && CanPlay(SongOfTime);}),
-      //Trick: IsAdult && (LogicLensGtgMQ || CanUse("Lens of Truth")) && BlueFire && (CanPlay(SongOfTime) || (LogicGtgFakeWall && CanUse("Hover Boots")))
+    ExitPairing::Both(&GerudoTrainingGrounds_MQ_BackAreas, []{return IsAdult && (LogicLensGtgMQ || CanUse(CanUseItem::Lens_of_Truth)) && BlueFire && CanPlay(SongOfTime);}),
+      //Trick: IsAdult && (LogicLensGtgMQ || CanUse(CanUseItem::Lens_of_Truth)) && BlueFire && (CanPlay(SongOfTime) || (LogicGtgFakeWall && CanUse(CanUseItem::Hover_Boots)))
   });
 
   Exit GerudoTrainingGrounds_MQ_BackAreas = Exit("Gerudo Training Grounds MQ Back Areas", "Gerudo Training Grounds", "", NO_DAY_NIGHT_CYCLE, {}, {
     //Locations
     ItemLocationPairing(&GerudoTrainingGrounds_MQ_EyeStatueChest,         []{return Bow;}),
     ItemLocationPairing(&GerudoTrainingGrounds_MQ_SecondIronKnuckleChest, []{return true;}),
-    ItemLocationPairing(&GerudoTrainingGrounds_MQ_FlameCircleChest,       []{return CanUse("Hookshot") || Bow || HasExplosives;}),
+    ItemLocationPairing(&GerudoTrainingGrounds_MQ_FlameCircleChest,       []{return CanUse(CanUseItem::Hookshot) || Bow || HasExplosives;}),
   }, {
     //Exits
     ExitPairing::Both(&GerudoTrainingGrounds_MQ_CentralMazeRight, []{return Hammer;}),
-    ExitPairing::Both(&GerudoTrainingGrounds_MQ_RightSide,        []{return CanUse("Longshot");}),
+    ExitPairing::Both(&GerudoTrainingGrounds_MQ_RightSide,        []{return CanUse(CanUseItem::Longshot);}),
   });
 
   Exit GerudoTrainingGrounds_MQ_CentralMazeRight = Exit("Gerudo Training Grounds MQ Central Maze Right", "Gerudo Training Grounds", "", NO_DAY_NIGHT_CYCLE, {}, {
@@ -3160,8 +3160,8 @@ namespace Exits { //name, scene, hint, events, locations, exits
     ItemLocationPairing(&GerudoTrainingGrounds_MQ_IceArrowsChest,        []{return SmallKeys(GerudoTrainingGroundsKeys, 3);}),
   }, {
     //Exits
-    ExitPairing::Both(&GerudoTrainingGrounds_MQ_Underwater, []{return CanUse("Longshot") || (CanUse("Hookshot") && Bow);}),
-    ExitPairing::Both(&GerudoTrainingGrounds_MQ_RightSide,  []{return CanUse("Hookshot");}),
+    ExitPairing::Both(&GerudoTrainingGrounds_MQ_Underwater, []{return CanUse(CanUseItem::Longshot) || (CanUse(CanUseItem::Hookshot) && Bow);}),
+    ExitPairing::Both(&GerudoTrainingGrounds_MQ_RightSide,  []{return CanUse(CanUseItem::Hookshot);}),
   });
 
   Exit GanonsCastle_MQ_Lobby = Exit("Ganon's Castle MQ Lobby", "Ganons Castle", "", NO_DAY_NIGHT_CYCLE, {}, {}, {
@@ -3172,14 +3172,14 @@ namespace Exits { //name, scene, hint, events, locations, exits
     ExitPairing::Both(&GanonsCastle_MQ_WaterTrial,  []{return true;}),
     ExitPairing::Both(&GanonsCastle_MQ_ShadowTrial, []{return true;}),
     ExitPairing::Both(&GanonsCastle_MQ_SpiritTrial, []{return true;}),
-    ExitPairing::Both(&GanonsCastle_MQ_LightTrial,  []{return CanUse("Golden Gauntlets");}),
+    ExitPairing::Both(&GanonsCastle_MQ_LightTrial,  []{return CanUse(CanUseItem::Golden_Gauntlets);}),
     ExitPairing::Both(&GanonsCastle_Tower,          []{return (ForestTrialClear || ForestTrialSkip) &&
                                                               (FireTrialClear   || FireTrialSkip)   &&
                                                               (WaterTrialClear  || WaterTrialSkip)  &&
                                                               (ShadowTrialClear || ShadowTrialSkip) &&
                                                               (SpiritTrialClear || SpiritTrialSkip) &&
                                                               (LightTrialClear  || LightTrialSkip);}),
-    ExitPairing::Both(&GanonsCastle_MQ_DekuScrubs,  []{return LogicLensCastleMQ || CanUse("Lens of Truth");}),
+    ExitPairing::Both(&GanonsCastle_MQ_DekuScrubs,  []{return LogicLensCastleMQ || CanUse(CanUseItem::Lens_of_Truth);}),
   });
 
   Exit GanonsCastle_MQ_DekuScrubs = Exit("Ganon's Castle MQ Deku Scrubs", "Ganon's Castle", "", NO_DAY_NIGHT_CYCLE, {
@@ -3196,7 +3196,7 @@ namespace Exits { //name, scene, hint, events, locations, exits
 
   Exit GanonsCastle_MQ_ForestTrial = Exit("Ganon's Castle MQ Forest Trial", "Ganons Castle", "", NO_DAY_NIGHT_CYCLE, {
     //Events
-    EventPairing(&ForestTrialClear, []{return CanUse("Light Arrows") && CanPlay(SongOfTime);}),
+    EventPairing(&ForestTrialClear, []{return CanUse(CanUseItem::Light_Arrows) && CanPlay(SongOfTime);}),
   }, {
     //Locations
     ItemLocationPairing(&GanonsCastle_MQ_ForestTrialEyeSwitchChest,       []{return Bow;}),
@@ -3206,13 +3206,13 @@ namespace Exits { //name, scene, hint, events, locations, exits
 
   Exit GanonsCastle_MQ_FireTrial = Exit("Ganon's Castle MQ Fire Trial", "Ganons Castle", "", NO_DAY_NIGHT_CYCLE, {
     //Events
-    EventPairing(&FireTrialClear, []{return CanUse("Goron Tunic") && CanUse("Golden Gauntlets") && CanUse("Light Arrows") && (CanUse("Longshot") || HoverBoots);}),
-      //Trick: CanUse("Goron Tunic") && CanUse("Golden Gauntlets") && CanUse("Light Arrows") && (CanUse("Longshot") || HoverBoots || (LogicFireTrialMQ && CanUse("Hookshot")))
+    EventPairing(&FireTrialClear, []{return CanUse(CanUseItem::Goron_Tunic) && CanUse(CanUseItem::Golden_Gauntlets) && CanUse(CanUseItem::Light_Arrows) && (CanUse(CanUseItem::Longshot) || HoverBoots);}),
+      //Trick: CanUse(CanUseItem::Goron_Tunic) && CanUse(CanUseItem::Golden_Gauntlets) && CanUse(CanUseItem::Light_Arrows) && (CanUse(CanUseItem::Longshot) || HoverBoots || (LogicFireTrialMQ && CanUse(CanUseItem::Hookshot)))
   }, {}, {});
 
   Exit GanonsCastle_MQ_WaterTrial = Exit("Ganon's Castle MQ Water Trial", "Ganons Castle", "", NO_DAY_NIGHT_CYCLE, {
     //Events
-    EventPairing(&WaterTrialClear, []{return BlueFire && CanUse("Light Arrows") && SmallKeys(GanonsCastleKeys, 3);}),
+    EventPairing(&WaterTrialClear, []{return BlueFire && CanUse(CanUseItem::Light_Arrows) && SmallKeys(GanonsCastleKeys, 3);}),
     EventPairing(&BlueFireAccess,  []{return BlueFireAccess || HasBottle;}),
   }, {
     //Locations
@@ -3221,33 +3221,33 @@ namespace Exits { //name, scene, hint, events, locations, exits
 
   Exit GanonsCastle_MQ_ShadowTrial = Exit("Ganon's Castle MQ Shadow Trial", "Ganons Castle", "", NO_DAY_NIGHT_CYCLE, {
     //Events
-    EventPairing(&ShadowTrialClear, []{return CanUse("Light Arrows") && (LogicLensCastleMQ || CanUse("Lens of Truth")) && (HoverBoots || (Hookshot && HasFireSource));}),
-      //Trick: CanUse("Light Arrows") && (LogicLensCastleMQ || CanUse("Lens of Truth")) && (HoverBoots || (Hookshot && (HasFireSource || LogicShadowTrialMQ)))
+    EventPairing(&ShadowTrialClear, []{return CanUse(CanUseItem::Light_Arrows) && (LogicLensCastleMQ || CanUse(CanUseItem::Lens_of_Truth)) && (HoverBoots || (Hookshot && HasFireSource));}),
+      //Trick: CanUse(CanUseItem::Light_Arrows) && (LogicLensCastleMQ || CanUse(CanUseItem::Lens_of_Truth)) && (HoverBoots || (Hookshot && (HasFireSource || LogicShadowTrialMQ)))
   }, {
     //Locations
-    ItemLocationPairing(&GanonsCastle_MQ_ShadowTrialBombFlowerChest, []{return (Bow && (Hookshot || HoverBoots)) || (HoverBoots && (LogicLensCastleMQ || CanUse("Lens of Truth")) && (HasExplosives || GoronBracelet || CanUse("Dins Fire")));}),
-    ItemLocationPairing(&GanonsCastle_MQ_ShadowTrialEyeSwitchChest,  []{return Bow && (LogicLensCastleMQ || CanUse("Lens of Truth")) && (HoverBoots || (Hookshot && HasFireSource));}),
-      //Trick: Bow && (LogicLensCastleMQ || CanUse("Lens of Truth")) && (HoverBoots || (Hookshot && (HasFireSource || LogicShadowTrialMQ)))
+    ItemLocationPairing(&GanonsCastle_MQ_ShadowTrialBombFlowerChest, []{return (Bow && (Hookshot || HoverBoots)) || (HoverBoots && (LogicLensCastleMQ || CanUse(CanUseItem::Lens_of_Truth)) && (HasExplosives || GoronBracelet || CanUse(CanUseItem::Dins_Fire)));}),
+    ItemLocationPairing(&GanonsCastle_MQ_ShadowTrialEyeSwitchChest,  []{return Bow && (LogicLensCastleMQ || CanUse(CanUseItem::Lens_of_Truth)) && (HoverBoots || (Hookshot && HasFireSource));}),
+      //Trick: Bow && (LogicLensCastleMQ || CanUse(CanUseItem::Lens_of_Truth)) && (HoverBoots || (Hookshot && (HasFireSource || LogicShadowTrialMQ)))
   }, {});
 
   Exit GanonsCastle_MQ_SpiritTrial = Exit("Ganon's Castle MQ Spirit Castle", "Ganons Castle", "", NO_DAY_NIGHT_CYCLE, {
     //Events
-    EventPairing(&SpiritTrialClear, []{return CanUse("Light Arrows") && Hammer && HasBombchus && FireArrows && MirrorShield;}),
-    EventPairing(&NutPot,           []{return NutPot || (Hammer && HasBombchus && CanUse("Fire Arrows") && MirrorShield);}),
+    EventPairing(&SpiritTrialClear, []{return CanUse(CanUseItem::Light_Arrows) && Hammer && HasBombchus && FireArrows && MirrorShield;}),
+    EventPairing(&NutPot,           []{return NutPot || (Hammer && HasBombchus && CanUse(CanUseItem::Fire_Arrows) && MirrorShield);}),
   }, {
     //Locations
     ItemLocationPairing(&GanonsCastle_MQ_SpiritTrialFirstChest,           []{return Bow && Hammer;}),
-    ItemLocationPairing(&GanonsCastle_MQ_SpiritTrialInvisibleChest,       []{return Bow && Hammer && HasBombchus && (LogicLensCastleMQ || CanUse("Lens of Truth"));}),
-    ItemLocationPairing(&GanonsCastle_MQ_SpiritTrialSunFrontLeftChest,    []{return Hammer && HasBombchus && CanUse("Fire Arrows") && MirrorShield;}),
-    ItemLocationPairing(&GanonsCastle_MQ_SpiritTrialSunBackLeftChest,     []{return Hammer && HasBombchus && CanUse("Fire Arrows") && MirrorShield;}),
-    ItemLocationPairing(&GanonsCastle_MQ_SpiritTrialGoldenGauntletsChest, []{return Hammer && HasBombchus && CanUse("Fire Arrows") && MirrorShield;}),
-    ItemLocationPairing(&GanonsCastle_MQ_SpiritTrialSunBackRightChest,    []{return Hammer && HasBombchus && CanUse("Fire Arrows") && MirrorShield;}),
+    ItemLocationPairing(&GanonsCastle_MQ_SpiritTrialInvisibleChest,       []{return Bow && Hammer && HasBombchus && (LogicLensCastleMQ || CanUse(CanUseItem::Lens_of_Truth));}),
+    ItemLocationPairing(&GanonsCastle_MQ_SpiritTrialSunFrontLeftChest,    []{return Hammer && HasBombchus && CanUse(CanUseItem::Fire_Arrows) && MirrorShield;}),
+    ItemLocationPairing(&GanonsCastle_MQ_SpiritTrialSunBackLeftChest,     []{return Hammer && HasBombchus && CanUse(CanUseItem::Fire_Arrows) && MirrorShield;}),
+    ItemLocationPairing(&GanonsCastle_MQ_SpiritTrialGoldenGauntletsChest, []{return Hammer && HasBombchus && CanUse(CanUseItem::Fire_Arrows) && MirrorShield;}),
+    ItemLocationPairing(&GanonsCastle_MQ_SpiritTrialSunBackRightChest,    []{return Hammer && HasBombchus && CanUse(CanUseItem::Fire_Arrows) && MirrorShield;}),
   }, {});
 
   Exit GanonsCastle_MQ_LightTrial = Exit("Ganon's Castle MQ Light Trial", "Ganons Castle", "", NO_DAY_NIGHT_CYCLE, {
     //Events
-    EventPairing(&LightTrialClear, []{return CanUse("Light Arrows") && SmallKeys(GanonsCastleKeys, 3) && (LogicLensCastleMQ || CanUse("Lens of Truth")) && Hookshot;}),
-      //Trick: CanUse("Light Arrows") && SmallKeys(GanonsCastleKeys, 3) && (LogicLensCastleMQ || CanUse("Lens of Truth")) && (Hookshot || LogicLightTrialMQ)
+    EventPairing(&LightTrialClear, []{return CanUse(CanUseItem::Light_Arrows) && SmallKeys(GanonsCastleKeys, 3) && (LogicLensCastleMQ || CanUse(CanUseItem::Lens_of_Truth)) && Hookshot;}),
+      //Trick: CanUse(CanUseItem::Light_Arrows) && SmallKeys(GanonsCastleKeys, 3) && (LogicLensCastleMQ || CanUse(CanUseItem::Lens_of_Truth)) && (Hookshot || LogicLightTrialMQ)
   }, {
     //Locations
     ItemLocationPairing(&GanonsCastle_MQ_LightTrialLullabyChest, []{return CanPlay(ZeldasLullaby);}),

--- a/source/logic.cpp
+++ b/source/logic.cpp
@@ -306,72 +306,72 @@ namespace Logic {
     return Ocarina && song;
   }
 
-  static bool IsMagicItem(std::string_view item) {
-    return item == "Dins Fire"    ||
-           item == "Farores Wind" ||
-           item == "Nayrus Love"  ||
-           item == "Lens of Truth";
+  static bool IsMagicItem(CanUseItem item) {
+    return item == CanUseItem::Dins_Fire    ||
+           item == CanUseItem::Farores_Wind ||
+           item == CanUseItem::Nayrus_Love  ||
+           item == CanUseItem::Lens_of_Truth;
   }
 
-  static bool IsAdultItem(std::string_view item) {
-    return item == "Bow"              ||
-           item == "Hammer"           ||
-           item == "Iron Boots"       ||
-           item == "Hover Boots"      ||
-           item == "Hookshot"         ||
-           item == "Longshot"         ||
-           item == "Silver Gauntlets" ||
-           item == "Golden Gauntlets" ||
-           item == "Goron Tunic"      ||
-           item == "Zora Tunic"       ||
-           item == "Scarecrow"        ||
-           item == "Distant Scarecrow";
+  static bool IsAdultItem(CanUseItem item) {
+    return item == CanUseItem::Bow              ||
+           item == CanUseItem::Hammer           ||
+           item == CanUseItem::Iron_Boots       ||
+           item == CanUseItem::Hover_Boots      ||
+           item == CanUseItem::Hookshot         ||
+           item == CanUseItem::Longshot         ||
+           item == CanUseItem::Silver_Gauntlets ||
+           item == CanUseItem::Golden_Gauntlets ||
+           item == CanUseItem::Goron_Tunic      ||
+           item == CanUseItem::Zora_Tunic       ||
+           item == CanUseItem::Scarecrow        ||
+           item == CanUseItem::Distant_Scarecrow;
   }
 
-  static bool IsChildItem(std::string_view item) {
-    return item == "Slingshot"    ||
-           item == "Boomerang"    ||
-           item == "Kokiri Sword" ||
-           item == "Sticks"       ||
-           item == "Deku Shield";
+  static bool IsChildItem(CanUseItem item) {
+    return item == CanUseItem::Slingshot    ||
+           item == CanUseItem::Boomerang    ||
+           item == CanUseItem::Kokiri_Sword ||
+           item == CanUseItem::Sticks       ||
+           item == CanUseItem::Deku_Shield;
   }
 
-  static bool IsMagicArrow(std::string_view item) {
-    return item == "Fire Arrows" ||
-           item == "Ice Arrows"  ||
-           item == "Light Arrows";
+  static bool IsMagicArrow(CanUseItem item) {
+    return item == CanUseItem::Fire_Arrows ||
+           item == CanUseItem::Ice_Arrows  ||
+           item == CanUseItem::Light_Arrows;
   }
 
-  bool HasItem(std::string_view itemName) {
-    return (itemName == "Dins Fire"        && DinsFire)        ||
-           (itemName == "Farores Wind"     && FaroresWind)     ||
-           (itemName == "NayrusLove"       && NayrusLove)      ||
-           (itemName == "Lens of Truth"    && LensOfTruth)     ||
-           (itemName == "Bow"              && Bow)             ||
-           (itemName == "Hammer"           && Hammer)          ||
-           (itemName == "Iron Boots"       && IronBoots)       ||
-           (itemName == "Hover Boots"      && HoverBoots)      ||
-           (itemName == "Hookshot"         && Hookshot)        ||
-           (itemName == "Longshot"         && Longshot)        ||
-           (itemName == "Silver Gauntlets" && SilverGauntlets) ||
-           (itemName == "Golden Gauntlets" && GoldenGauntlets) ||
-           (itemName == "Goron Tunic"      && GoronTunic)      ||
-           (itemName == "Zora Tunic"       && ZoraTunic)       ||
-           (itemName == "Scarecrow"        && Scarecrow)       ||
-           (itemName == "Distant Scarecrow"&& DistantScarecrow)||
-           (itemName == "Slingshot"        && Slingshot)       ||
-           (itemName == "Boomerang"        && Boomerang)       ||
-           (itemName == "Kokiri Sword"     && KokiriSword)     ||
-           (itemName == "Sticks"           && Sticks)          ||
-           (itemName == "Deku Shield"      && DekuShield)      ||
-           (itemName == "Fire Arrows"      && FireArrows)      ||
-           (itemName == "Ice Arrows"       && IceArrows)       ||
-           (itemName == "Light Arrows"     && LightArrows);
+  bool HasItem(CanUseItem itemName) {
+    return (itemName == CanUseItem::Dins_Fire         && DinsFire)        ||
+           (itemName == CanUseItem::Farores_Wind      && FaroresWind)     ||
+           (itemName == CanUseItem::Nayrus_Love       && NayrusLove)      ||
+           (itemName == CanUseItem::Lens_of_Truth     && LensOfTruth)     ||
+           (itemName == CanUseItem::Bow               && Bow)             ||
+           (itemName == CanUseItem::Hammer            && Hammer)          ||
+           (itemName == CanUseItem::Iron_Boots        && IronBoots)       ||
+           (itemName == CanUseItem::Hover_Boots       && HoverBoots)      ||
+           (itemName == CanUseItem::Hookshot          && Hookshot)        ||
+           (itemName == CanUseItem::Longshot          && Longshot)        ||
+           (itemName == CanUseItem::Silver_Gauntlets  && SilverGauntlets) ||
+           (itemName == CanUseItem::Golden_Gauntlets  && GoldenGauntlets) ||
+           (itemName == CanUseItem::Goron_Tunic       && GoronTunic)      ||
+           (itemName == CanUseItem::Zora_Tunic        && ZoraTunic)       ||
+           (itemName == CanUseItem::Scarecrow         && Scarecrow)       ||
+           (itemName == CanUseItem::Distant_Scarecrow && DistantScarecrow)||
+           (itemName == CanUseItem::Slingshot         && Slingshot)       ||
+           (itemName == CanUseItem::Boomerang         && Boomerang)       ||
+           (itemName == CanUseItem::Kokiri_Sword      && KokiriSword)     ||
+           (itemName == CanUseItem::Sticks            && Sticks)          ||
+           (itemName == CanUseItem::Deku_Shield       && DekuShield)      ||
+           (itemName == CanUseItem::Fire_Arrows       && FireArrows)      ||
+           (itemName == CanUseItem::Ice_Arrows        && IceArrows)       ||
+           (itemName == CanUseItem::Light_Arrows      && LightArrows);
 
   }
 
   //Can the passed in item be used?
-  bool CanUse(std::string_view itemName) {
+  bool CanUse(CanUseItem itemName) {
     return (IsMagicItem(itemName)  && HasItem(itemName) && MagicMeter) ||
            (IsAdultItem(itemName)  && HasItem(itemName) && IsAdult)    ||
            (IsMagicArrow(itemName) && HasItem(itemName) && MagicMeter  && IsAdult && Bow) ||
@@ -430,10 +430,10 @@ namespace Logic {
 
   //IsGlitched = false;
 
-    CanBlastOrSmash = HasExplosives || CanUse("Hammer");
-    CanChildAttack  = IsChild && (Slingshot || Boomerang || Sticks || KokiriSword || HasExplosives || CanUse("Dins Fire"));
-    CanChildDamage  = IsChild && (Slingshot ||              Sticks || KokiriSword || HasExplosives || CanUse("Dins Fire"));
-    CanStunDeku     = IsAdult || (Slingshot || Boomerang || Sticks || KokiriSword || HasExplosives || CanUse("Dins Fire") || Nuts || DekuShield);
+    CanBlastOrSmash = HasExplosives || CanUse(CanUseItem::Hammer);
+    CanChildAttack  = IsChild && (Slingshot || Boomerang || Sticks || KokiriSword || HasExplosives || CanUse(CanUseItem::Dins_Fire));
+    CanChildDamage  = IsChild && (Slingshot ||              Sticks || KokiriSword || HasExplosives || CanUse(CanUseItem::Dins_Fire));
+    CanStunDeku     = IsAdult || (Slingshot || Boomerang || Sticks || KokiriSword || HasExplosives || CanUse(CanUseItem::Dins_Fire) || Nuts || DekuShield);
     CanCutShrubs    = IsAdult || Sticks || KokiriSword || Boomerang || HasExplosives;
     CanDive         = ProgressiveScale >= 1;
     CanLeaveForest  = OpenForest.IsNot(OPENFOREST_CLOSED) || IsAdult || DekuTreeClear;
@@ -444,11 +444,11 @@ namespace Logic {
     CanPlantBean        = IsChild && (MagicBean || MagicBeanPack);
     CanOpenBombGrotto   = CanBlastOrSmash       && (ShardOfAgony || LogicGrottosWithoutAgony);
     CanOpenStormGrotto  = CanPlay(SongOfStorms) && (ShardOfAgony || LogicGrottosWithoutAgony);
-    HookshotOrBoomerang = CanUse("Hookshot") || CanUse("Boomerang");
+    HookshotOrBoomerang = CanUse(CanUseItem::Hookshot) || CanUse(CanUseItem::Boomerang);
 
     GuaranteeTradePath     = ShuffleInteriorEntrances || ShuffleOverworldEntrances || LogicBiggoronBolero || CanBlastOrSmash || StopGCRollingGoronAsAdult;
   //GuaranteeHint          = (hints == "Mask" && MaskofTruth) || (hints == "Agony") || (hints != "Mask" && hints != "Agony");
-    HasFireSource          = CanUse("Dins Fire") || CanUse("Fire Arrows");
+    HasFireSource          = CanUse(CanUseItem::Dins_Fire) || CanUse(CanUseItem::Fire_Arrows);
     HasFireSourceWithTorch = HasFireSource || (IsChild && Sticks);
 
     //Gerudo Fortress

--- a/source/logic.hpp
+++ b/source/logic.hpp
@@ -282,9 +282,37 @@ namespace Logic {
   extern u8 AddedProgressiveOcarinas;
   extern u8 TokensInPool;
 
+  //Enum values for CanUse() and related functions
+  enum class CanUseItem {
+    Dins_Fire,
+    Farores_Wind,
+    Nayrus_Love,
+    Lens_of_Truth,
+    Bow,
+    Hammer,
+    Iron_Boots,
+    Hover_Boots,
+    Hookshot,
+    Longshot,
+    Silver_Gauntlets,
+    Golden_Gauntlets,
+    Goron_Tunic,
+    Zora_Tunic,
+    Scarecrow,
+    Distant_Scarecrow,
+    Slingshot,
+    Boomerang,
+    Kokiri_Sword,
+    Sticks,
+    Deku_Shield,
+    Fire_Arrows,
+    Ice_Arrows,
+    Light_Arrows,
+  };
+
   extern void UpdateHelpers();
   extern bool CanPlay(bool song);
-  extern bool CanUse(std::string_view itemName);
+  extern bool CanUse(CanUseItem itemName);
   extern bool HasProjectile(std::string_view age);
   extern bool SmallKeys(u8 dungeonKeyCount, u8 requiredAmount);
   extern bool EventsUpdated();


### PR DESCRIPTION
Before CanUse() and the functions it called used string comparisons, which are slow. This PR changes them to compare using an enum declared in logic.hpp, called CanUseItem. Items in the enum are referenced with CanUseItem::ItemName.

This roughly halved gen time from ~5 seconds on the latest nightly to ~2.5 seconds.