### PR TITLE
Settings: Clear MQ dungeons before next generation

### DIFF
--- a/source/dungeon.hpp
+++ b/source/dungeon.hpp
@@ -26,6 +26,10 @@ public:
         masterQuest = true;
     }
 
+    void ClearMQ() {
+        masterQuest = false;
+    }
+
     bool IsMQ() const {
         return masterQuest;
     }

--- a/source/settings.cpp
+++ b/source/settings.cpp
@@ -872,6 +872,12 @@ namespace Settings {
     auto dungeons = dungeonList;
     Shuffle(dungeons);
 
+    //Clear MQ dungeons
+    for (u8 i = 0; i < dungeons.size(); i++) {
+      dungeons[i]->ClearMQ();
+    }
+
+    //Set appropriate amount of MQ dungeons
     if (RandomMQDungeons) {
       MQDungeonCount.SetSelectedIndex(Random(0, MQDungeonCount.GetOptionCount()));
     }


### PR DESCRIPTION
Which dungeons were set as MQ was not properly cleared between generations, meaning any dungeons randomly chosen to be MQ would also be MQ on subsequent generations unless the randomizer app was reset, even if the number of MQ dungeons was reduced.