### PR TITLE
dungeon: Minimize rebuilds and prevent copies/allocations where applicable

### DIFF
--- a/source/dungeon.cpp
+++ b/source/dungeon.cpp
@@ -25,19 +25,19 @@ DungeonInfo::DungeonInfo(std::string name_, Item* map_, Item* compass_,
 
 DungeonInfo::~DungeonInfo() = default;
 
-Item DungeonInfo::GetSmallKey() const {
+const Item& DungeonInfo::GetSmallKey() const {
   return *smallKey;
 }
 
-Item DungeonInfo::GetMap() const {
+const Item& DungeonInfo::GetMap() const {
   return *map;
 }
 
-Item DungeonInfo::GetCompass() const {
+const Item& DungeonInfo::GetCompass() const {
   return *compass;
 }
 
-Item DungeonInfo::GetBossKey() const {
+const Item& DungeonInfo::GetBossKey() const {
   return *bossKey;
 }
 

--- a/source/dungeon.cpp
+++ b/source/dungeon.cpp
@@ -593,7 +593,7 @@ std::vector<ItemLocation*> DungeonInfo::GetEveryLocation() const {
                             &Ganon,
                           });
 
-  std::vector<DungeonInfo*> dungeonList = {
+  const DungeonArray dungeonList = {
     &DekuTree,
     &DodongosCavern,
     &JabuJabusBelly,

--- a/source/dungeon.hpp
+++ b/source/dungeon.hpp
@@ -37,10 +37,10 @@ public:
         return (masterQuest) ? mqKeyCount : vanillaKeyCount;
     }
 
-    Item GetSmallKey() const;
-    Item GetMap() const;
-    Item GetCompass() const;
-    Item GetBossKey() const;
+    const Item& GetSmallKey() const;
+    const Item& GetMap() const;
+    const Item& GetCompass() const;
+    const Item& GetBossKey() const;
 
     void PlaceVanillaMap();
     void PlaceVanillaCompass();

--- a/source/dungeon.hpp
+++ b/source/dungeon.hpp
@@ -2,11 +2,12 @@
 
 #include <string>
 
+#include "category.hpp"
 #include "item_list.hpp"
 #include "item_location.hpp"
 #include "pool_functions.hpp"
-#include "category.hpp"
 
+namespace Dungeon {
 class DungeonInfo {
 public:
       DungeonInfo(std::string name_, Item* map_, Item* compass_, Item* smallKey_, Item* bossKey_, u8 vanillaKeyCount_, u8 mqKeyCount_,
@@ -54,14 +55,14 @@ public:
           return *bossKey;
       }
 
-      u8 GetSmallKeyCount() {
+      u8 GetSmallKeyCount() const {
           return (masterQuest) ? mqKeyCount : vanillaKeyCount;
       }
 
       void PlaceVanillaMap() {
           if (*map != NoItem) {
               auto dungeonLocations = GetDungeonLocations();
-              auto mapLocation = FilterFromPool(dungeonLocations, [](ItemLocation* loc){ return loc->IsCategory(Category::cVanillaMap);})[0];
+              auto mapLocation = FilterFromPool(dungeonLocations, [](const ItemLocation* loc){ return loc->IsCategory(Category::cVanillaMap); })[0];
               PlaceItemInLocation(mapLocation, *map);
           }
       }
@@ -69,7 +70,7 @@ public:
       void PlaceVanillaCompass() {
           if (*compass != NoItem) {
               auto dungeonLocations = GetDungeonLocations();
-              auto compassLocation = FilterFromPool(dungeonLocations, [](ItemLocation* loc){ return loc->IsCategory(Category::cVanillaCompass);})[0];
+              auto compassLocation = FilterFromPool(dungeonLocations, [](const ItemLocation* loc){ return loc->IsCategory(Category::cVanillaCompass); })[0];
               PlaceItemInLocation(compassLocation, *compass);
           }
       }
@@ -77,7 +78,7 @@ public:
       void PlaceVanillaBossKey() {
           if (*bossKey != NoItem) {
               auto dungeonLocations = GetDungeonLocations();
-              auto bossKeyLocation = FilterFromPool(dungeonLocations, [](ItemLocation* loc){ return loc->IsCategory(Category::cVanillaBossKey);})[0];
+              auto bossKeyLocation = FilterFromPool(dungeonLocations, [](const ItemLocation* loc){ return loc->IsCategory(Category::cVanillaBossKey); })[0];
               PlaceItemInLocation(bossKeyLocation, *bossKey);
           }
       }
@@ -85,7 +86,7 @@ public:
       void PlaceVanillaSmallKeys() {
           if (*smallKey != NoItem) {
               auto dungeonLocations = GetDungeonLocations();
-              auto smallKeyLocations = FilterFromPool(dungeonLocations, [](ItemLocation* loc){ return loc->IsCategory(Category::cVanillaSmallKey);});
+              auto smallKeyLocations = FilterFromPool(dungeonLocations, [](const ItemLocation* loc){ return loc->IsCategory(Category::cVanillaSmallKey); });
               for (auto location : smallKeyLocations) {
                   PlaceItemInLocation(location, *smallKey);
               }
@@ -93,14 +94,14 @@ public:
       }
 
       //Gets the chosen dungeon locations for a playthrough (so either MQ or Vanilla)
-      std::vector<ItemLocation*> GetDungeonLocations() {
+      std::vector<ItemLocation*> GetDungeonLocations() const {
           auto locations = masterQuest ? mqLocations : vanillaLocations;
           AddElementsToPool(locations, sharedLocations);
           return locations;
       }
 
       //Gets all dungeon locations (MQ + Vanilla)
-      std::vector<ItemLocation*> GetEveryLocation() {
+      std::vector<ItemLocation*> GetEveryLocation() const {
           auto locations = vanillaLocations;
           AddElementsToPool(locations, mqLocations);
           AddElementsToPool(locations, sharedLocations);
@@ -121,19 +122,18 @@ private:
       std::vector<ItemLocation*> sharedLocations;
 };
 
-namespace Dungeon {
-    extern DungeonInfo DekuTree;
-    extern DungeonInfo DodongosCavern;
-    extern DungeonInfo JabuJabusBelly;
-    extern DungeonInfo ForestTemple;
-    extern DungeonInfo FireTemple;
-    extern DungeonInfo WaterTemple;
-    extern DungeonInfo SpiritTemple;
-    extern DungeonInfo ShadowTemple;
-    extern DungeonInfo BottomOfTheWell;
-    extern DungeonInfo IceCavern;
-    extern DungeonInfo GerudoTrainingGrounds;
-    extern DungeonInfo GanonsCastle;
+extern DungeonInfo DekuTree;
+extern DungeonInfo DodongosCavern;
+extern DungeonInfo JabuJabusBelly;
+extern DungeonInfo ForestTemple;
+extern DungeonInfo FireTemple;
+extern DungeonInfo WaterTemple;
+extern DungeonInfo SpiritTemple;
+extern DungeonInfo ShadowTemple;
+extern DungeonInfo BottomOfTheWell;
+extern DungeonInfo IceCavern;
+extern DungeonInfo GerudoTrainingGrounds;
+extern DungeonInfo GanonsCastle;
 
-    extern std::vector<DungeonInfo*> dungeonList;
-}
+extern std::vector<DungeonInfo*> dungeonList;
+} // namespace Dungeon

--- a/source/dungeon.hpp
+++ b/source/dungeon.hpp
@@ -1,6 +1,7 @@
 #pragma once
 
 #include <3ds.h>
+#include <array>
 #include <string>
 #include <vector>
 
@@ -80,5 +81,7 @@ extern DungeonInfo IceCavern;
 extern DungeonInfo GerudoTrainingGrounds;
 extern DungeonInfo GanonsCastle;
 
-extern std::vector<DungeonInfo*> dungeonList;
+using DungeonArray = std::array<DungeonInfo*, 12>;
+
+extern const DungeonArray dungeonList;
 } // namespace Dungeon

--- a/source/dungeon.hpp
+++ b/source/dungeon.hpp
@@ -1,125 +1,70 @@
 #pragma once
 
+#include <3ds.h>
 #include <string>
+#include <vector>
 
-#include "category.hpp"
-#include "item_list.hpp"
-#include "item_location.hpp"
-#include "pool_functions.hpp"
+class Item;
+class ItemLocation;
 
 namespace Dungeon {
 class DungeonInfo {
 public:
-      DungeonInfo(std::string name_, Item* map_, Item* compass_, Item* smallKey_, Item* bossKey_, u8 vanillaKeyCount_, u8 mqKeyCount_,
-              std::vector<ItemLocation*> vanillaLocations_, std::vector<ItemLocation*> mqLocations_, std::vector<ItemLocation*> sharedLocations_)
-            : name(std::move(name_)),
-              map(map_),
-              compass(compass_),
-              smallKey(smallKey_),
-              bossKey(bossKey_),
-              vanillaKeyCount(vanillaKeyCount_),
-              mqKeyCount(mqKeyCount_),
-              vanillaLocations(std::move(vanillaLocations_)),
-              mqLocations(std::move(mqLocations_)),
-              sharedLocations(std::move(sharedLocations_)) {}
+    DungeonInfo(std::string name_, Item* map_, Item* compass_,
+                Item* smallKey_, Item* bossKey_, u8 vanillaKeyCount_, u8 mqKeyCount_,
+                std::vector<ItemLocation*> vanillaLocations_,
+                std::vector<ItemLocation*> mqLocations_,
+                std::vector<ItemLocation*> sharedLocations_);
+    ~DungeonInfo();
 
-      std::string GetName() const {
-          return name;
-      }
+    std::string GetName() const {
+        return name;
+    }
 
-      void SetMQ() {
-          masterQuest = true;
-      }
+    void SetMQ() {
+        masterQuest = true;
+    }
 
-      bool IsMQ() const {
-          return masterQuest;
-      }
+    bool IsMQ() const {
+        return masterQuest;
+    }
 
-      bool IsVanilla() const {
-          return !masterQuest;
-      }
+    bool IsVanilla() const {
+        return !masterQuest;
+    }
 
-      Item GetSmallKey() const {
-          return *smallKey;
-      }
+    u8 GetSmallKeyCount() const {
+        return (masterQuest) ? mqKeyCount : vanillaKeyCount;
+    }
 
-      Item GetMap() const {
-          return *map;
-      }
+    Item GetSmallKey() const;
+    Item GetMap() const;
+    Item GetCompass() const;
+    Item GetBossKey() const;
 
-      Item GetCompass() const {
-          return *compass;
-      }
+    void PlaceVanillaMap();
+    void PlaceVanillaCompass();
+    void PlaceVanillaBossKey();
+    void PlaceVanillaSmallKeys();
 
-      Item GetBossKey() const {
-          return *bossKey;
-      }
+    // Gets the chosen dungeon locations for a playthrough (so either MQ or Vanilla)
+    std::vector<ItemLocation*> GetDungeonLocations() const;
 
-      u8 GetSmallKeyCount() const {
-          return (masterQuest) ? mqKeyCount : vanillaKeyCount;
-      }
-
-      void PlaceVanillaMap() {
-          if (*map != NoItem) {
-              auto dungeonLocations = GetDungeonLocations();
-              auto mapLocation = FilterFromPool(dungeonLocations, [](const ItemLocation* loc){ return loc->IsCategory(Category::cVanillaMap); })[0];
-              PlaceItemInLocation(mapLocation, *map);
-          }
-      }
-
-      void PlaceVanillaCompass() {
-          if (*compass != NoItem) {
-              auto dungeonLocations = GetDungeonLocations();
-              auto compassLocation = FilterFromPool(dungeonLocations, [](const ItemLocation* loc){ return loc->IsCategory(Category::cVanillaCompass); })[0];
-              PlaceItemInLocation(compassLocation, *compass);
-          }
-      }
-
-      void PlaceVanillaBossKey() {
-          if (*bossKey != NoItem) {
-              auto dungeonLocations = GetDungeonLocations();
-              auto bossKeyLocation = FilterFromPool(dungeonLocations, [](const ItemLocation* loc){ return loc->IsCategory(Category::cVanillaBossKey); })[0];
-              PlaceItemInLocation(bossKeyLocation, *bossKey);
-          }
-      }
-
-      void PlaceVanillaSmallKeys() {
-          if (*smallKey != NoItem) {
-              auto dungeonLocations = GetDungeonLocations();
-              auto smallKeyLocations = FilterFromPool(dungeonLocations, [](const ItemLocation* loc){ return loc->IsCategory(Category::cVanillaSmallKey); });
-              for (auto location : smallKeyLocations) {
-                  PlaceItemInLocation(location, *smallKey);
-              }
-          }
-      }
-
-      //Gets the chosen dungeon locations for a playthrough (so either MQ or Vanilla)
-      std::vector<ItemLocation*> GetDungeonLocations() const {
-          auto locations = masterQuest ? mqLocations : vanillaLocations;
-          AddElementsToPool(locations, sharedLocations);
-          return locations;
-      }
-
-      //Gets all dungeon locations (MQ + Vanilla)
-      std::vector<ItemLocation*> GetEveryLocation() const {
-          auto locations = vanillaLocations;
-          AddElementsToPool(locations, mqLocations);
-          AddElementsToPool(locations, sharedLocations);
-          return locations;
-      }
+    // Gets all dungeon locations (MQ + Vanilla)
+    std::vector<ItemLocation*> GetEveryLocation() const;
 
 private:
-      std::string name;
-      Item* map;
-      Item* compass;
-      Item* smallKey;
-      Item* bossKey;
-      u8 vanillaKeyCount;
-      u8 mqKeyCount;
-      bool masterQuest = false;
-      std::vector<ItemLocation*> vanillaLocations;
-      std::vector<ItemLocation*> mqLocations;
-      std::vector<ItemLocation*> sharedLocations;
+    std::string name;
+    Item* map;
+    Item* compass;
+    Item* smallKey;
+    Item* bossKey;
+    u8 vanillaKeyCount;
+    u8 mqKeyCount;
+    bool masterQuest = false;
+    std::vector<ItemLocation*> vanillaLocations;
+    std::vector<ItemLocation*> mqLocations;
+    std::vector<ItemLocation*> sharedLocations;
 };
 
 extern DungeonInfo DekuTree;

--- a/source/dungeon.hpp
+++ b/source/dungeon.hpp
@@ -18,7 +18,7 @@ public:
                 std::vector<ItemLocation*> sharedLocations_);
     ~DungeonInfo();
 
-    std::string GetName() const {
+    std::string_view GetName() const {
         return name;
     }
 

--- a/source/fill.cpp
+++ b/source/fill.cpp
@@ -448,8 +448,7 @@ static void FillExcludedLocations() {
 }
 
 //Function to handle the Own Dungeon setting
-static void RandomizeOwnDungeon(DungeonInfo* dungeon) {
-
+static void RandomizeOwnDungeon(const Dungeon::DungeonInfo* dungeon) {
   std::vector<ItemLocation*> dungeonLocations = dungeon->GetDungeonLocations();
   std::vector<Item> dungeonItems = {};
 

--- a/source/item_location.hpp
+++ b/source/item_location.hpp
@@ -1,5 +1,6 @@
 #pragma once
 
+#include <algorithm>
 #include <array>
 #include <cstdio>
 #include <functional>
@@ -97,13 +98,9 @@ public:
       return excludedOption.Value<bool>();
     }
 
-    bool IsCategory(Category category) {
-      for (const Category& cat : categories) {
-        if (category == cat) {
-          return true;
-        }
-      }
-      return false;
+    bool IsCategory(Category category) const {
+      return std::any_of(categories.begin(), categories.end(),
+                         [category](auto entry) { return entry == category; });
     }
 
     bool IsDungeon() const {

--- a/source/spoiler_log.cpp
+++ b/source/spoiler_log.cpp
@@ -153,12 +153,12 @@ static void WriteSettings() {
 
   //Master Quest Dungeons
   logtxt += "\nMaster Quest Dungeons:\n";
-  for (auto dungeon : Dungeon::dungeonList) {
+  for (const auto* dungeon : Dungeon::dungeonList) {
     if (dungeon->IsMQ()) {
-      logtxt += "\t" + dungeon->GetName() + "\n";
+      logtxt += std::string("\t").append(dungeon->GetName()).append("\n");
     }
   }
-  logtxt += "\n";
+  logtxt += '\n';
 
 }
 


### PR DESCRIPTION
With most of the implementation details in the header, around 5/6 other files need to be rebuilt whenever a change is made to this file. We can move the implementation details to the cpp file to make it so only one file needs to be rebuilt.

While we're in the same area, we can slightly alter the interface so copies don't get churned at runtime.