### PR TITLE
Logic:Changed some settings for future medallion shuffle

### DIFF
--- a/code/src/item_override.c
+++ b/code/src/item_override.c
@@ -440,9 +440,11 @@ void ItemOverride_PushDungeonReward(u8 dungeon) {
 }
 
 void ItemOverride_CheckStartingItem() {
-  //use eventChkInf[0] |= 0x0001 as the check for this
-  if (EventCheck(0x00) == 0) {
-    ItemOverride_PushDungeonReward(0xFF); //Push Link's Pocket Reward
-    EventSet(0x00);
-  }
+    //use eventChkInf[0] |= 0x0001 as the check for this
+    if (EventCheck(0x00) == 0) {
+        if (gSettingsContext.linksPocketItem != LINKSPOCKET_DUNGEON_REWARD) {
+            ItemOverride_PushDungeonReward(0xFF); //Push Link's Pocket Reward
+        }
+        EventSet(0x00);
+    }
 }

--- a/code/src/savefile.c
+++ b/code/src/savefile.c
@@ -112,6 +112,9 @@ void SaveFile_Init() {
             gSaveContext.eventChkInf[0xC] |= 0x0008; //dispel Ganon's Tower Barrier
     }
 
+    //Give Link a starting stone/medallion if he has one (if he doesn't the value is just 0)
+    gSaveContext.questItems |= gSettingsContext.linksPocketRewardBitMask;
+
     if (gSettingsContext.fourPoesCutscene == SKIP) {
         gSaveContext.sceneFlags[3].swch |= 0x08000000; //Remove Poe cutscene in Forest Temple
     }

