### PR TITLE
Misc: Nightly Build Updates

### DIFF
--- a/.github/workflows/create_nightly.yml
+++ b/.github/workflows/create_nightly.yml
@@ -23,7 +23,7 @@ jobs:
         uses: ncipollo/release-action@v1.8.3
         with:
           token: "${{ secrets.GITHUB_TOKEN }}"
-          artifacts: "OoT3D_Randomizer.cia,OoT3D_Randomizer.3dsx,cia.png"
+          artifacts: "OoT3D_Randomizer.cia,OoT3D_Randomizer.3dsx,cia.png,3dsx.png"
           prerelease: true
           commit: "${{ github.sha }}"
           tag: "Nightly-${{ github.sha }}"
@@ -33,3 +33,5 @@ jobs:
             When reporting issues, please mention the six character commit listed in the randomizer menu.
             CIA QR Code:
             ![CIA Download](https://github.com/${{ github.repository }}/releases/download/Nightly-${{ github.sha }}/cia.png)
+            3DSX QR Code:
+            ![CIA Download](https://github.com/${{ github.repository }}/releases/download/Nightly-${{ github.sha }}/3dsx.png)

--- a/.github/workflows/create_nightly.yml
+++ b/.github/workflows/create_nightly.yml
@@ -1,4 +1,4 @@
-name: Create 3DSX and CIA Files, and drafts/posts a new Release.
+name: OoT3DR Nightly Builds
 
 on:
   push:
@@ -13,43 +13,23 @@ jobs:
     steps:
       - uses: actions/checkout@v2
 
-      - name: Create Environment
+      - name: Run Build Script
       
         run: |
           chmod +x linux_build_rando.sh
           ./linux_build_rando.sh
           
-      - name: Create a Release
-        id: create_release
-        uses: actions/create-release@v1.1.4
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      - name: Create Pre-release
+        uses: ncipollo/release-action@v1.8.3
         with:
-          tag_name: Nightly-${{ github.sha }}
-          release_name: nightly-${{ github.sha }}
-          draft: false
+          token: "${{ secrets.GITHUB_TOKEN }}"
+          artifacts: "OoT3D_Randomizer.cia,OoT3D_Randomizer.3dsx,cia.png"
           prerelease: true
+          commit: "${{ github.sha }}"
+          tag: "Nightly-${{ github.sha }}"
+          name: "Nightly-${{ github.sha }}"
           body: |
             Please note that these are DEVELOPMENT builds and may not be entirely stable.
             When reporting issues, please mention the six character commit listed in the randomizer menu.
-            
-      - name: Upload release asset CIA
-        id: upload-release-asset-cia
-        uses: actions/upload-release-asset@v1.0.2
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        with:
-          upload_url: ${{ steps.create_release.outputs.upload_url }}
-          asset_path: ./OoT3D_Randomizer.cia
-          asset_name: OoT3D_Randomizer.cia
-          asset_content_type: application/octet-stream
-      - name: Upload release asset 3dsx
-        id: upload-release-asset-3dsx
-        uses: actions/upload-release-asset@v1.0.2
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        with:
-          upload_url: ${{ steps.create_release.outputs.upload_url }}
-          asset_path: ./OoT3D_Randomizer.3dsx
-          asset_name: OoT3D_Randomizer.3dsx
-          asset_content_type: application/octet-stream
+            CIA QR Code:
+            ![CIA Download](https://github.com/${{ github.repository }}/releases/download/Nightly-${{ github.sha }}/cia.png)

--- a/linux_build_rando.sh
+++ b/linux_build_rando.sh
@@ -9,7 +9,7 @@ compile() {
   bannertoolexec makebanner -i ./banner.png -a ./audio.wav -o ./banner.bnr
   bannertoolexec makesmdh -s "Ocarina of Time 3D Randomizer" -l "A different Ocarina of Time experience" -p "Gamestabled & Gymnast86" -i icon.png -o ./icon.icn
   3dstool -cvtf romfs ./romfs.bin --romfs-dir ./romfs
-  makerom -f cia -o OoT3D_Randomizer.cia -DAPP_ENCRYPTED=false -target t -exefslogo -elf ./OoT3D_Randomizer.elf -icon ./icon.icn -banner ./banner.bnr -rsf ./ootrando.rsf -romfs ./romfs.bin -major 1 -minor 0 -micro 2
+  makerom -f cia -o OoT3D_Randomizer.cia -DAPP_ENCRYPTED=false -target t -exefslogo -elf ./OoT3D_Randomizer.elf -icon ./icon.icn -banner ./banner.bnr -rsf ./ootrando.rsf -romfs ./romfs.bin -major 1 -minor 1 -micro 1
   qrencode -ocia.png https://github.com/$GITHUB_REPOSITORY/releases/download/Nightly-$GITHUB_SHA/OoT3D_Randomizer.cia
   ls -la
 }

--- a/linux_build_rando.sh
+++ b/linux_build_rando.sh
@@ -11,6 +11,7 @@ compile() {
   3dstool -cvtf romfs ./romfs.bin --romfs-dir ./romfs
   makerom -f cia -o OoT3D_Randomizer.cia -DAPP_ENCRYPTED=false -target t -exefslogo -elf ./OoT3D_Randomizer.elf -icon ./icon.icn -banner ./banner.bnr -rsf ./ootrando.rsf -romfs ./romfs.bin -major 1 -minor 1 -micro 1
   qrencode -ocia.png https://github.com/$GITHUB_REPOSITORY/releases/download/Nightly-$GITHUB_SHA/OoT3D_Randomizer.cia
+  qrencode -o3dsx.png https://github.com/$GITHUB_REPOSITORY/releases/download/Nightly-$GITHUB_SHA/OoT3D_Randomizer.3dsx
   ls -la
 }
 

--- a/linux_build_rando.sh
+++ b/linux_build_rando.sh
@@ -10,6 +10,8 @@ compile() {
   bannertoolexec makesmdh -s "Ocarina of Time 3D Randomizer" -l "A different Ocarina of Time experience" -p "Gamestabled & Gymnast86" -i icon.png -o ./icon.icn
   3dstool -cvtf romfs ./romfs.bin --romfs-dir ./romfs
   makerom -f cia -o OoT3D_Randomizer.cia -DAPP_ENCRYPTED=false -target t -exefslogo -elf ./OoT3D_Randomizer.elf -icon ./icon.icn -banner ./banner.bnr -rsf ./ootrando.rsf -romfs ./romfs.bin -major 1 -minor 0 -micro 2
+  qrencode -ocia.png https://github.com/$GITHUB_REPOSITORY/releases/download/Nightly-$GITHUB_SHA/OoT3D_Randomizer.cia
+  ls -la
 }
 
 clean_up() {


### PR DESCRIPTION
Moving over the nightly builds to a different process to cleanup the automated commands.

I also included `qrencode` to generate a qr code and upload as a release asset. This is so people using FBI or any installer that can use QR codes can just download the latest nightly if they so choose.

This issue resolves #95 