### PR TITLE
Logic: Change jabu access to require bottle

### DIFF
--- a/source/location_access.cpp
+++ b/source/location_access.cpp
@@ -1529,8 +1529,8 @@ namespace Exits { //name, scene, hint, events, locations, exits
                 }, {
                   //Exits
                   ExitPairing::Both(&ZD_BehindKingZora,           []{return true;}),
-                  ExitPairing::Both(&JabuJabusBelly_Beginning,    []{return Dungeon::JabuJabusBelly.IsVanilla() && (IsChild && FishAccess);}),
-                  ExitPairing::Both(&JabuJabusBelly_MQ_Beginning, []{return Dungeon::JabuJabusBelly.IsMQ()      && (IsChild && FishAccess);}),
+                  ExitPairing::Both(&JabuJabusBelly_Beginning,    []{return Dungeon::JabuJabusBelly.IsVanilla() && (IsChild && Fish);}),
+                  ExitPairing::Both(&JabuJabusBelly_MQ_Beginning, []{return Dungeon::JabuJabusBelly.IsMQ()      && (IsChild && Fish);}),
                   ExitPairing::Both(&IceCavern_Beginning,         []{return Dungeon::IceCavern.IsVanilla() && IsAdult;}),
                   ExitPairing::Both(&IceCavern_MQ_Beginning,      []{return Dungeon::IceCavern.IsMQ()      && IsAdult;}),
                   ExitPairing::Both(&ZF_GreatFairyFountain,       []{return HasExplosives;})


### PR DESCRIPTION
Before, Jabu access only required access to a fish location, without checking for if the player had a bottle. (Presumably this was done under the assumption the player must have a bottle to get into Fountain in the first place past King Zora, but this is not true with open fountain.) Instead of checking for `FishAccess` the logic now checks for `Fish`, which is just `Bottle && FishAccess`.