--- a/code/src/settings.h
+++ b/code/src/settings.h
@@ -69,6 +69,13 @@ typedef enum {
 } DungeonMode;
 
 typedef enum {
+  LINKSPOCKET_DUNGEON_REWARD,
+  LINKSPOCKET_ADVANCEMENT,
+  LINKSPOCKET_ANYTHING,
+  LINKSPOCKET_NOTHING,
+} LinksPocketSetting;
+
+typedef enum {
   SONGSHUFFLE_SONG_LOCATIONS,
   SONGSHUFFLE_DUNGEON_REWARDS,
   SONGSHUFFLE_ANYWHERE,
@@ -184,6 +191,7 @@ typedef struct {
   u8 mqDungeonCount;
   u8 mirrorWorld;
 
+  u8 linksPocketItem;
   u8 shuffleSongs;
   u8 tokensanity;
   u8 scrubsanity;
@@ -245,7 +253,7 @@ typedef struct {
   u8 shadowTrialSkip;
   u8 lightTrialSkip;
 
-  u32 dungeonRewardBitMask;
+  u32 linksPocketRewardBitMask;
 
   u8 detailedLogic[100];
   u8 excludeLocations[700];

--- a/source/cosmetics.cpp
+++ b/source/cosmetics.cpp
@@ -72,7 +72,7 @@ namespace Cosmetics {
     RANDOM_CHOICE_DESC,
     RANDOM_COLOR_DESC,
     CUSTOM_COLOR_DESC,
-    "",
+    "This will only affect the color on Link's model.",
   };
 
 } //namespace Cosmetics

--- a/source/fill.cpp
+++ b/source/fill.cpp
@@ -410,7 +410,7 @@ static void RandomizeDungeonRewards() {
   AssumedFill(rewards, dungeonRewardLocations);
 
   int baseOffset = I_KokiriEmerald.GetItemID();
-  u32 bitMaskTable[9] = {
+  static constexpr std::array<u32, 9> bitMaskTable = {
     0x00040000,
     0x00080000,
     0x00100000,

--- a/source/fill.cpp
+++ b/source/fill.cpp
@@ -423,11 +423,12 @@ static void RandomizeDungeonRewards() {
   };
 
   for (size_t i = 0; i < dungeonRewardLocations.size(); i++) {
-    rDungeonRewardOverrides[i] = dungeonRewardLocations[i]->GetPlacedItem().GetItemID() - baseOffset;
+    const auto index = dungeonRewardLocations[i]->GetPlacedItem().GetItemID() - baseOffset;
+    rDungeonRewardOverrides[i] = index;
 
     //set the player's dugeon reward on file creation instead of pushing it to them at the start
     if (i == dungeonRewardLocations.size()-1 /*&& LinksPocket.Is(LINKSPOCKET_DUNGEON_REWARD)*/) {
-      LinksPocketRewardBitMask = bitMaskTable[dungeonRewardLocations[i]->GetPlacedItem().GetItemID() - baseOffset];
+      LinksPocketRewardBitMask = bitMaskTable[index];
     }
   }
 }

--- a/source/fill.cpp
+++ b/source/fill.cpp
@@ -410,8 +410,25 @@ static void RandomizeDungeonRewards() {
   AssumedFill(rewards, dungeonRewardLocations);
 
   int baseOffset = I_KokiriEmerald.GetItemID();
+  u32 bitMaskTable[9] = {
+    0x00040000,
+    0x00080000,
+    0x00100000,
+    0x00000001,
+    0x00000002,
+    0x00000004,
+    0x00000008,
+    0x00000010,
+    0x00000020,
+  };
+
   for (size_t i = 0; i < dungeonRewardLocations.size(); i++) {
     rDungeonRewardOverrides[i] = dungeonRewardLocations[i]->GetPlacedItem().GetItemID() - baseOffset;
+
+    //set the player's dugeon reward on file creation instead of pushing it to them at the start
+    if (i == dungeonRewardLocations.size()-1 /*&& LinksPocket.Is(LINKSPOCKET_DUNGEON_REWARD)*/) {
+      LinksPocketRewardBitMask = bitMaskTable[dungeonRewardLocations[i]->GetPlacedItem().GetItemID() - baseOffset];
+    }
   }
 }
 

--- a/source/item_pool.cpp
+++ b/source/item_pool.cpp
@@ -1261,15 +1261,15 @@ void GenerateItemPool() {
   }
 
   //all locations placements
-  if (Keysanity.Is(KEYSANITY_ANYWHERE)) {
-    AddItemToMainPool(ForestTemple_SmallKey, 5);
-    AddItemToMainPool(FireTemple_SmallKey, 8);
-    AddItemToMainPool(WaterTemple_SmallKey, 6);
-    AddItemToMainPool(SpiritTemple_SmallKey, 5);
-    AddItemToMainPool(ShadowTemple_SmallKey, 5);
-    AddItemToMainPool(BottomOfTheWell_SmallKey, 3);
-    AddItemToMainPool(GerudoTrainingGrounds_SmallKey, 9);
-    AddItemToMainPool(GanonsCastle_SmallKey, 2);
+  if (Keysanity.Is(KEYSANITY_ANYWHERE)) {           //check if MQ dungeon               MQ : Vanilla key count
+    AddItemToMainPool(ForestTemple_SmallKey,          ForestTempleDungeonMode          ? 6 : 5);
+    AddItemToMainPool(FireTemple_SmallKey,            FireTempleDungeonMode            ? 5 : 8);
+    AddItemToMainPool(WaterTemple_SmallKey,           WaterTempleDungeonMode           ? 2 : 6);
+    AddItemToMainPool(SpiritTemple_SmallKey,          SpiritTempleDungeonMode          ? 7 : 5);
+    AddItemToMainPool(ShadowTemple_SmallKey,          ShadowTempleDungeonMode          ? 6 : 5);
+    AddItemToMainPool(BottomOfTheWell_SmallKey,       BottomOfTheWellDungeonMode       ? 2 : 3);
+    AddItemToMainPool(GerudoTrainingGrounds_SmallKey, GerudoTrainingGroundsDungeonMode ? 3 : 9);
+    AddItemToMainPool(GanonsCastle_SmallKey,          GanonsCastleDungeonMode          ? 3 : 2);
   }
 
   if (BossKeysanity.Is(BOSSKEYSANITY_ANYWHERE)) {

--- a/source/setting_descriptions.cpp
+++ b/source/setting_descriptions.cpp
@@ -135,6 +135,16 @@ string_view mqDungeonCountDesc        = "Specify the number of Master Quest dung
                                         "Quest will be chosen at random.";                 //
                                                                                            //
 /*------------------------------                                                           //
+|        LINK'S POCKET         |                                                           //
+------------------------------*/                                                           //
+string_view linksPocketDungeonReward  = "Link will start with a Dungeon Reward in his\n"   //
+                                        "inventory.";                                      //
+string_view linksPocketAdvancement    = "Link will receive a random advancement item at the"
+                                        "beginning of the playthrough.";                   //
+string_view linksPocketAnything       = "Link will receive a random item from the item pool"
+                                        "at the beginning of the playthrough.";            //
+string_view linksPocketNothing        = "Link will start with nothing.";                   //
+/*------------------------------                                                           //
 |         SONG SHUFFLE         |                                                           //
 ------------------------------*/                                                           //
 string_view songsSongLocations        = "Songs will only appear at locations that normally\n"

--- a/source/setting_descriptions.cpp
+++ b/source/setting_descriptions.cpp
@@ -135,11 +135,6 @@ string_view mqDungeonCountDesc        = "Specify the number of Master Quest dung
                                         "Quest will be chosen at random.";                 //
                                                                                            //
 /*------------------------------                                                           //
-|         MIRROR WORLD         |                                                           //
-------------------------------*/                                                           //
-string_view mirrorWorldDesc           = "If set, the world will be mirrored.";             //
-                                                                                           //
-/*------------------------------                                                           //
 |         SONG SHUFFLE         |                                                           //
 ------------------------------*/                                                           //
 string_view songsSongLocations        = "Songs will only appear at locations that normally\n"
@@ -399,6 +394,11 @@ string_view adultBoomerangDesc        = "Adult Link can throw the boomerang.\n" 
 string_view childHammerDesc           = "Child Link can swing the Megaton Hammer.\n"       //
                                         "\n"                                               //
                                         "This setting will not change the logic.";         //
+                                                                                           //
+/*------------------------------                                                           //
+|         MIRROR WORLD         |                                                           //
+------------------------------*/                                                           //
+string_view mirrorWorldDesc           = "If set, the world will be mirrored.";             //
                                                                                            //--------------//
 /*------------------------------                                                                           //
 |  DETAILED LOGIC EXPLANATIONS |                                                                           //

--- a/source/setting_descriptions.hpp
+++ b/source/setting_descriptions.hpp
@@ -50,6 +50,11 @@ extern string_view mqDungeonCountDesc;
 
 extern string_view mirrorWorldDesc;
 
+extern string_view linksPocketDungeonReward;
+extern string_view linksPocketAdvancement;
+extern string_view linksPocketAnything;
+extern string_view linksPocketNothing;
+
 extern string_view songsSongLocations;
 extern string_view songsDungeonRewards;
 extern string_view songsAllLocations;

--- a/source/settings.cpp
+++ b/source/settings.cpp
@@ -62,6 +62,7 @@ namespace Settings {
   };
 
   //Shuffle Settings
+  Option LinksPocketItem     = Option::U8  ("Link's Pocket",          {"Dungeon Reward", "Advancement", "Anything", "Nothing"},{linksPocketDungeonReward, linksPocketAdvancement, linksPocketAnything, linksPocketNothing});
   Option ShuffleSongs        = Option::U8  ("Shuffle Songs",          {"Song Locations", "Dungeon Rewards", "Anywhere"},       {songsSongLocations, songsDungeonRewards, songsAllLocations});
   Option Tokensanity         = Option::U8  ("Tokensanity",            {"Off", "Dungeons", "Overworld", "All Tokens"},          {tokensOff, tokensDungeon, tokensOverworld, tokensAllTokens});
   Option Scrubsanity         = Option::U8  ("Scrub Shuffle",          {"Off", "Affordable", "Expensive", "Random Prices"},     {scrubsOff, scrubsAffordable, scrubsExpensive, scrubsRandomPrices});
@@ -73,6 +74,7 @@ namespace Settings {
   Option ShuffleMagicBeans   = Option::Bool("Shuffle Magic Beans",    {"Off", "On"},                                           {magicBeansDesc});
   //TODO: Medigoron and Carpet Salesman
   std::vector<Option *> shuffleOptions = {
+    //&LinksPocketItem,
     &ShuffleSongs,
     &Tokensanity,
     &Scrubsanity,
@@ -429,6 +431,7 @@ namespace Settings {
     ctx.mqDungeonCount       = MQDungeonCount.Value<u8>();
     ctx.mirrorWorld          = (MirrorWorld) ? 1 : 0;
 
+    ctx.linksPocketItem      = LinksPocketItem.Value<u8>();
     ctx.shuffleSongs         = ShuffleSongs.Value<u8>();
     ctx.tokensanity          = Tokensanity.Value<u8>();
     ctx.scrubsanity          = Scrubsanity.Value<u8>();
@@ -469,6 +472,8 @@ namespace Settings {
 
     ctx.itemPoolValue        = ItemPoolValue.Value<u8>();
     ctx.iceTrapValue         = IceTrapValue.Value<u8>();
+
+    ctx.linksPocketRewardBitMask = LinksPocketRewardBitMask;
 
     ctx.dekuTreeDungeonMode              = (DekuTreeDungeonMode)              ? 1 : 0;
     ctx.dodongosCavernDungeonMode        = (DodongosCavernDungeonMode)        ? 1 : 0;

--- a/source/spoiler_log.cpp
+++ b/source/spoiler_log.cpp
@@ -150,7 +150,22 @@ static void WriteSettings() {
     }
   }
 
+  //Master Quest Dungeons
+  logtxt += "\nMaster Quest Dungeons:\n";
+  logtxt += (Settings::DekuTreeDungeonMode == DUNGEONMODE_MQ)              ? "\tDeku Tree\n" : "";
+  logtxt += (Settings::DodongosCavernDungeonMode == DUNGEONMODE_MQ)        ? "\tDodongo's Cavern\n" : "";
+  logtxt += (Settings::JabuJabusBellyDungeonMode == DUNGEONMODE_MQ)        ? "\tJabu Jabu's Belly\n" : "";
+  logtxt += (Settings::ForestTempleDungeonMode == DUNGEONMODE_MQ)          ? "\tForest Temple\n" : "";
+  logtxt += (Settings::FireTempleDungeonMode == DUNGEONMODE_MQ)            ? "\tFire Temple\n" : "";
+  logtxt += (Settings::WaterTempleDungeonMode == DUNGEONMODE_MQ)           ? "\tWater Temple\n" : "";
+  logtxt += (Settings::SpiritTempleDungeonMode == DUNGEONMODE_MQ)          ? "\tSpirit Temple\n" : "";
+  logtxt += (Settings::ShadowTempleDungeonMode == DUNGEONMODE_MQ)          ? "\tShadow Temple\n" : "";
+  logtxt += (Settings::BottomOfTheWellDungeonMode == DUNGEONMODE_MQ)       ? "\tBottom of the Well\n" : "";
+  logtxt += (Settings::IceCavernDungeonMode == DUNGEONMODE_MQ)             ? "\tIce Cavern\n" : "";
+  logtxt += (Settings::GerudoTrainingGroundsDungeonMode == DUNGEONMODE_MQ) ? "\tGerudo Training Grounds\n" : "";
+  logtxt += (Settings::GanonsCastleDungeonMode == DUNGEONMODE_MQ)          ? "\tGanon's Castle\n" : "";
   logtxt += "\n";
+
 }
 
 bool SpoilerLog_Write() {


### PR DESCRIPTION
- Added a (currently unsettable) option that specifies Link's Pocket item as a dungeon reward for the time being. This setting gives him the dungeon reward on file creation instead of pushing an override like the other future settings probably will.
- Added a clarification message that gauntlet colors will currently only apply to Link's model and not GID models.