### PR TITLE
Added a setting to choose the Info Menu button

### DIFF
--- a/code/src/gfx.c
+++ b/code/src/gfx.c
@@ -107,8 +107,18 @@ void Gfx_Update(void) {
     if (!GfxInit) {
         Gfx_Init();
     }
+    
+    u8 openingButton = 0;
+    if(	(gSettingsContext.menuOpeningButton == 0 && rInputCtx.cur.sel) ||
+	(gSettingsContext.menuOpeningButton == 1 && rInputCtx.cur.strt) ||
+	(gSettingsContext.menuOpeningButton == 2 && rInputCtx.cur.d_up) ||
+	(gSettingsContext.menuOpeningButton == 3 && rInputCtx.cur.d_down) ||
+	(gSettingsContext.menuOpeningButton == 4 && rInputCtx.cur.d_right) ||
+	(gSettingsContext.menuOpeningButton == 5 && rInputCtx.cur.d_left)){
+		openingButton = 1;
+    }
 
-    if(gSaveContext.gameMode == 0 && rInputCtx.cur.sel) {
+    if(gSaveContext.gameMode == 0 && openingButton) {
         Gfx_ShowMenu();
         svcSleepThread(1000 * 1000 * 300LL);
     }

--- a/code/src/settings.h
+++ b/code/src/settings.h
@@ -216,6 +216,7 @@ typedef struct {
   u8 damageMultiplier;
   u8 startingTime;
   u8 generateSpoilerLog;
+  u8 menuOpeningButton;
 
   u8 stickAsAdult;
   u8 boomerangAsAdult;

--- a/source/setting_descriptions.cpp
+++ b/source/setting_descriptions.cpp
@@ -352,6 +352,13 @@ string_view damageMultiDesc           = "Changes the amount of damage taken.\n" 
 string_view startingTimeDesc          = "Change up Link's sleep routine.";                 //
                                                                                            //
 /*------------------------------                                                           //
+|      MENU OPENING BUTTON     |                                                           //
+------------------------------*/                                                           //
+string_view menuButtonDesc            = "Choose which button will bring up the Dungeon\n"  //
+                                        "Information Menu. You can also use the menu to\n" //
+                                        "buffer frame perfect inputs if you choose D-Pad"; //
+                                                                                           //
+/*------------------------------                                                           //
 |          ITEM POOL           |                                                           //
 ------------------------------*/                                                           //
 string_view itemPoolPlentiful         = "Extra major items are added to the pool.";        //

--- a/source/setting_descriptions.hpp
+++ b/source/setting_descriptions.hpp
@@ -123,6 +123,8 @@ extern string_view damageMultiDesc;
 
 extern string_view startingTimeDesc;
 
+extern string_view menuButtonDesc;
+
 extern string_view itemPoolPlentiful;
 extern string_view itemPoolBalanced;
 extern string_view itemPoolScarce;

--- a/source/settings.cpp
+++ b/source/settings.cpp
@@ -130,11 +130,13 @@ namespace Settings {
   Option DamageMultiplier    = Option::U8  ("Damage Multiplier",      {"Half", "Default", "Double", "Quadruple", "OHKO"},      {damageMultiDesc});
   Option StartingTime        = Option::U8  ("Starting Time",          {"Day", "Night"},                                        {startingTimeDesc});
   Option GenerateSpoilerLog  = Option::Bool("Generate Spoiler Log",   {"No", "Yes"},                                           {"", ""});
+  Option MenuOpeningButton   = Option::U8  ("Open Info Menu with",  {"Select", "Start", "D-Pad Up", "D-Pad Down", "D-Pad Right", "D-Pad Left",},    {menuButtonDesc});
   bool HasNightStart         = false;
   std::vector<Option *> miscOptions = {
     &DamageMultiplier,
     &StartingTime,
     &GenerateSpoilerLog,
+    &MenuOpeningButton,
   };
 
   //Item Usability Settings
@@ -458,6 +460,7 @@ namespace Settings {
     ctx.damageMultiplier     = DamageMultiplier.Value<u8>();
     ctx.startingTime         = StartingTime.Value<u8>();
     ctx.generateSpoilerLog   = (GenerateSpoilerLog) ? 1 : 0;
+    ctx.menuOpeningButton    = MenuOpeningButton.Value<u8>();
 
     ctx.stickAsAdult         = (StickAsAdult) ? 1 : 0;
     ctx.boomerangAsAdult     = (BoomerangAsAdult) ? 1 : 0;

--- a/source/settings.hpp
+++ b/source/settings.hpp
@@ -286,6 +286,7 @@ namespace Settings {
   extern Option DamageMultiplier;
   extern Option StartingTime;
   extern Option GenerateSpoilerLog;
+  extern Option MenuOpeningButton;
   extern bool HasNightStart;
 
   extern Option StickAsAdult;


### PR DESCRIPTION
I added an option in the settings to choose the button that opens the Info Menu in game.
The default button is still Select, and the other options are Start and the 4 directions on the D-Pad. Button combos could be added too.