### PR TITLE
Logic: Add option for nighttime skulltulas expect sun's song

### DIFF
--- a/source/location_access.cpp
+++ b/source/location_access.cpp
@@ -50,9 +50,9 @@ namespace Exits { //name, scene, hint, events, locations, exits
                 }, {
                   //Locations
                   ItemLocationPairing(&KF_KokiriSwordChest,  []{return IsChild;}),
-                  ItemLocationPairing(&KF_GS_KnowItAllHouse, []{return IsChild && CanChildAttack && AtNight && (HasNightStart || CanLeaveForest || CanPlay(SunsSong));}),
+                  ItemLocationPairing(&KF_GS_KnowItAllHouse, []{return IsChild && CanChildAttack && AtNight && (HasNightStart || CanLeaveForest || CanPlay(SunsSong)) && (CanPlay(SunsSong) || !NightGSExpectSuns);}),
                   ItemLocationPairing(&KF_GS_BeanPatch,      []{return CanPlantBugs && CanChildAttack;}),
-                  ItemLocationPairing(&KF_GS_HouseOfTwins,   []{return IsAdult && AtNight && CanUse(CanUseItem::Hookshot);}),
+                  ItemLocationPairing(&KF_GS_HouseOfTwins,   []{return IsAdult && AtNight && CanUse(CanUseItem::Hookshot) && (CanPlay(SunsSong) || !NightGSExpectSuns);}),
                 }, {
                   //Exits
                   ExitPairing::Both(&KF_LinksHouse,       []{return true;}),
@@ -177,7 +177,7 @@ namespace Exits { //name, scene, hint, events, locations, exits
                   //Locations
                   ItemLocationPairing(&LW_DekuScrubNearDekuTheaterRight, []{return IsChild && CanStunDeku;}),
                   ItemLocationPairing(&LW_DekuScrubNearDekuTheaterLeft,  []{return IsChild && CanStunDeku;}),
-                  ItemLocationPairing(&LW_GS_AboveTheater,               []{return IsAdult && AtNight && (LW_BeyondMido.CanPlantBean() || (LogicLostWoodsGSBean && CanUse(CanUseItem::Hookshot) && (CanUse(CanUseItem::Longshot) || CanUse(CanUseItem::Bow) || HasBombchus || CanUse(CanUseItem::Dins_Fire))));}),
+                  ItemLocationPairing(&LW_GS_AboveTheater,               []{return IsAdult && AtNight && (LW_BeyondMido.CanPlantBean() || (LogicLostWoodsGSBean && CanUse(CanUseItem::Hookshot) && (CanUse(CanUseItem::Longshot) || CanUse(CanUseItem::Bow) || HasBombchus || CanUse(CanUseItem::Dins_Fire)))) && (CanPlay(SunsSong) || !NightGSExpectSuns);}),
                   ItemLocationPairing(&LW_GS_BeanPatchNearTheater,       []{return CanPlantBugs && (CanChildAttack || (Scrubsanity.Is(SCRUBSANITY_OFF) && DekuShield));}),
                 }, {
                   //Exits
@@ -229,7 +229,7 @@ namespace Exits { //name, scene, hint, events, locations, exits
                   //Locations
                   ItemLocationPairing(&SongFromSaria, []{return IsChild && ZeldasLetter;}),
                   ItemLocationPairing(&SheikInForest, []{return IsAdult;}),
-                  ItemLocationPairing(&SFM_GS,        []{return CanUse(CanUseItem::Hookshot) && AtNight;}),
+                  ItemLocationPairing(&SFM_GS,        []{return CanUse(CanUseItem::Hookshot) && AtNight && (CanPlay(SunsSong) || !NightGSExpectSuns);}),
                   //SFM Maze Gossip Stone (Lower)
                   //SFM Maze Gossip Stone (Upper)
                   //SFM Saria Gossip Stone
@@ -390,9 +390,9 @@ namespace Exits { //name, scene, hint, events, locations, exits
                   ItemLocationPairing(&LH_Sun,             []{return IsAdult && WaterTempleClear && CanUse(CanUseItem::Bow);}),
                   ItemLocationPairing(&LH_FreestandingPoH, []{return IsAdult && (CanUse(CanUseItem::Scarecrow) || LH_Main.CanPlantBean());}),
                   ItemLocationPairing(&LH_GS_BeanPatch,    []{return CanPlantBugs && CanChildAttack;}),
-                  ItemLocationPairing(&LH_GS_LabWall,      []{return IsChild && (Boomerang || (LogicLabWallGS && (Sticks || KokiriSword))) && AtNight;}),
-                  ItemLocationPairing(&LH_GS_SmallIsland,  []{return IsChild && CanChildAttack && AtNight;}),
-                  ItemLocationPairing(&LH_GS_Tree,         []{return CanUse(CanUseItem::Longshot) && AtNight;}),
+                  ItemLocationPairing(&LH_GS_LabWall,      []{return IsChild && (Boomerang || (LogicLabWallGS && (Sticks || KokiriSword))) && AtNight && (CanPlay(SunsSong) || !NightGSExpectSuns);}),
+                  ItemLocationPairing(&LH_GS_SmallIsland,  []{return IsChild && CanChildAttack && AtNight && (CanPlay(SunsSong) || !NightGSExpectSuns);}),
+                  ItemLocationPairing(&LH_GS_Tree,         []{return CanUse(CanUseItem::Longshot) && AtNight && (CanPlay(SunsSong) || !NightGSExpectSuns);}),
                   //LH Gossip Stone (Southeast)
                   //LH Gossip Stone (Southwest)
                 }, {
@@ -448,7 +448,7 @@ namespace Exits { //name, scene, hint, events, locations, exits
                   EventPairing(&BugRock, []{return IsChild && HasBottle;}),
                 }, {
                   //Locations
-                  ItemLocationPairing(&GV_GS_SmallBridge, []{return CanUse(CanUseItem::Boomerang) && AtNight;}),
+                  ItemLocationPairing(&GV_GS_SmallBridge, []{return CanUse(CanUseItem::Boomerang) && AtNight && (CanPlay(SunsSong) || !NightGSExpectSuns);}),
                 }, {
                   //Exits
                   ExitPairing::Both(&HF_Main,          []{return true;}),
@@ -486,8 +486,8 @@ namespace Exits { //name, scene, hint, events, locations, exits
                 }, {
                   //Locations
                   ItemLocationPairing(&GV_Chest,         []{return CanUse(CanUseItem::Hammer);}),
-                  ItemLocationPairing(&GV_GS_BehindTent, []{return CanUse(CanUseItem::Hookshot) && AtNight;}),
-                  ItemLocationPairing(&GV_GS_Pillar,     []{return CanUse(CanUseItem::Hookshot) && AtNight;}),
+                  ItemLocationPairing(&GV_GS_BehindTent, []{return CanUse(CanUseItem::Hookshot) && AtNight && (CanPlay(SunsSong) || !NightGSExpectSuns);}),
+                  ItemLocationPairing(&GV_GS_Pillar,     []{return CanUse(CanUseItem::Hookshot) && AtNight && (CanPlay(SunsSong) || !NightGSExpectSuns);}),
                 }, {
                   //Exits
                   ExitPairing::Both(&GF_Main,          []{return true;}),
@@ -530,8 +530,8 @@ namespace Exits { //name, scene, hint, events, locations, exits
                   ItemLocationPairing(&GF_SouthF1Carpenter, []{return  IsAdult || KokiriSword;}),
                   ItemLocationPairing(&GF_SouthF2Carpenter, []{return  IsAdult || KokiriSword;}),
                   ItemLocationPairing(&GF_GerudoToken,      []{return CanFinishGerudoFortress;}),
-                  ItemLocationPairing(&GF_GS_ArcheryRange,  []{return CanUse(CanUseItem::Hookshot) && GerudoToken && AtNight;}),
-                  ItemLocationPairing(&GF_GS_TopFloor,      []{return IsAdult && AtNight && (GerudoToken || CanUse(CanUseItem::Bow) || CanUse(CanUseItem::Hookshot) || CanUse(CanUseItem::Hover_Boots) || LogicGerudoKitchen);})
+                  ItemLocationPairing(&GF_GS_ArcheryRange,  []{return CanUse(CanUseItem::Hookshot) && GerudoToken && AtNight && (CanPlay(SunsSong) || !NightGSExpectSuns);}),
+                  ItemLocationPairing(&GF_GS_TopFloor,      []{return IsAdult && AtNight && (GerudoToken || CanUse(CanUseItem::Bow) || CanUse(CanUseItem::Hookshot) || CanUse(CanUseItem::Hover_Boots) || LogicGerudoKitchen) && (CanPlay(SunsSong) || !NightGSExpectSuns);})
                 }, {
                   //Exits
                   ExitPairing::Both(&GV_FortressSide,                []{return true;}),
@@ -594,8 +594,8 @@ namespace Exits { //name, scene, hint, events, locations, exits
                   ItemLocationPairing(&Colossus_FreestandingPoH, []{return IsAdult && Colossus_Main.CanPlantBean();}),
                   ItemLocationPairing(&SheikAtColossus,          []{return true;}),
                   ItemLocationPairing(&Colossus_GS_BeanPatch,    []{return CanPlantBugs && CanChildAttack;}),
-                  ItemLocationPairing(&Colossus_GS_Tree,         []{return CanUse(CanUseItem::Hookshot) && AtNight;}),
-                  ItemLocationPairing(&Colossus_GS_Hill,         []{return IsAdult && AtNight && (Colossus_Main.CanPlantBean() || CanUse(CanUseItem::Longshot) || (LogicColossusGS && CanUse(CanUseItem::Hookshot)));})
+                  ItemLocationPairing(&Colossus_GS_Tree,         []{return CanUse(CanUseItem::Hookshot) && AtNight && (CanPlay(SunsSong) || !NightGSExpectSuns);}),
+                  ItemLocationPairing(&Colossus_GS_Hill,         []{return IsAdult && AtNight && (Colossus_Main.CanPlantBean() || CanUse(CanUseItem::Longshot) || (LogicColossusGS && CanUse(CanUseItem::Hookshot))) && (CanPlay(SunsSong) || !NightGSExpectSuns);})
                   //Colossus Gossip Stone
                 }, {
                   //Exits
@@ -877,12 +877,12 @@ namespace Exits { //name, scene, hint, events, locations, exits
                   ItemLocationPairing(&SheikInKakariko,               []{return IsAdult && ForestMedallion && FireMedallion && WaterMedallion;}),
                   ItemLocationPairing(&Kak_AnjuAsChild,               []{return IsChild && AtDay;}),
                   ItemLocationPairing(&Kak_AnjuAsAdult,               []{return IsAdult && AtDay;}),
-                  ItemLocationPairing(&Kak_GS_HouseUnderConstruction, []{return IsChild && AtNight;}),
-                  ItemLocationPairing(&Kak_GS_SkulltulaHouse,         []{return IsChild && AtNight;}),
-                  ItemLocationPairing(&Kak_GS_GuardsHouse,            []{return IsChild && AtNight;}),
-                  ItemLocationPairing(&Kak_GS_Tree,                   []{return IsChild && AtNight;}),
-                  ItemLocationPairing(&Kak_GS_Watchtower,             []{return IsChild && (Slingshot || HasBombchus) && AtNight;}),
-                  ItemLocationPairing(&Kak_GS_AboveImpasHouse,        []{return CanUse(CanUseItem::Hookshot) && AtNight;}),
+                  ItemLocationPairing(&Kak_GS_HouseUnderConstruction, []{return IsChild && AtNight && (CanPlay(SunsSong) || !NightGSExpectSuns);}),
+                  ItemLocationPairing(&Kak_GS_SkulltulaHouse,         []{return IsChild && AtNight && (CanPlay(SunsSong) || !NightGSExpectSuns);}),
+                  ItemLocationPairing(&Kak_GS_GuardsHouse,            []{return IsChild && AtNight && (CanPlay(SunsSong) || !NightGSExpectSuns);}),
+                  ItemLocationPairing(&Kak_GS_Tree,                   []{return IsChild && AtNight && (CanPlay(SunsSong) || !NightGSExpectSuns);}),
+                  ItemLocationPairing(&Kak_GS_Watchtower,             []{return IsChild && (Slingshot || HasBombchus) && AtNight && (CanPlay(SunsSong) || !NightGSExpectSuns);}),
+                  ItemLocationPairing(&Kak_GS_AboveImpasHouse,        []{return CanUse(CanUseItem::Hookshot) && AtNight && (CanPlay(SunsSong) || !NightGSExpectSuns);}),
                 }, {
                   //Exits
                   ExitPairing::Both(&HF_Main,                []{return true;}),
@@ -1061,7 +1061,7 @@ namespace Exits { //name, scene, hint, events, locations, exits
                   //Locations
                   ItemLocationPairing(&GY_FreestandingPoH,       []{return (IsAdult && (GY_Main.CanPlantBean() || CanUse(CanUseItem::Longshot))) || (LogicGraveyardPoH && CanUse(CanUseItem::Boomerang));}),
                   ItemLocationPairing(&GY_DampeGravediggingTour, []{return IsChild && AtNight;}), //This needs to change
-                  ItemLocationPairing(&GY_GS_Wall,               []{return CanUse(CanUseItem::Boomerang) && AtNight;}),
+                  ItemLocationPairing(&GY_GS_Wall,               []{return CanUse(CanUseItem::Boomerang) && AtNight && (CanPlay(SunsSong) || !NightGSExpectSuns);}),
                   ItemLocationPairing(&GY_GS_BeanPatch,          []{return CanPlantBugs && CanChildAttack;}),
                 }, {
                   //Exits
@@ -1148,7 +1148,7 @@ namespace Exits { //name, scene, hint, events, locations, exits
                   ItemLocationPairing(&DMT_FreestandingPoH,        []{return (DamageMultiplier.IsNot(DAMAGEMULTIPLIER_OHKO)) || CanUse(CanUseItem::Nayrus_Love) || Fairy || CanUse(CanUseItem::Hover_Boots) || (IsAdult && DMT_Main.CanPlantBean() && (HasExplosives || GoronBracelet));}),
                   ItemLocationPairing(&DMT_GS_BeanPatch,           []{return CanPlantBugs && (HasExplosives || GoronBracelet || (LogicDMTSoilGS && CanUse(CanUseItem::Boomerang)));}),
                   ItemLocationPairing(&DMT_GS_NearKak,             []{return CanBlastOrSmash;}),
-                  ItemLocationPairing(&DMT_GS_AboveDodongosCavern, []{return IsAdult && AtNight && CanUse(CanUseItem::Hammer);})
+                  ItemLocationPairing(&DMT_GS_AboveDodongosCavern, []{return IsAdult && AtNight && CanUse(CanUseItem::Hammer) && (CanPlay(SunsSong) || !NightGSExpectSuns);})
                 }, {
                   //Exits
                   ExitPairing::Both(&Kak_BehindGate,          []{return true;}),
@@ -1166,7 +1166,7 @@ namespace Exits { //name, scene, hint, events, locations, exits
                 }, {
                   //Locations
                   ItemLocationPairing(&DMT_Biggoron,            []{return IsAdult && (ClaimCheck || (GuaranteeTradePath && (EyedropsAccess || (Eyedrops && DisableTradeRevert))));}),
-                  ItemLocationPairing(&DMT_GS_FallingRocksPath, []{return IsAdult && AtNight && CanUse(CanUseItem::Hammer);}),
+                  ItemLocationPairing(&DMT_GS_FallingRocksPath, []{return IsAdult && AtNight && CanUse(CanUseItem::Hammer) && (CanPlay(SunsSong) || !NightGSExpectSuns);}),
                   //DMT Gossip Stone
                 }, {
                   //Exits
@@ -1415,9 +1415,9 @@ namespace Exits { //name, scene, hint, events, locations, exits
                   ItemLocationPairing(&ZR_FrogsInTheRain,                []{return IsChild && CanPlay(SongOfStorms);}),
                   ItemLocationPairing(&ZR_NearOpenGrottoFreestandingPoH, []{return IsChild || CanUse(CanUseItem::Hover_Boots) || (IsAdult && LogicZoraRiverLower);}),
                   ItemLocationPairing(&ZR_NearDomainFreestandingPoH,     []{return IsChild || CanUse(CanUseItem::Hover_Boots) || (IsAdult && LogicZoraRiverUpper);}),
-                  ItemLocationPairing(&ZR_GS_Ladder,                     []{return IsChild && AtNight && CanChildAttack;}),
-                  ItemLocationPairing(&ZR_GS_NearRaisedGrottos,          []{return CanUse(CanUseItem::Hookshot) && AtNight;}),
-                  ItemLocationPairing(&ZR_GS_AboveBridge,                []{return CanUse(CanUseItem::Hookshot) && AtNight;}),
+                  ItemLocationPairing(&ZR_GS_Ladder,                     []{return IsChild && AtNight && CanChildAttack && (CanPlay(SunsSong) || !NightGSExpectSuns);}),
+                  ItemLocationPairing(&ZR_GS_NearRaisedGrottos,          []{return CanUse(CanUseItem::Hookshot) && AtNight && (CanPlay(SunsSong) || !NightGSExpectSuns);}),
+                  ItemLocationPairing(&ZR_GS_AboveBridge,                []{return CanUse(CanUseItem::Hookshot) && AtNight && (CanPlay(SunsSong) || !NightGSExpectSuns);}),
                   //ZR Near Grottos Gossip Stone
                   //ZR Near Domain Gossip Stone
                 }, {
@@ -1476,7 +1476,7 @@ namespace Exits { //name, scene, hint, events, locations, exits
                   ItemLocationPairing(&ZD_DivingMinigame,     []{return IsChild;}),
                   ItemLocationPairing(&ZD_Chest,              []{return CanUse(CanUseItem::Sticks);}),
                   ItemLocationPairing(&ZD_KingZoraThawed,     []{return KingZoraThawed;}),
-                  ItemLocationPairing(&ZD_GS_FrozenWaterfall, []{return IsAdult && AtNight && (Hookshot || Bow || MagicMeter);}),
+                  ItemLocationPairing(&ZD_GS_FrozenWaterfall, []{return IsAdult && AtNight && (Hookshot || Bow || MagicMeter) && (CanPlay(SunsSong) || !NightGSExpectSuns);}),
                   //ZD Gossip Stone
                 }, {
                   //Exits
@@ -1525,8 +1525,8 @@ namespace Exits { //name, scene, hint, events, locations, exits
                   ItemLocationPairing(&ZF_IcebergFreestandingPoH, []{return IsAdult;}),
                   ItemLocationPairing(&ZF_BottomFreestandingPoH,  []{return IsAdult && IronBoots && (LogicFewerTunicRequirements || CanUse(CanUseItem::Zora_Tunic));}),
                   ItemLocationPairing(&ZF_GS_Tree,                []{return IsChild;}),
-                  ItemLocationPairing(&ZF_GS_AboveTheLog,         []{return CanUse(CanUseItem::Boomerang) && AtNight;}),
-                  ItemLocationPairing(&ZF_GS_HiddenCave,          []{return CanUse(CanUseItem::Silver_Gauntlets) && CanBlastOrSmash && CanUse(CanUseItem::Hookshot) && AtNight;}),
+                  ItemLocationPairing(&ZF_GS_AboveTheLog,         []{return CanUse(CanUseItem::Boomerang) && AtNight && (CanPlay(SunsSong) || !NightGSExpectSuns);}),
+                  ItemLocationPairing(&ZF_GS_HiddenCave,          []{return CanUse(CanUseItem::Silver_Gauntlets) && CanBlastOrSmash && CanUse(CanUseItem::Hookshot) && AtNight && (CanPlay(SunsSong) || !NightGSExpectSuns);}),
                   //ZF Fairy Gossip Stone
                   //ZF Jabu Gossip Stone
                 }, {
@@ -1555,9 +1555,9 @@ namespace Exits { //name, scene, hint, events, locations, exits
                   //Locations
                   ItemLocationPairing(&SongFromMalon,      []{return IsChild && ZeldasLetter && Ocarina && AtDay;}),
                   ItemLocationPairing(&LLR_GS_Tree,        []{return IsChild;}),
-                  ItemLocationPairing(&LLR_GS_RainShed,    []{return IsChild && AtNight;}),
-                  ItemLocationPairing(&LLR_GS_HouseWindow, []{return CanUse(CanUseItem::Boomerang) && AtNight;}),
-                  ItemLocationPairing(&LLR_GS_BackWall,    []{return CanUse(CanUseItem::Boomerang) && AtNight;}),
+                  ItemLocationPairing(&LLR_GS_RainShed,    []{return IsChild && AtNight && (CanPlay(SunsSong) || !NightGSExpectSuns);}),
+                  ItemLocationPairing(&LLR_GS_HouseWindow, []{return CanUse(CanUseItem::Boomerang) && AtNight && (CanPlay(SunsSong) || !NightGSExpectSuns);}),
+                  ItemLocationPairing(&LLR_GS_BackWall,    []{return CanUse(CanUseItem::Boomerang) && AtNight && (CanPlay(SunsSong) || !NightGSExpectSuns);}),
                 }, {
                   //Exits
                   ExitPairing::Both(&HF_Main,         []{return true;}),

--- a/source/location_access.cpp
+++ b/source/location_access.cpp
@@ -50,9 +50,9 @@ namespace Exits { //name, scene, hint, events, locations, exits
                 }, {
                   //Locations
                   ItemLocationPairing(&KF_KokiriSwordChest,  []{return IsChild;}),
-                  ItemLocationPairing(&KF_GS_KnowItAllHouse, []{return IsChild && CanChildAttack && AtNight && (HasNightStart || CanLeaveForest || CanPlay(SunsSong)) && (CanPlay(SunsSong) || !NightGSExpectSuns);}),
+                  ItemLocationPairing(&KF_GS_KnowItAllHouse, []{return IsChild && CanChildAttack && AtNight && (HasNightStart || CanLeaveForest || CanPlay(SunsSong)) && CanGetNightTimeGS;}),
                   ItemLocationPairing(&KF_GS_BeanPatch,      []{return CanPlantBugs && CanChildAttack;}),
-                  ItemLocationPairing(&KF_GS_HouseOfTwins,   []{return IsAdult && AtNight && CanUse(CanUseItem::Hookshot) && (CanPlay(SunsSong) || !NightGSExpectSuns);}),
+                  ItemLocationPairing(&KF_GS_HouseOfTwins,   []{return IsAdult && AtNight && CanUse(CanUseItem::Hookshot) && CanGetNightTimeGS;}),
                 }, {
                   //Exits
                   ExitPairing::Both(&KF_LinksHouse,       []{return true;}),
@@ -177,7 +177,7 @@ namespace Exits { //name, scene, hint, events, locations, exits
                   //Locations
                   ItemLocationPairing(&LW_DekuScrubNearDekuTheaterRight, []{return IsChild && CanStunDeku;}),
                   ItemLocationPairing(&LW_DekuScrubNearDekuTheaterLeft,  []{return IsChild && CanStunDeku;}),
-                  ItemLocationPairing(&LW_GS_AboveTheater,               []{return IsAdult && AtNight && (LW_BeyondMido.CanPlantBean() || (LogicLostWoodsGSBean && CanUse(CanUseItem::Hookshot) && (CanUse(CanUseItem::Longshot) || CanUse(CanUseItem::Bow) || HasBombchus || CanUse(CanUseItem::Dins_Fire)))) && (CanPlay(SunsSong) || !NightGSExpectSuns);}),
+                  ItemLocationPairing(&LW_GS_AboveTheater,               []{return IsAdult && AtNight && (LW_BeyondMido.CanPlantBean() || (LogicLostWoodsGSBean && CanUse(CanUseItem::Hookshot) && (CanUse(CanUseItem::Longshot) || CanUse(CanUseItem::Bow) || HasBombchus || CanUse(CanUseItem::Dins_Fire)))) && CanGetNightTimeGS;}),
                   ItemLocationPairing(&LW_GS_BeanPatchNearTheater,       []{return CanPlantBugs && (CanChildAttack || (Scrubsanity.Is(SCRUBSANITY_OFF) && DekuShield));}),
                 }, {
                   //Exits
@@ -229,7 +229,7 @@ namespace Exits { //name, scene, hint, events, locations, exits
                   //Locations
                   ItemLocationPairing(&SongFromSaria, []{return IsChild && ZeldasLetter;}),
                   ItemLocationPairing(&SheikInForest, []{return IsAdult;}),
-                  ItemLocationPairing(&SFM_GS,        []{return CanUse(CanUseItem::Hookshot) && AtNight && (CanPlay(SunsSong) || !NightGSExpectSuns);}),
+                  ItemLocationPairing(&SFM_GS,        []{return CanUse(CanUseItem::Hookshot) && AtNight && CanGetNightTimeGS;}),
                   //SFM Maze Gossip Stone (Lower)
                   //SFM Maze Gossip Stone (Upper)
                   //SFM Saria Gossip Stone
@@ -390,9 +390,9 @@ namespace Exits { //name, scene, hint, events, locations, exits
                   ItemLocationPairing(&LH_Sun,             []{return IsAdult && WaterTempleClear && CanUse(CanUseItem::Bow);}),
                   ItemLocationPairing(&LH_FreestandingPoH, []{return IsAdult && (CanUse(CanUseItem::Scarecrow) || LH_Main.CanPlantBean());}),
                   ItemLocationPairing(&LH_GS_BeanPatch,    []{return CanPlantBugs && CanChildAttack;}),
-                  ItemLocationPairing(&LH_GS_LabWall,      []{return IsChild && (Boomerang || (LogicLabWallGS && (Sticks || KokiriSword))) && AtNight && (CanPlay(SunsSong) || !NightGSExpectSuns);}),
-                  ItemLocationPairing(&LH_GS_SmallIsland,  []{return IsChild && CanChildAttack && AtNight && (CanPlay(SunsSong) || !NightGSExpectSuns);}),
-                  ItemLocationPairing(&LH_GS_Tree,         []{return CanUse(CanUseItem::Longshot) && AtNight && (CanPlay(SunsSong) || !NightGSExpectSuns);}),
+                  ItemLocationPairing(&LH_GS_LabWall,      []{return IsChild && (Boomerang || (LogicLabWallGS && (Sticks || KokiriSword))) && AtNight && CanGetNightTimeGS;}),
+                  ItemLocationPairing(&LH_GS_SmallIsland,  []{return IsChild && CanChildAttack && AtNight && CanGetNightTimeGS;}),
+                  ItemLocationPairing(&LH_GS_Tree,         []{return CanUse(CanUseItem::Longshot) && AtNight && CanGetNightTimeGS;}),
                   //LH Gossip Stone (Southeast)
                   //LH Gossip Stone (Southwest)
                 }, {
@@ -448,7 +448,7 @@ namespace Exits { //name, scene, hint, events, locations, exits
                   EventPairing(&BugRock, []{return IsChild && HasBottle;}),
                 }, {
                   //Locations
-                  ItemLocationPairing(&GV_GS_SmallBridge, []{return CanUse(CanUseItem::Boomerang) && AtNight && (CanPlay(SunsSong) || !NightGSExpectSuns);}),
+                  ItemLocationPairing(&GV_GS_SmallBridge, []{return CanUse(CanUseItem::Boomerang) && AtNight && CanGetNightTimeGS;}),
                 }, {
                   //Exits
                   ExitPairing::Both(&HF_Main,          []{return true;}),
@@ -486,8 +486,8 @@ namespace Exits { //name, scene, hint, events, locations, exits
                 }, {
                   //Locations
                   ItemLocationPairing(&GV_Chest,         []{return CanUse(CanUseItem::Hammer);}),
-                  ItemLocationPairing(&GV_GS_BehindTent, []{return CanUse(CanUseItem::Hookshot) && AtNight && (CanPlay(SunsSong) || !NightGSExpectSuns);}),
-                  ItemLocationPairing(&GV_GS_Pillar,     []{return CanUse(CanUseItem::Hookshot) && AtNight && (CanPlay(SunsSong) || !NightGSExpectSuns);}),
+                  ItemLocationPairing(&GV_GS_BehindTent, []{return CanUse(CanUseItem::Hookshot) && AtNight && CanGetNightTimeGS;}),
+                  ItemLocationPairing(&GV_GS_Pillar,     []{return CanUse(CanUseItem::Hookshot) && AtNight && CanGetNightTimeGS;}),
                 }, {
                   //Exits
                   ExitPairing::Both(&GF_Main,          []{return true;}),
@@ -530,8 +530,8 @@ namespace Exits { //name, scene, hint, events, locations, exits
                   ItemLocationPairing(&GF_SouthF1Carpenter, []{return  IsAdult || KokiriSword;}),
                   ItemLocationPairing(&GF_SouthF2Carpenter, []{return  IsAdult || KokiriSword;}),
                   ItemLocationPairing(&GF_GerudoToken,      []{return CanFinishGerudoFortress;}),
-                  ItemLocationPairing(&GF_GS_ArcheryRange,  []{return CanUse(CanUseItem::Hookshot) && GerudoToken && AtNight && (CanPlay(SunsSong) || !NightGSExpectSuns);}),
-                  ItemLocationPairing(&GF_GS_TopFloor,      []{return IsAdult && AtNight && (GerudoToken || CanUse(CanUseItem::Bow) || CanUse(CanUseItem::Hookshot) || CanUse(CanUseItem::Hover_Boots) || LogicGerudoKitchen) && (CanPlay(SunsSong) || !NightGSExpectSuns);})
+                  ItemLocationPairing(&GF_GS_ArcheryRange,  []{return CanUse(CanUseItem::Hookshot) && GerudoToken && AtNight && CanGetNightTimeGS;}),
+                  ItemLocationPairing(&GF_GS_TopFloor,      []{return IsAdult && AtNight && (GerudoToken || CanUse(CanUseItem::Bow) || CanUse(CanUseItem::Hookshot) || CanUse(CanUseItem::Hover_Boots) || LogicGerudoKitchen) && CanGetNightTimeGS;})
                 }, {
                   //Exits
                   ExitPairing::Both(&GV_FortressSide,                []{return true;}),
@@ -594,8 +594,8 @@ namespace Exits { //name, scene, hint, events, locations, exits
                   ItemLocationPairing(&Colossus_FreestandingPoH, []{return IsAdult && Colossus_Main.CanPlantBean();}),
                   ItemLocationPairing(&SheikAtColossus,          []{return true;}),
                   ItemLocationPairing(&Colossus_GS_BeanPatch,    []{return CanPlantBugs && CanChildAttack;}),
-                  ItemLocationPairing(&Colossus_GS_Tree,         []{return CanUse(CanUseItem::Hookshot) && AtNight && (CanPlay(SunsSong) || !NightGSExpectSuns);}),
-                  ItemLocationPairing(&Colossus_GS_Hill,         []{return IsAdult && AtNight && (Colossus_Main.CanPlantBean() || CanUse(CanUseItem::Longshot) || (LogicColossusGS && CanUse(CanUseItem::Hookshot))) && (CanPlay(SunsSong) || !NightGSExpectSuns);})
+                  ItemLocationPairing(&Colossus_GS_Tree,         []{return CanUse(CanUseItem::Hookshot) && AtNight && CanGetNightTimeGS;}),
+                  ItemLocationPairing(&Colossus_GS_Hill,         []{return IsAdult && AtNight && (Colossus_Main.CanPlantBean() || CanUse(CanUseItem::Longshot) || (LogicColossusGS && CanUse(CanUseItem::Hookshot))) && CanGetNightTimeGS;})
                   //Colossus Gossip Stone
                 }, {
                   //Exits
@@ -877,12 +877,12 @@ namespace Exits { //name, scene, hint, events, locations, exits
                   ItemLocationPairing(&SheikInKakariko,               []{return IsAdult && ForestMedallion && FireMedallion && WaterMedallion;}),
                   ItemLocationPairing(&Kak_AnjuAsChild,               []{return IsChild && AtDay;}),
                   ItemLocationPairing(&Kak_AnjuAsAdult,               []{return IsAdult && AtDay;}),
-                  ItemLocationPairing(&Kak_GS_HouseUnderConstruction, []{return IsChild && AtNight && (CanPlay(SunsSong) || !NightGSExpectSuns);}),
-                  ItemLocationPairing(&Kak_GS_SkulltulaHouse,         []{return IsChild && AtNight && (CanPlay(SunsSong) || !NightGSExpectSuns);}),
-                  ItemLocationPairing(&Kak_GS_GuardsHouse,            []{return IsChild && AtNight && (CanPlay(SunsSong) || !NightGSExpectSuns);}),
-                  ItemLocationPairing(&Kak_GS_Tree,                   []{return IsChild && AtNight && (CanPlay(SunsSong) || !NightGSExpectSuns);}),
-                  ItemLocationPairing(&Kak_GS_Watchtower,             []{return IsChild && (Slingshot || HasBombchus) && AtNight && (CanPlay(SunsSong) || !NightGSExpectSuns);}),
-                  ItemLocationPairing(&Kak_GS_AboveImpasHouse,        []{return CanUse(CanUseItem::Hookshot) && AtNight && (CanPlay(SunsSong) || !NightGSExpectSuns);}),
+                  ItemLocationPairing(&Kak_GS_HouseUnderConstruction, []{return IsChild && AtNight && CanGetNightTimeGS;}),
+                  ItemLocationPairing(&Kak_GS_SkulltulaHouse,         []{return IsChild && AtNight && CanGetNightTimeGS;}),
+                  ItemLocationPairing(&Kak_GS_GuardsHouse,            []{return IsChild && AtNight && CanGetNightTimeGS;}),
+                  ItemLocationPairing(&Kak_GS_Tree,                   []{return IsChild && AtNight && CanGetNightTimeGS;}),
+                  ItemLocationPairing(&Kak_GS_Watchtower,             []{return IsChild && (Slingshot || HasBombchus) && AtNight && CanGetNightTimeGS;}),
+                  ItemLocationPairing(&Kak_GS_AboveImpasHouse,        []{return CanUse(CanUseItem::Hookshot) && AtNight && CanGetNightTimeGS;}),
                 }, {
                   //Exits
                   ExitPairing::Both(&HF_Main,                []{return true;}),
@@ -1061,7 +1061,7 @@ namespace Exits { //name, scene, hint, events, locations, exits
                   //Locations
                   ItemLocationPairing(&GY_FreestandingPoH,       []{return (IsAdult && (GY_Main.CanPlantBean() || CanUse(CanUseItem::Longshot))) || (LogicGraveyardPoH && CanUse(CanUseItem::Boomerang));}),
                   ItemLocationPairing(&GY_DampeGravediggingTour, []{return IsChild && AtNight;}), //This needs to change
-                  ItemLocationPairing(&GY_GS_Wall,               []{return CanUse(CanUseItem::Boomerang) && AtNight && (CanPlay(SunsSong) || !NightGSExpectSuns);}),
+                  ItemLocationPairing(&GY_GS_Wall,               []{return CanUse(CanUseItem::Boomerang) && AtNight && CanGetNightTimeGS;}),
                   ItemLocationPairing(&GY_GS_BeanPatch,          []{return CanPlantBugs && CanChildAttack;}),
                 }, {
                   //Exits
@@ -1148,7 +1148,7 @@ namespace Exits { //name, scene, hint, events, locations, exits
                   ItemLocationPairing(&DMT_FreestandingPoH,        []{return (DamageMultiplier.IsNot(DAMAGEMULTIPLIER_OHKO)) || CanUse(CanUseItem::Nayrus_Love) || Fairy || CanUse(CanUseItem::Hover_Boots) || (IsAdult && DMT_Main.CanPlantBean() && (HasExplosives || GoronBracelet));}),
                   ItemLocationPairing(&DMT_GS_BeanPatch,           []{return CanPlantBugs && (HasExplosives || GoronBracelet || (LogicDMTSoilGS && CanUse(CanUseItem::Boomerang)));}),
                   ItemLocationPairing(&DMT_GS_NearKak,             []{return CanBlastOrSmash;}),
-                  ItemLocationPairing(&DMT_GS_AboveDodongosCavern, []{return IsAdult && AtNight && CanUse(CanUseItem::Hammer) && (CanPlay(SunsSong) || !NightGSExpectSuns);})
+                  ItemLocationPairing(&DMT_GS_AboveDodongosCavern, []{return IsAdult && AtNight && CanUse(CanUseItem::Hammer) && CanGetNightTimeGS;})
                 }, {
                   //Exits
                   ExitPairing::Both(&Kak_BehindGate,          []{return true;}),
@@ -1166,7 +1166,7 @@ namespace Exits { //name, scene, hint, events, locations, exits
                 }, {
                   //Locations
                   ItemLocationPairing(&DMT_Biggoron,            []{return IsAdult && (ClaimCheck || (GuaranteeTradePath && (EyedropsAccess || (Eyedrops && DisableTradeRevert))));}),
-                  ItemLocationPairing(&DMT_GS_FallingRocksPath, []{return IsAdult && AtNight && CanUse(CanUseItem::Hammer) && (CanPlay(SunsSong) || !NightGSExpectSuns);}),
+                  ItemLocationPairing(&DMT_GS_FallingRocksPath, []{return IsAdult && AtNight && CanUse(CanUseItem::Hammer) && CanGetNightTimeGS;}),
                   //DMT Gossip Stone
                 }, {
                   //Exits
@@ -1415,9 +1415,9 @@ namespace Exits { //name, scene, hint, events, locations, exits
                   ItemLocationPairing(&ZR_FrogsInTheRain,                []{return IsChild && CanPlay(SongOfStorms);}),
                   ItemLocationPairing(&ZR_NearOpenGrottoFreestandingPoH, []{return IsChild || CanUse(CanUseItem::Hover_Boots) || (IsAdult && LogicZoraRiverLower);}),
                   ItemLocationPairing(&ZR_NearDomainFreestandingPoH,     []{return IsChild || CanUse(CanUseItem::Hover_Boots) || (IsAdult && LogicZoraRiverUpper);}),
-                  ItemLocationPairing(&ZR_GS_Ladder,                     []{return IsChild && AtNight && CanChildAttack && (CanPlay(SunsSong) || !NightGSExpectSuns);}),
-                  ItemLocationPairing(&ZR_GS_NearRaisedGrottos,          []{return CanUse(CanUseItem::Hookshot) && AtNight && (CanPlay(SunsSong) || !NightGSExpectSuns);}),
-                  ItemLocationPairing(&ZR_GS_AboveBridge,                []{return CanUse(CanUseItem::Hookshot) && AtNight && (CanPlay(SunsSong) || !NightGSExpectSuns);}),
+                  ItemLocationPairing(&ZR_GS_Ladder,                     []{return IsChild && AtNight && CanChildAttack && CanGetNightTimeGS;}),
+                  ItemLocationPairing(&ZR_GS_NearRaisedGrottos,          []{return CanUse(CanUseItem::Hookshot) && AtNight && CanGetNightTimeGS;}),
+                  ItemLocationPairing(&ZR_GS_AboveBridge,                []{return CanUse(CanUseItem::Hookshot) && AtNight && CanGetNightTimeGS;}),
                   //ZR Near Grottos Gossip Stone
                   //ZR Near Domain Gossip Stone
                 }, {
@@ -1476,7 +1476,7 @@ namespace Exits { //name, scene, hint, events, locations, exits
                   ItemLocationPairing(&ZD_DivingMinigame,     []{return IsChild;}),
                   ItemLocationPairing(&ZD_Chest,              []{return CanUse(CanUseItem::Sticks);}),
                   ItemLocationPairing(&ZD_KingZoraThawed,     []{return KingZoraThawed;}),
-                  ItemLocationPairing(&ZD_GS_FrozenWaterfall, []{return IsAdult && AtNight && (Hookshot || Bow || MagicMeter) && (CanPlay(SunsSong) || !NightGSExpectSuns);}),
+                  ItemLocationPairing(&ZD_GS_FrozenWaterfall, []{return IsAdult && AtNight && (Hookshot || Bow || MagicMeter) && CanGetNightTimeGS;}),
                   //ZD Gossip Stone
                 }, {
                   //Exits
@@ -1525,8 +1525,8 @@ namespace Exits { //name, scene, hint, events, locations, exits
                   ItemLocationPairing(&ZF_IcebergFreestandingPoH, []{return IsAdult;}),
                   ItemLocationPairing(&ZF_BottomFreestandingPoH,  []{return IsAdult && IronBoots && (LogicFewerTunicRequirements || CanUse(CanUseItem::Zora_Tunic));}),
                   ItemLocationPairing(&ZF_GS_Tree,                []{return IsChild;}),
-                  ItemLocationPairing(&ZF_GS_AboveTheLog,         []{return CanUse(CanUseItem::Boomerang) && AtNight && (CanPlay(SunsSong) || !NightGSExpectSuns);}),
-                  ItemLocationPairing(&ZF_GS_HiddenCave,          []{return CanUse(CanUseItem::Silver_Gauntlets) && CanBlastOrSmash && CanUse(CanUseItem::Hookshot) && AtNight && (CanPlay(SunsSong) || !NightGSExpectSuns);}),
+                  ItemLocationPairing(&ZF_GS_AboveTheLog,         []{return CanUse(CanUseItem::Boomerang) && AtNight && CanGetNightTimeGS;}),
+                  ItemLocationPairing(&ZF_GS_HiddenCave,          []{return CanUse(CanUseItem::Silver_Gauntlets) && CanBlastOrSmash && CanUse(CanUseItem::Hookshot) && AtNight && CanGetNightTimeGS;}),
                   //ZF Fairy Gossip Stone
                   //ZF Jabu Gossip Stone
                 }, {
@@ -1555,9 +1555,9 @@ namespace Exits { //name, scene, hint, events, locations, exits
                   //Locations
                   ItemLocationPairing(&SongFromMalon,      []{return IsChild && ZeldasLetter && Ocarina && AtDay;}),
                   ItemLocationPairing(&LLR_GS_Tree,        []{return IsChild;}),
-                  ItemLocationPairing(&LLR_GS_RainShed,    []{return IsChild && AtNight && (CanPlay(SunsSong) || !NightGSExpectSuns);}),
-                  ItemLocationPairing(&LLR_GS_HouseWindow, []{return CanUse(CanUseItem::Boomerang) && AtNight && (CanPlay(SunsSong) || !NightGSExpectSuns);}),
-                  ItemLocationPairing(&LLR_GS_BackWall,    []{return CanUse(CanUseItem::Boomerang) && AtNight && (CanPlay(SunsSong) || !NightGSExpectSuns);}),
+                  ItemLocationPairing(&LLR_GS_RainShed,    []{return IsChild && AtNight && CanGetNightTimeGS;}),
+                  ItemLocationPairing(&LLR_GS_HouseWindow, []{return CanUse(CanUseItem::Boomerang) && AtNight && CanGetNightTimeGS;}),
+                  ItemLocationPairing(&LLR_GS_BackWall,    []{return CanUse(CanUseItem::Boomerang) && AtNight && CanGetNightTimeGS;}),
                 }, {
                   //Exits
                   ExitPairing::Both(&HF_Main,         []{return true;}),

--- a/source/logic.cpp
+++ b/source/logic.cpp
@@ -230,6 +230,7 @@ namespace Logic {
   bool CanOpenStormGrotto  = false;
   bool BigPoeKill          = false;
   bool HookshotOrBoomerang = false;
+  bool CanGetNightTimeGS   = false;
 
   bool GuaranteeTradePath     = false;
   bool GuaranteeHint          = false;
@@ -448,6 +449,7 @@ namespace Logic {
     CanOpenBombGrotto   = CanBlastOrSmash       && (ShardOfAgony || LogicGrottosWithoutAgony);
     CanOpenStormGrotto  = CanPlay(SongOfStorms) && (ShardOfAgony || LogicGrottosWithoutAgony);
     HookshotOrBoomerang = CanUse(CanUseItem::Hookshot) || CanUse(CanUseItem::Boomerang);
+    CanGetNightTimeGS = (CanPlay(SunsSong) || !NightGSExpectSuns);
 
     GuaranteeTradePath     = ShuffleInteriorEntrances || ShuffleOverworldEntrances || LogicBiggoronBolero || CanBlastOrSmash || StopGCRollingGoronAsAdult;
   //GuaranteeHint          = (hints == "Mask" && MaskofTruth) || (hints == "Agony") || (hints != "Mask" && hints != "Agony");

--- a/source/logic.hpp
+++ b/source/logic.hpp
@@ -225,6 +225,7 @@ namespace Logic {
   extern bool CanOpenBombGrotto;
   extern bool CanOpenStormGrotto;
   extern bool HookshotOrBoomerang;
+  extern bool CanGetNightTimeGS;
   extern bool BigPoeKill;
 
   extern bool GuaranteeTradePath;

--- a/source/setting_descriptions.cpp
+++ b/source/setting_descriptions.cpp
@@ -352,6 +352,14 @@ string_view damageMultiDesc           = "Changes the amount of damage taken.\n" 
 string_view startingTimeDesc          = "Change up Link's sleep routine.";                 //
                                                                                            //
 /*------------------------------                                                           //
+|     NIGHT GS EXPECT SUNS     |                                                           //
+------------------------------*/                                                           //
+string_view nightGSDesc               = "GS Tokens that can only be obtained during the\n" //
+                                        "night expect you to have Sun's Song to collect\n" //
+                                        "them. This prevents needing to wait until night\n"//
+                                        "for some locations";                              //
+                                                                                           //
+/*------------------------------                                                           //
 |      MENU OPENING BUTTON     |                                                           //
 ------------------------------*/                                                           //
 string_view menuButtonDesc            = "Choose which button will bring up the Dungeon\n"  //

--- a/source/setting_descriptions.cpp
+++ b/source/setting_descriptions.cpp
@@ -357,7 +357,7 @@ string_view startingTimeDesc          = "Change up Link's sleep routine.";      
 string_view nightGSDesc               = "GS Tokens that can only be obtained during the\n" //
                                         "night expect you to have Sun's Song to collect\n" //
                                         "them. This prevents needing to wait until night\n"//
-                                        "for some locations";                              //
+                                        "for some locations.";                             //
                                                                                            //
 /*------------------------------                                                           //
 |      MENU OPENING BUTTON     |                                                           //

--- a/source/setting_descriptions.hpp
+++ b/source/setting_descriptions.hpp
@@ -123,6 +123,8 @@ extern string_view damageMultiDesc;
 
 extern string_view startingTimeDesc;
 
+extern string_view nightGSDesc;
+
 extern string_view menuButtonDesc;
 
 extern string_view itemPoolPlentiful;

--- a/source/settings.cpp
+++ b/source/settings.cpp
@@ -130,12 +130,14 @@ namespace Settings {
   //Misc Settings
   Option DamageMultiplier    = Option::U8  ("Damage Multiplier",      {"Half", "Default", "Double", "Quadruple", "OHKO"},      {damageMultiDesc});
   Option StartingTime        = Option::U8  ("Starting Time",          {"Day", "Night"},                                        {startingTimeDesc});
+  Option NightGSExpectSuns   = Option::Bool("Night GS Expect Sun's",  {"Off", "On"},                                 {nightGSDesc});
   Option GenerateSpoilerLog  = Option::Bool("Generate Spoiler Log",   {"No", "Yes"},                                           {"", ""});
-  Option MenuOpeningButton   = Option::U8  ("Open Info Menu with",  {"Select", "Start", "D-Pad Up", "D-Pad Down", "D-Pad Right", "D-Pad Left",},    {menuButtonDesc});
+  Option MenuOpeningButton   = Option::U8  ("Open Info Menu with",    {"Select", "Start", "D-Pad Up", "D-Pad Down", "D-Pad Right", "D-Pad Left",},    {menuButtonDesc});
   bool HasNightStart         = false;
   std::vector<Option *> miscOptions = {
     &DamageMultiplier,
     &StartingTime,
+    &NightGSExpectSuns,
     &GenerateSpoilerLog,
     &MenuOpeningButton,
   };

--- a/source/settings.cpp
+++ b/source/settings.cpp
@@ -130,7 +130,7 @@ namespace Settings {
   //Misc Settings
   Option DamageMultiplier    = Option::U8  ("Damage Multiplier",      {"Half", "Default", "Double", "Quadruple", "OHKO"},      {damageMultiDesc});
   Option StartingTime        = Option::U8  ("Starting Time",          {"Day", "Night"},                                        {startingTimeDesc});
-  Option NightGSExpectSuns   = Option::Bool("Night GS Expect Sun's",  {"Off", "On"},                                 {nightGSDesc});
+  Option NightGSExpectSuns   = Option::Bool("Night GSs Expect Sun's", {"Off", "On"},                                 {nightGSDesc});
   Option GenerateSpoilerLog  = Option::Bool("Generate Spoiler Log",   {"No", "Yes"},                                           {"", ""});
   Option MenuOpeningButton   = Option::U8  ("Open Info Menu with",    {"Select", "Start", "D-Pad Up", "D-Pad Down", "D-Pad Right", "D-Pad Left",},    {menuButtonDesc});
   bool HasNightStart         = false;

--- a/source/settings.hpp
+++ b/source/settings.hpp
@@ -286,6 +286,7 @@ namespace Settings {
 
   extern Option DamageMultiplier;
   extern Option StartingTime;
+  extern Option NightGXExpectSuns;
   extern Option GenerateSpoilerLog;
   extern Option MenuOpeningButton;
   extern bool HasNightStart;

--- a/source/settings.hpp
+++ b/source/settings.hpp
@@ -286,7 +286,7 @@ namespace Settings {
 
   extern Option DamageMultiplier;
   extern Option StartingTime;
-  extern Option NightGXExpectSuns;
+  extern Option NightGSExpectSuns;
   extern Option GenerateSpoilerLog;
   extern Option MenuOpeningButton;
   extern bool HasNightStart;


### PR DESCRIPTION
This adds an option to make it so night-exclusive gold skulltula locations will expect the player to have sun's song in logic. This is simply done by ANDing the following clause with every logic statement for a nighttime GS:
`(CanPlay(SunsSong) || !NightGSExpectSuns)`