### PR TITLE
item_location: Avoid copying entire location pools in GetLocations()

### DIFF
--- a/source/item_location.cpp
+++ b/source/item_location.cpp
@@ -1728,9 +1728,9 @@ void PlaceItemInLocation(ItemLocation* loc, Item item, bool applyEffectImmediate
     loc->SetPlacedItem(item);
 }
 
-std::vector<ItemLocation*> GetLocations(std::vector<ItemLocation*> locationPool, Category category) {
-  std::vector<ItemLocation*> locationsInCategory = {};
-  for (auto& loc : locationPool) {
+std::vector<ItemLocation*> GetLocations(const std::vector<ItemLocation*>& locationPool, Category category) {
+  std::vector<ItemLocation*> locationsInCategory;
+  for (auto* loc : locationPool) {
     if (loc->IsCategory(category)) {
       locationsInCategory.push_back(loc);
     }

--- a/source/item_location.hpp
+++ b/source/item_location.hpp
@@ -1041,10 +1041,10 @@ extern bool playthroughBeatable;
 
 extern u16 itemsPlaced;
 
-extern void GenerateLocationPool();
-extern void PlaceItemInLocation(ItemLocation* loc, Item item, bool applyEffectImmediately = false);
-extern std::vector<ItemLocation*> GetLocations(std::vector<ItemLocation*> locationPool, const Category category);
-extern void LocationReset();
-extern void ItemReset();
-extern void AddExcludedOptions();
-extern void CreateOverrides();
+void GenerateLocationPool();
+void PlaceItemInLocation(ItemLocation* loc, Item item, bool applyEffectImmediately = false);
+std::vector<ItemLocation*> GetLocations(const std::vector<ItemLocation*>& locationPool, Category category);
+void LocationReset();
+void ItemReset();
+void AddExcludedOptions();
+void CreateOverrides();


### PR DESCRIPTION
Takes the input vector by reference to avoid copying whole pools.