### PR TITLE
General: Centralize version numbering

### DIFF
--- a/source/menu.cpp
+++ b/source/menu.cpp
@@ -7,11 +7,12 @@
 #include <cstring>
 #include <algorithm>
 
+#include "cosmetics.hpp"
 #include "menu.hpp"
 #include "patch.hpp"
 #include "preset.hpp"
+#include "randomizer.hpp"
 #include "settings.hpp"
-#include "cosmetics.hpp"
 #include "spoiler_log.hpp"
 
 namespace {
@@ -39,7 +40,7 @@ void PrintTopScreen() {
   consoleSelect(&topScreen);
   consoleClear();
   printf("\x1b[2;11H%sOcarina of Time 3D Randomizer%s", CYAN, RESET);
-  printf("\x1b[3;18H%sv1.1.1%s", CYAN, RESET);
+  printf("\x1b[3;18H%s%s%s", CYAN, RANDOMIZER_VERSION, RESET);
   printf("\x1b[4;10HA/B/D-pad: Navigate Menu\n");
   printf("            Select: Exit to Homebrew Menu\n");
   printf("                 Y: New Random Seed\n");

--- a/source/randomizer.hpp
+++ b/source/randomizer.hpp
@@ -1,0 +1,3 @@
+#pragma once
+
+#define RANDOMIZER_VERSION "v1.1.1"

--- a/source/settings.cpp
+++ b/source/settings.cpp
@@ -1,19 +1,20 @@
 #include <unistd.h>
 
-#include "settings.hpp"
-#include "setting_descriptions.hpp"
-#include "item_location.hpp"
-#include "random.hpp"
-#include "fill.hpp"
 #include "cosmetics.hpp"
 #include "dungeon.hpp"
+#include "fill.hpp"
+#include "item_location.hpp"
+#include "random.hpp"
+#include "randomizer.hpp"
+#include "settings.hpp"
+#include "setting_descriptions.hpp"
 
 using namespace Cosmetics;
 using namespace Dungeon;
 
 namespace Settings {
   std::string seed;
-  std::string version = "v1.1.1-COMMITNUM";
+  std::string version = RANDOMIZER_VERSION "-COMMITNUM";
   std::array<u8, 5> hashIconIndexes;
 
   //                                        Setting name,              Options,                                                          Setting Descriptions (assigned in setting_descriptions.cpp)


### PR DESCRIPTION
Currently, when updating the version of the randomizer, one needs to remember to update two locations with the new version.

Instead, we can make use of a define so that we only need to update the version in one location.