### PR TITLE
Logic:Fix error where playthrough thinks the player always has explosives

### DIFF
--- a/source/location_access.cpp
+++ b/source/location_access.cpp
@@ -833,20 +833,16 @@ namespace Exits { //name, scene, hint, events, locations, exits
                   ExitPairing::Both(&MK_Main, []{return true;})
   });
 
-  Exit MK_BombchuShop = Exit("Market Bombchu Shop", "", "", NO_DAY_NIGHT_CYCLE, {
-                  //Events
-                  EventPairing(&BuyBombchus10, []{return GoronRuby;}),
-                  EventPairing(&BuyBombchus20, []{return GoronRuby;}),
-                }, {
+  Exit MK_BombchuShop = Exit("Market Bombchu Shop", "", "", NO_DAY_NIGHT_CYCLE, {}, {
                   //Locations
-                  ItemLocationPairing(&MK_BombchuShopItem1, []{return true;}),
-                  ItemLocationPairing(&MK_BombchuShopItem2, []{return true;}),
-                  ItemLocationPairing(&MK_BombchuShopItem3, []{return true;}),
-                  ItemLocationPairing(&MK_BombchuShopItem4, []{return true;}),
-                  ItemLocationPairing(&MK_BombchuShopItem5, []{return true;}),
-                  ItemLocationPairing(&MK_BombchuShopItem6, []{return true;}),
-                  ItemLocationPairing(&MK_BombchuShopItem7, []{return true;}),
-                  ItemLocationPairing(&MK_BombchuShopItem8, []{return true;}),
+                  ItemLocationPairing(&MK_BombchuShopItem1, []{return HasExplosives;}),
+                  ItemLocationPairing(&MK_BombchuShopItem2, []{return HasExplosives;}),
+                  ItemLocationPairing(&MK_BombchuShopItem3, []{return HasExplosives;}),
+                  ItemLocationPairing(&MK_BombchuShopItem4, []{return HasExplosives;}),
+                  ItemLocationPairing(&MK_BombchuShopItem5, []{return HasExplosives;}),
+                  ItemLocationPairing(&MK_BombchuShopItem6, []{return HasExplosives;}),
+                  ItemLocationPairing(&MK_BombchuShopItem7, []{return HasExplosives;}),
+                  ItemLocationPairing(&MK_BombchuShopItem8, []{return HasExplosives;}),
                 }, {
                   //Exits
                   ExitPairing::Both(&MK_Main, []{return true;})

--- a/source/logic.cpp
+++ b/source/logic.cpp
@@ -425,7 +425,7 @@ namespace Logic {
     Fish         = HasBottle && FishAccess;
     Fairy        = HasBottle && FairyAccess;
 
-    HasBombchus   = (BuyBombchus5 || BuyBombchus10 || BuyBombchus20 || BombchuDrops || BombchuDrop) && (BombchusInLogic || BombBag);
+    HasBombchus   = (BuyBombchus5 || BuyBombchus10 || BuyBombchus20 || BombchuDrop) && (BombchusInLogic || BombBag);
     FoundBombchus = (BombchusInLogic && (Bombchus || Bombchus5 || Bombchus10 || Bombchus20)) || (!BombchusInLogic && BombBag);
     HasExplosives =  Bombs || (BombchusInLogic && HasBombchus);
 

--- a/source/menu.cpp
+++ b/source/menu.cpp
@@ -39,7 +39,7 @@ void PrintTopScreen() {
   consoleSelect(&topScreen);
   consoleClear();
   printf("\x1b[2;11H%sOcarina of Time 3D Randomizer%s", CYAN, RESET);
-  printf("\x1b[3;18H%sv1.1%s", CYAN, RESET);
+  printf("\x1b[3;18H%sv1.1.1%s", CYAN, RESET);
   printf("\x1b[4;10HA/B/D-pad: Navigate Menu\n");
   printf("            Select: Exit to Homebrew Menu\n");
   printf("                 Y: New Random Seed\n");

--- a/source/settings.cpp
+++ b/source/settings.cpp
@@ -11,7 +11,7 @@ using namespace Cosmetics;
 
 namespace Settings {
   std::string seed;
-  std::string version = "v1.1-COMMITNUM";
+  std::string version = "v1.1.1-COMMITNUM";
   std::array<u8, 5> hashIconIndexes;
 
   //                                        Setting name,              Options,                                                Setting Descriptions (assigned in setting_descriptions.cpp)

--- a/source/settings.cpp
+++ b/source/settings.cpp
@@ -11,7 +11,7 @@ using namespace Cosmetics;
 
 namespace Settings {
   std::string seed;
-  std::string version = "v1.1";
+  std::string version = "v1.1-COMMITNUM";
   std::array<u8, 5> hashIconIndexes;
 
   //                                        Setting name,              Options,                                                Setting Descriptions (assigned in setting_descriptions.cpp)


### PR DESCRIPTION
This fixes two instances where the playthrough assumed players always had explosives before they were obtainable.