### PR TITLE
starting_inventory: Reduce copies in AddItemToInventory()

### DIFF
--- a/source/starting_inventory.cpp
+++ b/source/starting_inventory.cpp
@@ -3,20 +3,23 @@
 #include "debug.hpp"
 #include <unistd.h>
 
+#include "item_list.hpp"
+#include "settings.hpp"
+
 using namespace Settings;
 using namespace Dungeon;
 
-std::vector<Item> StartingInventory = {};
+std::vector<Item> StartingInventory;
 
-void AddItemToInventory(Item item, int count = 1) {
-  StartingInventory.resize(StartingInventory.size() + count, item);
+static void AddItemToInventory(const Item& item, size_t count = 1) {
+  StartingInventory.insert(StartingInventory.end(), count, item);
 }
 
 void GenerateStartingInventory() {
   StartingInventory.clear();
 
   if (MapsAndCompasses.Is(MAPSANDCOMPASSES_START_WITH)) {
-    for (auto dungeon : dungeonList) {
+    for (auto* dungeon : dungeonList) {
       if (dungeon->GetMap() != NoItem) {
         AddItemToInventory(dungeon->GetMap());
       }
@@ -28,18 +31,17 @@ void GenerateStartingInventory() {
   }
 
   if (Keysanity.Is(KEYSANITY_START_WITH)) {
-    for (auto dungeon : dungeonList) {
+    for (auto* dungeon : dungeonList) {
       if (dungeon->GetSmallKeyCount() > 0) {
         AddItemToInventory(dungeon->GetSmallKey(), dungeon->GetSmallKeyCount());
       }
     }
-
   } else if (Keysanity.Is(KEYSANITY_VANILLA)) {
-  /*Logic cannot handle vanilla key layout in some dungeons
-    this is because vanilla expects the dungeon major item to be
-    locked behind the keys, which is not always true in rando.
-    We can resolve this by starting with some extra keys
-    - OoT Randomizer*/
+    // Logic cannot handle vanilla key layout in some dungeons
+    // this is because vanilla expects the dungeon major item to be
+    // locked behind the keys, which is not always true in rando.
+    // We can resolve this by starting with some extra keys
+    // - OoT Randomizer
     if (SpiritTemple.IsMQ()) {
       AddItemToInventory(SpiritTemple_SmallKey, 3);
     }
@@ -56,7 +58,6 @@ void GenerateStartingInventory() {
   if (GanonsBossKey.Is(GANONSBOSSKEY_START_WITH)) {
     AddItemToInventory(GanonsCastle_BossKey);
   }
-
 }
 
 void ApplyStartingInventory() {

--- a/source/starting_inventory.hpp
+++ b/source/starting_inventory.hpp
@@ -1,8 +1,9 @@
 #pragma once
-#include "item_list.hpp"
-#include "settings.hpp"
 
+#include <vector>
+
+class Item;
 extern std::vector<Item> StartingInventory;
 
-extern void GenerateStartingInventory();
-extern void ApplyStartingInventory();
+void GenerateStartingInventory();
+void ApplyStartingInventory();


### PR DESCRIPTION
We can pass by reference to avoid copying item instances.