### PR TITLE
Implement Dungeon Reward Shuffling

### DIFF
--- a/code/oot.ld
+++ b/code/oot.ld
@@ -64,8 +64,20 @@ SECTIONS
 		*(.patch_ScrubNutUpgradeOne)
 	}
 
-	.patch_EnKoInitBitMask 0x165760 : {
-		*(.patch_EnKoInitBitMask)
+	.patch_EnKoInitCheckForest_165834 0x165834 : {
+		*(.patch_EnKoInitCheckForest_165834)
+	}
+
+	.patch_EnKoInitCheckForest_165878 0x165878 : {
+		*(.patch_EnKoInitCheckForest_165878)
+	}
+
+	.patch_EnKoInitCheckForest_1658c0 0x1658c0 : {
+		*(.patch_EnKoInitCheckForest_1658c0)
+	}
+
+	.patch_EnKoInitCheckForest_1658f0 0x1658f0 : {
+		*(.patch_EnKoInitCheckForest_1658f0)
 	}
 
 	.patch_KingZoraCheckMovedFlag 0x165A60 : {
@@ -232,8 +244,8 @@ SECTIONS
 		*(.patch_WaterTempleCutsceneOverride)
 	}
 
-	.patch_SpiritTempleBitMask 0x1E4154 : {
-		*(.patch_SpiritTempleBitMask)
+	.patch_SpiritTempleCompleteCheck 0x1E415C : {
+		*(.patch_SpiritTempleCompleteCheck)
 	}
 
 	.patch_SpiritTempleItemGive 0x1E4168 : {
@@ -244,8 +256,8 @@ SECTIONS
 		*(.patch_SpiritTempleCutsceneOverride)
 	}
 
-	.patch_ShadowTempleBitMask 0x1E41DC : {
-		*(.patch_ShadowTempleBitMask)
+	.patch_ShadowTempleCompleteCheck 0x1E41E4 : {
+		*(.patch_ShadowTempleCompleteCheck)
 	}
 
 	.patch_ShadowTempleItemGive 0x1E41F0 : {
@@ -280,8 +292,8 @@ SECTIONS
 		*(.patch_CourtyardCheckForVisitedZeldaTwo)
 	}
 
-	.patch_DekuSproutBitMask 0x2153A8 : {
-		*(.patch_DekuSproutBitMask)
+	.patch_DekuSproutCheckForest 0x2153A4 : {
+		*(.patch_DekuSproutCheckForest)
 	}
 
 	.patch_DekuTheaterMaskOfTruth 0x21CA30 : {
@@ -632,8 +644,8 @@ SECTIONS
 		*(.patch_HandleDoorDestroyCustomModels)
 	}
 
-	.patch_FireArrowBitMask 0x3F23B0 : {
-		*(.patch_FireArrowBitMask)
+	.patch_FireArrowRequirement 0x3F23AC : {
+		*(.patch_FireArrowRequirement)
 	}
 
 	.patch_FireArrowCheckChestFlagOne 0x3F23FC : {

--- a/code/oot.ld
+++ b/code/oot.ld
@@ -72,12 +72,12 @@ SECTIONS
 		*(.patch_EnKoInitCheckForest_165878)
 	}
 
-	.patch_EnKoInitCheckForest_1658c0 0x1658c0 : {
-		*(.patch_EnKoInitCheckForest_1658c0)
+	.patch_EnKoInitCheckForest_1658C0 0x1658C0 : {
+		*(.patch_EnKoInitCheckForest_1658C0)
 	}
 
-	.patch_EnKoInitCheckForest_1658f0 0x1658f0 : {
-		*(.patch_EnKoInitCheckForest_1658f0)
+	.patch_EnKoInitCheckForest_1658F0 0x1658F0 : {
+		*(.patch_EnKoInitCheckForest_1658F0)
 	}
 
 	.patch_KingZoraCheckMovedFlag 0x165A60 : {

--- a/code/src/cutscenes.c
+++ b/code/src/cutscenes.c
@@ -236,8 +236,8 @@ void Custcene_OverrideSpiritTemple(void) {
     gGlobalContext->fadeOutTransition = 0x3;
     gSaveContext.nextCutsceneIndex = 0x0;
     if (EventCheck(0x47) == 0) {
-      ItemOverride_PushDungeonReward(DUNGEON_SPIRIT_TEMPLE);
-      EventSet(0x47);
+        ItemOverride_PushDungeonReward(DUNGEON_SPIRIT_TEMPLE);
+        EventSet(0x47);
     }
 }
 
@@ -247,7 +247,7 @@ void Custcene_OverrideShadowTemple(void) {
     gGlobalContext->fadeOutTransition = 0x3;
     gSaveContext.nextCutsceneIndex = 0x0;
     if (EventCheck(0x46) == 0) {
-      ItemOverride_PushDungeonReward(DUNGEON_SHADOW_TEMPLE);
-      EventSet(0x46);
+        ItemOverride_PushDungeonReward(DUNGEON_SHADOW_TEMPLE);
+        EventSet(0x46);
     }
 }

--- a/code/src/cutscenes.c
+++ b/code/src/cutscenes.c
@@ -235,7 +235,10 @@ void Custcene_OverrideSpiritTemple(void) {
     gGlobalContext->sceneLoadFlag = 0x14;
     gGlobalContext->fadeOutTransition = 0x3;
     gSaveContext.nextCutsceneIndex = 0x0;
-    ItemOverride_PushDungeonReward(DUNGEON_SPIRIT_TEMPLE);
+    if (EventCheck(0x47) == 0) {
+      ItemOverride_PushDungeonReward(DUNGEON_SPIRIT_TEMPLE);
+      EventSet(0x47);
+    }
 }
 
 void Custcene_OverrideShadowTemple(void) {
@@ -243,5 +246,8 @@ void Custcene_OverrideShadowTemple(void) {
     gGlobalContext->sceneLoadFlag = 0x14;
     gGlobalContext->fadeOutTransition = 0x3;
     gSaveContext.nextCutsceneIndex = 0x0;
-    ItemOverride_PushDungeonReward(DUNGEON_SHADOW_TEMPLE);
+    if (EventCheck(0x46) == 0) {
+      ItemOverride_PushDungeonReward(DUNGEON_SHADOW_TEMPLE);
+      EventSet(0x46);
+    }
 }

--- a/code/src/gfx.c
+++ b/code/src/gfx.c
@@ -47,7 +47,7 @@ static void Gfx_DrawDungeonItems(void) {
 static void Gfx_DrawDungeonRewards(void) {
     for (u32 dungeonId = 0; dungeonId <= DUNGEON_SHADOW_TEMPLE; ++dungeonId) {
         Draw_DrawFormattedString(10, 10 + (dungeonId * SPACING_Y), COLOR_WHITE, "%-30s - %s",
-            DungeonNames[dungeonId], DungeonReward_GetName(dungeonId));
+            DungeonNames[dungeonId], (gSettingsContext.shuffleRewards == REWARDSHUFFLE_END_OF_DUNGEON) ? DungeonReward_GetName(dungeonId) : "???");
     }
     Gfx_DrawChangeMenuPrompt();
     Draw_FlushFramebuffer();
@@ -107,7 +107,7 @@ void Gfx_Update(void) {
     if (!GfxInit) {
         Gfx_Init();
     }
-    
+
     u8 openingButton = 0;
     if(	(gSettingsContext.menuOpeningButton == 0 && rInputCtx.cur.sel) ||
 	(gSettingsContext.menuOpeningButton == 1 && rInputCtx.cur.strt) ||

--- a/code/src/hooks.s
+++ b/code/src/hooks.s
@@ -67,7 +67,7 @@ hook_OverrideItemID:
     bl ItemOverride_GetItemTextAndItemID
     pop {r0-r12, lr}
     b 0x2BC1DC
-noOverrideItemID:    
+noOverrideItemID:
     ldrb r1,[r6,#0x0]
     b 0x2BC1D4
 
@@ -86,7 +86,7 @@ hook_OverrideGraphicID:
 
     ldr r0,.rActiveItemGraphicId_addr
     ldr r0,[r0]
-    b returnGraphicID    
+    b returnGraphicID
 noOverrideGraphicID:
     mov r0,#-0x1
 returnGraphicID:
@@ -244,51 +244,12 @@ hook_DemoEffectStoneDraw:
     ldr r0,[r4,#0x2A8]
     b 0x1D20A0
 
-#The magic number here is SPIRIT_MEDALLION from dungeon_rewards.h
-.global hook_SpiritTempleBitMask
-hook_SpiritTempleBitMask:
+.global hook_EnKoInitCheckForest
+hook_EnKoInitCheckForest:
     push {r1-r12, lr}
-    mov r0,#0x06
-    bl DungeonReward_GetBitMask
+    bl EnKo_CheckForestTempleBeat
+    tst r0,#0x1
     pop {r1-r12, lr}
-    bx lr
-
-#The magic number here is SHADOW_MEDALLION from dungeon_rewards.h
-.global hook_ShadowTempleBitMask
-hook_ShadowTempleBitMask:
-    push {r1-r12, lr}
-    mov r0,#0x07
-    bl DungeonReward_GetBitMask
-    pop {r1-r12, lr}
-    bx lr
-
-#The magic number here is FOREST_MEDALLION from dungeon_rewards.h
-.global hook_DekuSproutBitMask
-hook_DekuSproutBitMask:
-    push {r0, r2-r12, lr}
-    mov r0,#0x03
-    bl DungeonReward_GetBitMask
-    cpy r1,r0
-    pop {r0, r2-r12, lr}
-    bx lr
-
-.global hook_EnKoInitBitMask
-hook_EnKoInitBitMask:
-    push {r0, r2-r12, lr}
-    mov r0,#0x03
-    bl DungeonReward_GetBitMaskAddr
-    cpy r1,r0
-    pop {r0, r2-r12, lr}
-    bx lr
-
-#The magic number here is WATER_MEDALLION from dungeon_rewards.h
-.global hook_FireArrowBitMask
-hook_FireArrowBitMask:
-    push {r0-r2, r4-r12, lr}
-    mov r0,#0x05
-    bl DungeonReward_GetBitMask
-    cpy r3,r0
-    pop {r0-r2, r4-r12, lr}
     bx lr
 
 .global hook_FireArrowCheckChestFlag

--- a/code/src/item_override.c
+++ b/code/src/item_override.c
@@ -442,7 +442,7 @@ void ItemOverride_PushDungeonReward(u8 dungeon) {
 void ItemOverride_CheckStartingItem() {
     //use eventChkInf[0] |= 0x0001 as the check for this
     if (EventCheck(0x00) == 0) {
-        if (gSettingsContext.linksPocketItem != LINKSPOCKET_DUNGEON_REWARD) {
+        if (gSettingsContext.linksPocketItem != LINKSPOCKETITEM_DUNGEON_REWARD) {
             ItemOverride_PushDungeonReward(0xFF); //Push Link's Pocket Reward
         }
         EventSet(0x00);

--- a/code/src/kokiri.c
+++ b/code/src/kokiri.c
@@ -8,3 +8,11 @@ u32 EnKo_CheckOpenForest(void) {
         return 0;
     }
 }
+
+u32 EnKo_CheckForestTempleBeat(void) {
+    if (EventCheck(0x48) == 0) {
+      return 0;
+    } else {
+      return 1;
+    }
+}

--- a/code/src/models.c
+++ b/code/src/models.c
@@ -313,12 +313,12 @@ void Model_Create(Model* model, GlobalContext* globalCtx) {
                 newModel->scale = 0.25f;
                 break;
             case 0x00BA : //Medallions
-                newModel->scale = ((globalCtx->sceneNum == 0x44) ? 0.2f : 0.082f);
-                break;
+                // newModel->scale = ((globalCtx->sceneNum == 0x44) ? 0.2f : 0.082f);
+                // break;
             case 0x019C : //Kokiri Emerald
             case 0x019D : //Goron Ruby
             case 0x019E : //Zora Sapphire
-                newModel->scale = 0.082f;
+                newModel->scale = 0.2f;
                 break;
             default:
                 newModel->scale = 0.3f;
@@ -329,7 +329,7 @@ void Model_Create(Model* model, GlobalContext* globalCtx) {
 
 void Model_SpawnByActor(Actor* actor, GlobalContext* globalCtx, u16 baseItemId) {
     Model model = { NULL, { 0, 0, 0 }, 0, NULL };
-    
+
     Model_InfoLookup(&model, actor, globalCtx, baseItemId);
     if (model.info.objectId != 0) {
         model.actor = actor;

--- a/code/src/patches.s
+++ b/code/src/patches.s
@@ -690,16 +690,16 @@ EnKoInitCheckForest_165878_patch:
     nop
     nop
 
-.section .patch_EnKoInitCheckForest_1658c0
-.global EnKoInitCheckForest_1658c0_patch
-EnKoInitCheckForest_1658c0_patch:
+.section .patch_EnKoInitCheckForest_1658C0
+.global EnKoInitCheckForest_1658C0_patch
+EnKoInitCheckForest_1658C0_patch:
     bl hook_EnKoInitCheckForest
     nop
     nop
 
-.section .patch_EnKoInitCheckForest_1658f0
-.global EnKoInitCheckForest_1658f0_patch
-EnKoInitCheckForest_1658f0_patch:
+.section .patch_EnKoInitCheckForest_1658F0
+.global EnKoInitCheckForest_1658F0_patch
+EnKoInitCheckForest_1658F0_patch:
     bl hook_EnKoInitCheckForest
     nop
     nop

--- a/code/src/patches.s
+++ b/code/src/patches.s
@@ -499,7 +499,7 @@ BombchuBowlingStaticReward_patch:
 .section .patch_DekuTreeItemGive
 .global DekuTreeItemGive_patch
 DekuTreeItemGive_patch:
-    bl DungeonReward_OverrideItemGive
+    nop
 
 .section .patch_DekuTreeCutsceneOverride
 .global DekuTreeCutsceneOverride_patch
@@ -510,7 +510,7 @@ DekuTreeCutsceneOverride_patch:
 .section .patch_DodongosCavernItemGive
 .global DodongosCavernItemGive_patch
 DodongosCavernItemGive_patch:
-    bl DungeonReward_OverrideItemGive
+    nop
 
 .section .patch_DodongosCavernCutsceneOverride
 .global DodongosCavernCutsceneOverride_patch
@@ -521,7 +521,7 @@ DodongosCavernCutsceneOverride_patch:
 .section .patch_JabuJabuItemGive
 .global JabuJabuItemGive_patch
 JabuJabuItemGive_patch:
-    bl DungeonReward_OverrideItemGive
+    nop
 
 .section .patch_JabuJabuCutsceneOverride
 .global JabuJabuCutsceneOverride_patch
@@ -533,17 +533,17 @@ JabuJabuCutsceneOverride_patch:
 .section .patch_ForestTempleItemGive
 .global ForestTempleItemGive_patch
 ForestTempleItemGive_patch:
-    bl DungeonReward_OverrideItemGive
+    nop
 
 .section .patch_ForestTempleItemGiveTwo
 .global ForestTempleItemGiveTwo_patch
 ForestTempleItemGiveTwo_patch:
-    bl DungeonReward_OverrideItemGive
+    nop
 
 .section .patch_ForestTempleItemGiveThree
 .global ForestTempleItemGiveThree_patch
 ForestTempleItemGiveThree_patch:
-    b DungeonReward_OverrideItemGive
+    nop
 
 .section .patch_ForestTempleCutsceneOverride
 .global ForestTempleCutsceneOverride_patch
@@ -555,22 +555,22 @@ ForestTempleCutsceneOverride_patch:
 .section .patch_FireTempleItemGive
 .global FireTempleItemGive_patch
 FireTempleItemGive_patch:
-    bl DungeonReward_OverrideItemGive
+    nop
 
 .section .patch_FireTempleItemGiveTwo
 .global FireTempleItemGiveTwo_patch
 FireTempleItemGiveTwo_patch:
-    bl DungeonReward_OverrideItemGive
+    nop
 
 .section .patch_FireTempleItemGiveThree
 .global FireTempleItemGiveThree_patch
 FireTempleItemGiveThree_patch:
-    bl DungeonReward_OverrideItemGive
+    nop
 
 .section .patch_FireTempleItemGiveFour
 .global FireTempleItemGiveFour_patch
 FireTempleItemGiveFour_patch:
-    b DungeonReward_OverrideItemGive
+    nop
 
 .section .patch_FireTempleCutsceneOverride
 .global FireTempleCutsceneOverride_patch
@@ -582,17 +582,17 @@ FireTempleCutsceneOverride_patch:
 .section .patch_WaterTempleItemGive
 .global WaterTempleItemGive_patch
 WaterTempleItemGive_patch:
-    bl DungeonReward_OverrideItemGive
+    nop
 
 .section .patch_WaterTempleItemGiveTwo
 .global WaterTempleItemGiveTwo_patch
 WaterTempleItemGiveTwo_patch:
-    bl DungeonReward_OverrideItemGive
+    nop
 
 .section .patch_WaterTempleItemGiveThree
 .global WaterTempleItemGiveThree_patch
 WaterTempleItemGiveThree_patch:
-    b DungeonReward_OverrideItemGive
+    nop
 
 .section .patch_WaterTempleCutsceneOverride
 .global WaterTempleCutsceneOverride_patch
@@ -605,22 +605,22 @@ WaterTempleCutsceneOverride_patch:
 .section .patch_SpiritTempleItemGive
 .global SpiritTempleItemGive_patch
 SpiritTempleItemGive_patch:
-    bl DungeonReward_OverrideItemGive
+    nop
 
 .section .patch_SpiritTempleItemGiveTwo
 .global SpiritTempleItemGiveTwo_patch
 SpiritTempleItemGiveTwo_patch:
-    bl DungeonReward_OverrideItemGive
+    nop
 
 .section .patch_SpiritTempleItemGiveThree
 .global SpiritTempleItemGiveThree_patch
 SpiritTempleItemGiveThree_patch:
-    b DungeonReward_OverrideItemGive
+    nop
 
-.section .patch_SpiritTempleBitMask
-.global SpiritTempleBitMask_patch
-SpiritTempleBitMask_patch:
-    bl hook_SpiritTempleBitMask
+.section .patch_SpiritTempleCompleteCheck
+.global SpiritTempleCompleteCheck_patch
+SpiritTempleCompleteCheck_patch:
+    nop
 
 .section .patch_SpiritTempleCutsceneOverride
 .global SpiritTempleCutsceneOverride_patch
@@ -631,22 +631,22 @@ SpiritTempleCutsceneOverride_patch:
 .section .patch_ShadowTempleItemGive
 .global ShadowTempleItemGive_patch
 ShadowTempleItemGive_patch:
-    bl DungeonReward_OverrideItemGive
+    nop
 
 .section .patch_ShadowTempleItemGiveTwo
 .global ShadowTempleItemGiveTwo_patch
 ShadowTempleItemGiveTwo_patch:
-    bl DungeonReward_OverrideItemGive
+    nop
 
 .section .patch_ShadowTempleItemGiveThree
 .global ShadowTempleItemGiveThree_patch
 ShadowTempleItemGiveThree_patch:
-    b DungeonReward_OverrideItemGive
+    nop
 
-.section .patch_ShadowTempleBitMask
-.global ShadowTempleBitMask_patch
-ShadowTempleBitMask_patch:
-    bl hook_ShadowTempleBitMask
+.section .patch_ShadowTempleCompleteCheck
+.global ShadowTempleCompleteCheck_patch
+ShadowTempleCompleteCheck_patch:
+    nop
 
 .section .patch_ShadowTempleCutsceneOverride
 .global ShadowTempleCutsceneOverride_patch
@@ -669,15 +669,40 @@ DemoEffectMedallionDraw_patch:
 DemoEffectStoneDraw_patch:
     b hook_DemoEffectStoneDraw
 
-.section .patch_DekuSproutBitMask
-.global DekuSproutBitMask_patch
-DekuSproutBitMask_patch:
-    bl hook_DekuSproutBitMask
+.section .patch_DekuSproutCheckForest
+.global DekuSproutCheckForest_patch
+DekuSproutCheckForest_patch:
+    ldr r0, [r0,#0xEF4]
+    nop
+    tst r0,#0x100
 
-.section .patch_EnKoInitBitMask
-.global EnKoInitBitMask_patch
-EnKoInitBitMask_patch:
-    bl hook_EnKoInitBitMask
+.section .patch_EnKoInitCheckForest_165834
+.global EnKoInitCheckForest_165834_patch
+EnKoInitCheckForest_165834_patch:
+    bl hook_EnKoInitCheckForest
+    nop
+    nop
+
+.section .patch_EnKoInitCheckForest_165878
+.global EnKoInitCheckForest_165878_patch
+EnKoInitCheckForest_165878_patch:
+    bl hook_EnKoInitCheckForest
+    nop
+    nop
+
+.section .patch_EnKoInitCheckForest_1658c0
+.global EnKoInitCheckForest_1658c0_patch
+EnKoInitCheckForest_1658c0_patch:
+    bl hook_EnKoInitCheckForest
+    nop
+    nop
+
+.section .patch_EnKoInitCheckForest_1658f0
+.global EnKoInitCheckForest_1658f0_patch
+EnKoInitCheckForest_1658f0_patch:
+    bl hook_EnKoInitCheckForest
+    nop
+    nop
 
 .section .patch_FireArrowCheckChestFlagOne
 .global FireArrowCheckChestFlagOne_patch
@@ -689,10 +714,12 @@ FireArrowCheckChestFlagOne_patch:
 FireArrowCheckChestFlagTwo_patch:
     bl hook_FireArrowCheckChestFlag
 
-.section .patch_FireArrowBitMask
-.global FireArrowBitMask_patch
-FireArrowBitMask_patch:
-    bl hook_FireArrowBitMask
+.section .patch_FireArrowRequirement
+.global FireArrowRequirement_patch
+FireArrowRequirement_patch:
+    ldr r2, [r1,#0xEF4]
+    nop
+    tst r2,#0x400
 
 .section .patch_BusinessScrubCheckFlags
 .global BusinessScrubCheckFlags_patch

--- a/code/src/settings.h
+++ b/code/src/settings.h
@@ -69,10 +69,17 @@ typedef enum {
 } DungeonMode;
 
 typedef enum {
-  LINKSPOCKET_DUNGEON_REWARD,
-  LINKSPOCKET_ADVANCEMENT,
-  LINKSPOCKET_ANYTHING,
-  LINKSPOCKET_NOTHING,
+  REWARDSHUFFLE_END_OF_DUNGEON,
+  REWARDSHUFFLE_ANY_DUNGEON,
+  REWARDSHUFFLE_OVERWORLD,
+  REWARDSHUFFLE_ANYWHERE,
+} RewardShuffleSetting;
+
+typedef enum {
+  LINKSPOCKETITEM_DUNGEON_REWARD,
+  LINKSPOCKETITEM_ADVANCEMENT,
+  LINKSPOCKETITEM_ANYTHING,
+  LINKSPOCKETITEM_NOTHING,
 } LinksPocketSetting;
 
 typedef enum {
@@ -206,6 +213,7 @@ typedef struct {
   u8 mqDungeonCount;
   u8 mirrorWorld;
 
+  u8 shuffleRewards;
   u8 linksPocketItem;
   u8 shuffleSongs;
   u8 tokensanity;

--- a/source/fill.cpp
+++ b/source/fill.cpp
@@ -408,11 +408,6 @@ static void AssumedFill(std::vector<Item> items, std::vector<ItemLocation*> allo
 
 static void RandomizeDungeonRewards() {
 
-  //get stones and medallions
-  std::vector<Item> rewards = FilterAndEraseFromPool(ItemPool, [](const Item& i) {return i.GetItemType() == ITEMTYPE_DUNGEONREWARD;});
-  AssumedFill(rewards, dungeonRewardLocations);
-
-  int baseOffset = I_KokiriEmerald.GetItemID();
   static constexpr std::array<u32, 9> bitMaskTable = {
     0x00040000,
     0x00080000,
@@ -424,15 +419,31 @@ static void RandomizeDungeonRewards() {
     0x00000010,
     0x00000020,
   };
+  int baseOffset = I_KokiriEmerald.GetItemID();
 
-  for (size_t i = 0; i < dungeonRewardLocations.size(); i++) {
-    const auto index = dungeonRewardLocations[i]->GetPlacedItem().GetItemID() - baseOffset;
-    rDungeonRewardOverrides[i] = index;
+  if (ShuffleRewards.Is(REWARDSHUFFLE_END_OF_DUNGEON)) {
+    //get stones and medallions
+    std::vector<Item> rewards = FilterAndEraseFromPool(ItemPool, [](const Item& i) {return i.GetItemType() == ITEMTYPE_DUNGEONREWARD;});
+    AssumedFill(rewards, dungeonRewardLocations);
 
-    //set the player's dungeon reward on file creation instead of pushing it to them at the start
-    if (i == dungeonRewardLocations.size()-1 /*&& LinksPocket.Is(LINKSPOCKET_DUNGEON_REWARD)*/) {
-      LinksPocketRewardBitMask = bitMaskTable[index];
+    for (size_t i = 0; i < dungeonRewardLocations.size(); i++) {
+      const auto index = dungeonRewardLocations[i]->GetPlacedItem().GetItemID() - baseOffset;
+      rDungeonRewardOverrides[i] = index;
+
+      //set the player's dungeon reward on file creation instead of pushing it to them at the start
+      if (i == dungeonRewardLocations.size()-1) {
+        LinksPocketRewardBitMask = bitMaskTable[index];
+      }
     }
+  } else if (LinksPocketItem.Is(LINKSPOCKETITEM_DUNGEON_REWARD)) {
+    //get 1 stone/medallion
+    std::vector<Item> rewards = FilterFromPool(ItemPool, [](const Item& i) {return i.GetItemType() == ITEMTYPE_DUNGEONREWARD;});
+    Item startingReward = RandomElement(rewards, true);
+
+    LinksPocketRewardBitMask = bitMaskTable[startingReward.GetItemID() - baseOffset];
+    PlaceItemInLocation(&LinksPocket, startingReward);
+    //erase the stone/medallion from the Item Pool
+    FilterAndEraseFromPool(ItemPool, [startingReward](const Item& i) {return i == startingReward;});
   }
 }
 
@@ -475,7 +486,7 @@ static void RandomizeOwnDungeon(DungeonInfo* dungeon) {
   }
 }
 
-/*Randomize dungeon items restricted to a certain set of locations.
+/*Randomize items restricted to a certain set of locations.
   The fill order of location groups is as follows:
     - Own Dungeon
     - Any Dungeon
@@ -533,6 +544,14 @@ static void RandomizeDungeonItems() {
     AddElementsToPool(overworldItems, gerudoKeys);
   }
 
+  if (ShuffleRewards.Is(REWARDSHUFFLE_ANY_DUNGEON)) {
+    auto rewards = FilterAndEraseFromPool(ItemPool, [](const Item& i){return i.GetItemType() == ITEMTYPE_DUNGEONREWARD;});
+    AddElementsToPool(anyDungeonItems, rewards);
+  } else if (ShuffleRewards.Is(REWARDSHUFFLE_OVERWORLD)) {
+    auto rewards = FilterAndEraseFromPool(ItemPool, [](const Item& i){return i.GetItemType() == ITEMTYPE_DUNGEONREWARD;});
+    AddElementsToPool(overworldItems, rewards);
+  }
+
   //Randomize Any Dungeon and Overworld pools
   AssumedFill(anyDungeonItems, anyDungeonLocations);
   AssumedFill(overworldItems, overworldLocations);
@@ -547,6 +566,21 @@ static void RandomizeDungeonItems() {
       AssumedFill(mapAndCompassItems, overworldLocations);
     }
   }
+}
+
+static void RandomizeLinksPocket() {
+  if (LinksPocketItem.Is(LINKSPOCKETITEM_ADVANCEMENT)) {
+   //Get all the advancement items                                                                                     don't include tokens
+   std::vector<Item> advancementItems = FilterAndEraseFromPool(ItemPool, [](const Item& i){return i.IsAdvancement() && i.GetItemType() != ITEMTYPE_TOKEN;});
+   //select a random one
+   Item startingItem = RandomElement(advancementItems, true);
+   //add the others back
+   AddElementsToPool(ItemPool, advancementItems);
+
+   PlaceItemInLocation(&LinksPocket, startingItem);
+ } else if (LinksPocketItem.Is(LINKSPOCKETITEM_NOTHING)) {
+   PlaceItemInLocation(&LinksPocket, GreenRupee);
+ }
 }
 
 int Fill() {
@@ -579,6 +613,9 @@ int Fill() {
 
     //Then place dungeon items that are assigned to restrictive pools
     RandomizeDungeonItems();
+
+    //Then place Link's Pocket Item if it has to be an advancement item
+    RandomizeLinksPocket();
 
     //Then place the rest of the advancement items
     std::vector<Item> remainingAdvancementItems = FilterAndEraseFromPool(ItemPool, [](const Item& i) { return i.IsAdvancement();});

--- a/source/item_location.hpp
+++ b/source/item_location.hpp
@@ -124,7 +124,10 @@ public:
                               "the location pool. Locations that require an item\n"
                               "to be placed at them based on your current\n"
                               "settings cannot be excluded and won't be shown\n"
-                              "unless you change your settings.";
+                              "unless you change your settings.\n"
+                              "\n"
+                              "If you exclude to many locations, it might not be\n"
+                              "possible to fill the world.";
 
       //add option to forbid any location from progress items
       if (name.length() < 23) {

--- a/source/logic.cpp
+++ b/source/logic.cpp
@@ -425,7 +425,7 @@ namespace Logic {
     Fish         = HasBottle && FishAccess;
     Fairy        = HasBottle && FairyAccess;
 
-    HasBombchus   = (BuyBombchus5 || BuyBombchus10 || BuyBombchus20 || BombchuDrop) && (BombchusInLogic || BombBag);
+    HasBombchus   = (BuyBombchus5 || BuyBombchus10 || BuyBombchus20 /*|| BombchuDrop*/) && (BombchusInLogic || BombBag);
     FoundBombchus = (BombchusInLogic && (Bombchus || Bombchus5 || Bombchus10 || Bombchus20)) || (!BombchusInLogic && BombBag);
     HasExplosives =  Bombs || (BombchusInLogic && HasBombchus);
 

--- a/source/setting_descriptions.cpp
+++ b/source/setting_descriptions.cpp
@@ -133,7 +133,20 @@ string_view randomMQDungeonsDesc      = "If set, a random number of dungeons wil
 string_view mqDungeonCountDesc        = "Specify the number of Master Quest dungeons to\n"
                                         "appear in the game. Which dungeons become Master\n"
                                         "Quest will be chosen at random.";                 //
-                                                                                           //
+/*------------------------------                                                           //
+|   SHUFFLE DUNGEON REWARDS    |                                                           //
+------------------------------*/                                                           //
+string_view shuffleRewardsEndOfDungeon= "Medallions and Spiritual Stones will be given as\n"
+                                        "rewards for beating dungeons.\n"                  //
+                                        "\n"                                               //
+                                        "This setting will force Link's Pocket to be a\n"  //
+                                        "Medallion or Spiritual Stone.";                   //
+string_view shuffleRewardsAnyDungeon  = "Medallions and Spiritual Stones can only appear\n"//
+                                        "inside of dungeons.";                             //
+string_view shuffleRewardsOverworld   = "Medallions and Spiritual Stones can only appear\n"//
+                                        "outside of dungeons.";                            //
+string_view shuffleRewardsAnywhere    = "Medallions and Spiritual Stones can appear\n"     //
+                                        "anywhere.";                                       //
 /*------------------------------                                                           //
 |        LINK'S POCKET         |                                                           //
 ------------------------------*/                                                           //
@@ -143,7 +156,7 @@ string_view linksPocketAdvancement    = "Link will receive a random advancement 
                                         "beginning of the playthrough.";                   //
 string_view linksPocketAnything       = "Link will receive a random item from the item pool"
                                         "at the beginning of the playthrough.";            //
-string_view linksPocketNothing        = "Link will start with nothing.";                   //
+string_view linksPocketNothing        = "Link will start with a very useful green rupee."; //
 /*------------------------------                                                           //
 |         SONG SHUFFLE         |                                                           //
 ------------------------------*/                                                           //

--- a/source/setting_descriptions.hpp
+++ b/source/setting_descriptions.hpp
@@ -50,6 +50,11 @@ extern string_view mqDungeonCountDesc;
 
 extern string_view mirrorWorldDesc;
 
+extern string_view shuffleRewardsEndOfDungeon;
+extern string_view shuffleRewardsAnyDungeon;
+extern string_view shuffleRewardsOverworld;
+extern string_view shuffleRewardsAnywhere;
+
 extern string_view linksPocketDungeonReward;
 extern string_view linksPocketAdvancement;
 extern string_view linksPocketAnything;

--- a/source/settings.cpp
+++ b/source/settings.cpp
@@ -64,6 +64,7 @@ namespace Settings {
   };
 
   //Shuffle Settings
+  Option ShuffleRewards      = Option::U8  ("Shuffle Dungeon Rewards",{"End of Dungeons", "Any Dungeon", "Overworld", "Anywhere"},       {shuffleRewardsEndOfDungeon, shuffleRewardsAnyDungeon, shuffleRewardsOverworld, shuffleRewardsAnywhere});
   Option LinksPocketItem     = Option::U8  ("Link's Pocket",          {"Dungeon Reward", "Advancement", "Anything", "Nothing"},          {linksPocketDungeonReward, linksPocketAdvancement, linksPocketAnything, linksPocketNothing});
   Option ShuffleSongs        = Option::U8  ("Shuffle Songs",          {"Song Locations", "Dungeon Rewards", "Anywhere"},                 {songsSongLocations, songsDungeonRewards, songsAllLocations});
   Option Tokensanity         = Option::U8  ("Tokensanity",            {"Off", "Dungeons", "Overworld", "All Tokens"},                    {tokensOff, tokensDungeon, tokensOverworld, tokensAllTokens});
@@ -76,7 +77,8 @@ namespace Settings {
   Option ShuffleMagicBeans   = Option::Bool("Shuffle Magic Beans",    {"Off", "On"},                                                     {magicBeansDesc});
   //TODO: Medigoron and Carpet Salesman
   std::vector<Option *> shuffleOptions = {
-    //&LinksPocketItem,
+    &ShuffleRewards,
+    &LinksPocketItem,
     &ShuffleSongs,
     &Tokensanity,
     &Scrubsanity,
@@ -438,6 +440,7 @@ namespace Settings {
     ctx.mqDungeonCount       = MQDungeonCount.Value<u8>();
     ctx.mirrorWorld          = (MirrorWorld) ? 1 : 0;
 
+    ctx.shuffleRewards       = ShuffleRewards.Value<u8>();
     ctx.linksPocketItem      = LinksPocketItem.Value<u8>();
     ctx.shuffleSongs         = ShuffleSongs.Value<u8>();
     ctx.tokensanity          = Tokensanity.Value<u8>();
@@ -783,6 +786,14 @@ namespace Settings {
       MQDungeonCount.SetSelectedIndex(0);
     } else {
       MQDungeonCount.Unhide();
+    }
+
+    //Force Link's Pocket Item to be a dungeon reward if Shuffle Rewards is end of dungeons
+    if (ShuffleRewards.Is(REWARDSHUFFLE_END_OF_DUNGEON)) {
+      LinksPocketItem.Lock();
+      LinksPocketItem.SetSelectedIndex(LINKSPOCKETITEM_DUNGEON_REWARD);
+    } else {
+      LinksPocketItem.Unlock();
     }
 
     //Only show Medallion Count if setting Ganons Boss Key to LACS Medallions

--- a/source/settings.hpp
+++ b/source/settings.hpp
@@ -257,6 +257,8 @@ namespace Settings {
   extern Option MQDungeonCount;
   extern Option MirrorWorld;
 
+  extern Option ShuffleRewards;
+  extern Option LinksPocketItem;
   extern Option ShuffleSongs;
   extern Option Tokensanity;
   extern Option Scrubsanity;


### PR DESCRIPTION
The options "Dungeon Reward Shuffle" and "Link's Pocket" are now available to use. The dungeon reward shuffle option allows players to shuffle the medallions and spiritual stones to locations which aren't at the end of dungeons.

This new option also changes the following:
- Link's Pocket is a new option that the player can set to determine what kind of item Link should start with. Previously Link always started with a stone/medallion. For now the options are: Dungeon Reward(Stone/Medallion), Advancement, Anything, Nothing.
- Previously there were ASM patches that would swap an expected dungeon reward from the base game with the dungeon reward assigned to the end of the dungeon in the randomizer. These patches have been replaced with nop operations, and instead items obtained at the end of dungeons will be pushed as delayed overrides when players enter a blue warp.
- Unused savecontext bits in the eventChkInf table are now used to track whether players have completed the shadow and spirit temples (values 0x46 and 0x47). The base game only ever checks for shadow/spirit medallions.
- Model sizes for stones/medallions have been changed to make them appear properly sized on the overworld.