### PR TITLE
cosmetics: Make strings and APIs non-allocating where applicable

### DIFF
--- a/source/cosmetics.cpp
+++ b/source/cosmetics.cpp
@@ -5,11 +5,11 @@
 
 namespace Cosmetics {
 
-  bool ValidHexString(std::string hexStr) {
-    return hexStr.find_first_not_of("0123456789ABCDEFabcdef") == std::string::npos;
+  bool ValidHexString(std::string_view hexStr) {
+    return hexStr.find_first_not_of("0123456789ABCDEFabcdef") == std::string_view::npos;
   }
 
-  Color_RGB HexStrToColorRGB(std::string hexStr) {
+  Color_RGB HexStrToColorRGB(const std::string& hexStr) {
     u32 hex = std::stoi(hexStr, nullptr, 16);
 
     return Color_RGB{
@@ -20,22 +20,22 @@ namespace Cosmetics {
     };
   }
 
-  std::string CustomColorOptionText(std::string color) {
-    return CUSTOM_COLOR_STR.substr(0, CUSTOM_COLOR_STR.length() - 6) + color;
+  std::string CustomColorOptionText(std::string_view color) {
+    return std::string(CUSTOM_COLOR_STR.substr(0, CUSTOM_COLOR_STR.length() - 6)).append(color);
   }
 
-  std::string GetCustomColor(std::string str) {
-    return str.substr(str.length() - 6);
+  std::string GetCustomColor(std::string_view str) {
+    return std::string(str.substr(str.length() - 6));
   }
 
   //Generate random hex color
   std::string RandomColor() {
-    std::stringstream color;
+    std::ostringstream color;
     color << std::hex << (rand() % 0x1000000); //use default rand to not interfere with main settings
     return color.str();
   }
 
-  const std::array<std::string, 13> gauntletColors = {
+  const std::array<std::string_view, 13> gauntletColors = {
     "FFFFFF", //Silver
     "FECF0F", //Gold
     "000006", //Black
@@ -50,10 +50,10 @@ namespace Cosmetics {
     "5B8A06", //Lime
     "800080", //Purple
   };
-  std::vector<std::string> gauntletOptions = {
-    RANDOM_CHOICE_STR,
-    RANDOM_COLOR_STR,
-    CUSTOM_COLOR_STR,
+  const std::vector<std::string> gauntletOptions = {
+    std::string(RANDOM_CHOICE_STR),
+    std::string(RANDOM_COLOR_STR),
+    std::string(CUSTOM_COLOR_STR),
     "Silver",
     "Gold",
     "Black",
@@ -68,7 +68,7 @@ namespace Cosmetics {
     "Lime",
     "Purple",
   };
-  std::vector<std::string_view> cosmeticDescriptions = {
+  const std::vector<std::string_view> cosmeticDescriptions = {
     RANDOM_CHOICE_DESC,
     RANDOM_COLOR_DESC,
     CUSTOM_COLOR_DESC,

--- a/source/cosmetics.hpp
+++ b/source/cosmetics.hpp
@@ -5,14 +5,14 @@
 #include <vector>
 
 namespace Cosmetics {
-  const std::string RANDOM_CHOICE_STR = "Random Choice";
-  const std::string RANDOM_COLOR_STR  = "Random Color";
-  const std::string CUSTOM_COLOR_STR  = "Custom #FFFFFF";
-  const std::string CUSTOM_COLOR_PREFIX = "Custom #";
-                                        /*--------------------------------------------------*/
-  const std::string RANDOM_CHOICE_DESC = "A random color from the list of colors will be\nchosen.";
-  const std::string RANDOM_COLOR_DESC  = "A completely random color will be chosen.";
-  const std::string CUSTOM_COLOR_DESC  = "Press A and type in a custom 6 digit hex color.";
+  constexpr std::string_view RANDOM_CHOICE_STR = "Random Choice";
+  constexpr std::string_view RANDOM_COLOR_STR  = "Random Color";
+  constexpr std::string_view CUSTOM_COLOR_STR  = "Custom #FFFFFF";
+  constexpr std::string_view CUSTOM_COLOR_PREFIX = "Custom #";
+
+  constexpr std::string_view RANDOM_CHOICE_DESC = "A random color from the list of colors will be\nchosen.";
+  constexpr std::string_view RANDOM_COLOR_DESC  = "A completely random color will be chosen.";
+  constexpr std::string_view CUSTOM_COLOR_DESC  = "Press A and type in a custom 6 digit hex color.";
 
   enum CosmeticSettings {
     RANDOM_CHOICE,
@@ -28,13 +28,13 @@ namespace Cosmetics {
     float a;
   };
 
-  extern const std::array<std::string, 13> gauntletColors;
-  extern std::vector<std::string> gauntletOptions;
-  extern std::vector<std::string_view> cosmeticDescriptions;
+  extern const std::array<std::string_view, 13> gauntletColors;
+  extern const std::vector<std::string> gauntletOptions;
+  extern const std::vector<std::string_view> cosmeticDescriptions;
 
-  bool ValidHexString(std::string hexStr);
-  Color_RGB HexStrToColorRGB(std::string hexStr);
-  std::string CustomColorOptionText(std::string color);
-  std::string GetCustomColor(std::string str);
+  bool ValidHexString(std::string_view hexStr);
+  Color_RGB HexStrToColorRGB(const std::string& hexStr);
+  std::string CustomColorOptionText(std::string_view color);
+  std::string GetCustomColor(std::string_view str);
   std::string RandomColor();
 } //namespace Cosmetics

--- a/source/cosmetics.hpp
+++ b/source/cosmetics.hpp
@@ -1,41 +1,40 @@
 #pragma once
 
-#include <vector>
-#include <string>
 #include <array>
-
-const std::string RANDOM_CHOICE_STR = "Random Choice";
-const std::string RANDOM_COLOR_STR  = "Random Color";
-const std::string CUSTOM_COLOR_STR  = "Custom #FFFFFF";
-const std::string CUSTOM_COLOR_PREFIX = "Custom #";
-                                      /*--------------------------------------------------*/
-const std::string RANDOM_CHOICE_DESC = "A random color from the list of colors will be\nchosen.";
-const std::string RANDOM_COLOR_DESC  = "A completely random color will be chosen.";
-const std::string CUSTOM_COLOR_DESC  = "Press A and type in a custom 6 digit hex color.";
-
-typedef enum {
-  RANDOM_CHOICE,
-  RANDOM_COLOR,
-  CUSTOM_COLOR,
-  NON_COLOR_COUNT,
-} CosmeticSettings;
-
-typedef struct {
-  float r;
-  float g;
-  float b;
-  float a;
-} Color_RGB;
+#include <string>
+#include <vector>
 
 namespace Cosmetics {
+  const std::string RANDOM_CHOICE_STR = "Random Choice";
+  const std::string RANDOM_COLOR_STR  = "Random Color";
+  const std::string CUSTOM_COLOR_STR  = "Custom #FFFFFF";
+  const std::string CUSTOM_COLOR_PREFIX = "Custom #";
+                                        /*--------------------------------------------------*/
+  const std::string RANDOM_CHOICE_DESC = "A random color from the list of colors will be\nchosen.";
+  const std::string RANDOM_COLOR_DESC  = "A completely random color will be chosen.";
+  const std::string CUSTOM_COLOR_DESC  = "Press A and type in a custom 6 digit hex color.";
 
-  extern bool ValidHexString(std::string hexStr);
-  extern Color_RGB HexStrToColorRGB(std::string hexStr);
-  extern std::string CustomColorOptionText(std::string color);
-  extern std::string GetCustomColor(std::string str);
-  extern std::string RandomColor();
+  enum CosmeticSettings {
+    RANDOM_CHOICE,
+    RANDOM_COLOR,
+    CUSTOM_COLOR,
+    NON_COLOR_COUNT,
+  };
+
+  struct Color_RGB {
+    float r;
+    float g;
+    float b;
+    float a;
+  };
 
   extern const std::array<std::string, 13> gauntletColors;
   extern std::vector<std::string> gauntletOptions;
   extern std::vector<std::string_view> cosmeticDescriptions;
+
+  bool ValidHexString(std::string hexStr);
+  Color_RGB HexStrToColorRGB(std::string hexStr);
+  std::string CustomColorOptionText(std::string color);
+  std::string GetCustomColor(std::string str);
+  std::string RandomColor();
 } //namespace Cosmetics

--- a/source/menu.cpp
+++ b/source/menu.cpp
@@ -231,7 +231,7 @@ void UpdateMainMenu(u32 kDown) {
 
 void UpdateCustomCosmeticColors(u32 kDown) {
   if (kDown & KEY_A) {
-    if (currentSetting->GetSelectedOptionText().substr(0, 8) == CUSTOM_COLOR_PREFIX) {
+    if (currentSetting->GetSelectedOptionText().substr(0, 8) == Cosmetics::CUSTOM_COLOR_PREFIX) {
       std::string newColor = GetInput("Enter a 6 digit hex color").substr(0, 6);
       if (Cosmetics::ValidHexString(newColor)) {
         currentSetting->SetSelectedOptionText(Cosmetics::CustomColorOptionText(newColor));

--- a/source/patch.cpp
+++ b/source/patch.cpp
@@ -358,7 +358,7 @@ bool WritePatch() {
   ---------------------------------*/
 
   const u32 GAUNTLETCOLORSARRAY_ADDR = 0x0053CA1C;
-  Color_RGB rGauntletColors[2] = {
+  const std::array rGauntletColors{
     Cosmetics::HexStrToColorRGB(Settings::finalSilverGauntletsColor),
     Cosmetics::HexStrToColorRGB(Settings::finalGoldGauntletsColor),
   };
@@ -383,7 +383,7 @@ bool WritePatch() {
   totalRW += 2;
 
   // Write gauntletColors to code
-  if (!R_SUCCEEDED(res = FSFILE_Write(code, &bytesWritten, totalRW, rGauntletColors, sizeof(rGauntletColors), FS_WRITE_FLUSH))) {
+  if (!R_SUCCEEDED(res = FSFILE_Write(code, &bytesWritten, totalRW, rGauntletColors.data(), sizeof(rGauntletColors), FS_WRITE_FLUSH))) {
     return false;
   }
   totalRW += sizeof(rGauntletColors);

--- a/source/settings.hpp
+++ b/source/settings.hpp
@@ -123,6 +123,7 @@ public:
     }
 
     void SetSelectedIndexByString(std::string newSetting) {
+      using namespace Cosmetics;
 
       //Special case for custom cosmetic settings
       if (options.size() > CUSTOM_COLOR) {


### PR DESCRIPTION
Same behavior, but reduces a little bit of string churn.