### PR TITLE
Logic: Change FiT Compass chest to require 6 keys

### DIFF
--- a/source/location_access.cpp
+++ b/source/location_access.cpp
@@ -1894,7 +1894,7 @@ namespace Exits { //name, scene, hint, events, locations, exits
                   ItemLocationPairing(&FireTemple_BoulderMazeShortcutChest, []{return SmallKeys(FireTempleKeys, 5) && HasExplosives;}),
                   ItemLocationPairing(&FireTemple_ScarecrowChest,           []{return SmallKeys(FireTempleKeys, 5) && (CanUse(CanUseItem::Scarecrow) || (LogicFireScarecrow && CanUse(CanUseItem::Longshot)));}),
                   ItemLocationPairing(&FireTemple_MapChest,                 []{return SmallKeys(FireTempleKeys, 5) || (SmallKeys(FireTempleKeys, 4) && CanUse(CanUseItem::Bow));}),
-                  ItemLocationPairing(&FireTemple_CompassChest,             []{return SmallKeys(FireTempleKeys, 5);}),
+                  ItemLocationPairing(&FireTemple_CompassChest,             []{return SmallKeys(FireTempleKeys, 6);}),
                   ItemLocationPairing(&FireTemple_GS_BoulderMaze,           []{return SmallKeys(FireTempleKeys, 4) && HasExplosives;}),
                   ItemLocationPairing(&FireTemple_GS_ScarecrowClimb,        []{return SmallKeys(FireTempleKeys, 5) && (CanUse(CanUseItem::Scarecrow) || (LogicFireScarecrow && CanUse(CanUseItem::Longshot)));}),
                   ItemLocationPairing(&FireTemple_GS_ScarecrowTop,          []{return SmallKeys(FireTempleKeys, 5) && (CanUse(CanUseItem::Scarecrow) || (LogicFireScarecrow && CanUse(CanUseItem::Longshot)));}),


### PR DESCRIPTION
Small logical error- The compass chest in Fire Temple only requires 5 keys, when it should require 6.

OoTR requires 7 keys, although that is accounting for the key in the basement loop we ignore, subtracting one for that gives 6- https://github.com/TestRunnerSRL/OoT-Randomizer/blob/Dev/data/World/Fire%20Temple.json#L64

[You can also see in this map that you must go through 6 key doors to reach the area that contains the compass chest.](https://drive.google.com/file/d/1Hnp2J8NMsDuC2h0ONCuSZoNDr2gZGfPD/view)

Found from #99 