### PR TITLE
Settings: Add option for dungeon completion on LACS/Rainbow Bridge

### DIFF
--- a/code/src/cutscenes.c
+++ b/code/src/cutscenes.c
@@ -22,8 +22,12 @@ u32 LACS_ConditionMedallions(void) {
     return SaveFile_GetMedallionCount() >= gSettingsContext.lacsMedallionCount;
 }
 
+u32 LACS_ConditionRewards(void) {
+    return SaveFile_GetStoneCount() + SaveFile_GetMedallionCount() >= gSettingsContext.lacsRewardCount;
+}
+
 u32 LACS_ConditionDungeons(void) {
-    return SaveFile_GetStoneCount() + SaveFile_GetMedallionCount() >= gSettingsContext.lacsDungeonCount;
+    return SaveFile_GetDungeonCount() >= gSettingsContext.lacsDungeonCount;
 }
 
 u32 LACS_ConditionTokens(void) {
@@ -42,6 +46,9 @@ void Cutscene_OverrideLACS(void) {
             break;
         case LACSCONDITION_MEDALLIONS:
             conditionMet = LACS_ConditionMedallions();
+            break;
+        case LACSCONDITION_REWARDS:
+            conditionMet = LACS_ConditionRewards();
             break;
         case LACSCONDITION_DUNGEONS:
             conditionMet = LACS_ConditionDungeons();

--- a/code/src/rainbow_bridge.c
+++ b/code/src/rainbow_bridge.c
@@ -15,8 +15,12 @@ u32 BgGjyoBridge_ConditionMedallions(void) {
     return SaveFile_GetMedallionCount() >= gSettingsContext.bridgeMedallionCount;
 }
 
+u32 BgGjyoBridge_ConditionRewards(void) {
+    return SaveFile_GetMedallionCount() + SaveFile_GetStoneCount() >= gSettingsContext.bridgeRewardCount;
+}
+
 u32 BgGjyoBridge_ConditionDungeons(void) {
-    return SaveFile_GetMedallionCount() + SaveFile_GetStoneCount() >= gSettingsContext.bridgeDungeonCount;
+    return SaveFile_GetDungeonCount() >= gSettingsContext.bridgeDungeonCount;
 }
 
 u32 BgGjyoBridge_CheckCondition(void) {
@@ -29,6 +33,8 @@ u32 BgGjyoBridge_CheckCondition(void) {
             return BgGjyoBridge_ConditionStones();
         case RAINBOWBRIDGE_MEDALLIONS:
             return BgGjyoBridge_ConditionMedallions();
+        case RAINBOWBRIDGE_REWARDS:
+            return BgGjyoBridge_ConditionRewards();
         case RAINBOWBRIDGE_DUNGEONS:
             return BgGjyoBridge_ConditionDungeons();
         case RAINBOWBRIDGE_TOKENS:

--- a/code/src/savefile.c
+++ b/code/src/savefile.c
@@ -224,3 +224,19 @@ u8 SaveFile_GetStoneCount(void) {
     }
     return count;
 }
+
+u8 SaveFile_GetDungeonCount(void) {
+    u8 count = 0;
+
+    //Adult dungeons
+    for (u8 i = 0x6; i <= 0xA; i++) {
+        count += (gSaveContext.eventChkInf[4] >> i) & 0x1;
+    }
+
+    //Child dungeons
+    count += (gSaveContext.eventChkInf[0] >> 9) & 0x1; //Deku Tree
+    count += (gSaveContext.eventChkInf[2] >> 5) & 0x1; //Dodongo's Cavern
+    count += (gSaveContext.eventChkInf[3] >> 7) & 0x1; //Jabu Jabu's Belly
+
+    return count;
+}

--- a/code/src/savefile.h
+++ b/code/src/savefile.h
@@ -5,5 +5,6 @@
 
 u8 SaveFile_GetMedallionCount(void);
 u8 SaveFile_GetStoneCount(void);
+u8 SaveFile_GetDungeonCount(void);
 
 #endif //_SAVEFILE_H_

--- a/code/src/settings.h
+++ b/code/src/settings.h
@@ -45,6 +45,7 @@ typedef enum {
   RAINBOWBRIDGE_VANILLA,
   RAINBOWBRIDGE_STONES,
   RAINBOWBRIDGE_MEDALLIONS,
+  RAINBOWBRIDGE_REWARDS,
   RAINBOWBRIDGE_DUNGEONS,
   RAINBOWBRIDGE_TOKENS,
 } RainbowBridgeSetting;
@@ -53,6 +54,7 @@ typedef enum {
   LACSCONDITION_VANILLA,
   LACSCONDITION_STONES,
   LACSCONDITION_MEDALLIONS,
+  LACSCONDITION_REWARDS,
   LACSCONDITION_DUNGEONS,
   LACSCONDITION_TOKENS,
 } LACSConditionSetting;
@@ -146,6 +148,7 @@ typedef enum {
   GANONSBOSSKEY_LACS_VANILLA,
   GANONSBOSSKEY_LACS_MEDALLIONS,
   GANONSBOSSKEY_LACS_STONES,
+  GANONSBOSSKEY_LACS_REWARDS,
   GANONSBOSSKEY_LACS_DUNGEONS,
   GANONSBOSSKEY_LACS_TOKENS,
 } GanonsBossKeySetting;
@@ -200,6 +203,7 @@ typedef struct {
   u8 rainbowBridge;
   u8 bridgeStoneCount;
   u8 bridgeMedallionCount;
+  u8 bridgeRewardCount;
   u8 bridgeDungeonCount;
   u8 bridgeTokenCount;
   u8 randomGanonsTrials;
@@ -233,6 +237,7 @@ typedef struct {
   u8 lacsCondition;
   u8 lacsMedallionCount;
   u8 lacsStoneCount;
+  u8 lacsRewardCount;
   u8 lacsDungeonCount;
   u8 lacsTokenCount;
 

--- a/source/location_access.cpp
+++ b/source/location_access.cpp
@@ -2433,867 +2433,867 @@ namespace Exits { //name, scene, hint, events, locations, exits
   ---------------------------*/
 
   Exit DekuTree_MQ_Lobby = Exit("Deku Tree MQ Lobby", "Deku Tree", "", NO_DAY_NIGHT_CYCLE, {
-    //Events
-    EventPairing(&DekuBabaSticks, []{return DekuBabaSticks || (IsAdult || KokiriSword || Boomerang);}),
-    EventPairing(&DekuBabaNuts,   []{return DekuBabaNuts   || (IsAdult || KokiriSword || Slingshot || Sticks || HasExplosives || CanUse(CanUseItem::Dins_Fire));}),
+                  //Events
+                  EventPairing(&DekuBabaSticks, []{return DekuBabaSticks || (IsAdult || KokiriSword || Boomerang);}),
+                  EventPairing(&DekuBabaNuts,   []{return DekuBabaNuts   || (IsAdult || KokiriSword || Slingshot || Sticks || HasExplosives || CanUse(CanUseItem::Dins_Fire));}),
   }, {
-    //Locations
-    ItemLocationPairing(&DekuTree_MQ_MapChest,               []{return true;}),
-    ItemLocationPairing(&DekuTree_MQ_SlingshotChest,         []{return IsAdult || CanChildAttack;}),
-    ItemLocationPairing(&DekuTree_MQ_SlingshotRoomBackChest, []{return HasFireSourceWithTorch || CanUse(CanUseItem::Bow);}),
-    ItemLocationPairing(&DekuTree_MQ_BasementChest,          []{return HasFireSourceWithTorch || CanUse(CanUseItem::Bow);}),
-    ItemLocationPairing(&DekuTree_MQ_GS_Lobby,               []{return IsAdult || CanChildAttack;}),
+                  //Locations
+                  ItemLocationPairing(&DekuTree_MQ_MapChest,               []{return true;}),
+                  ItemLocationPairing(&DekuTree_MQ_SlingshotChest,         []{return IsAdult || CanChildAttack;}),
+                  ItemLocationPairing(&DekuTree_MQ_SlingshotRoomBackChest, []{return HasFireSourceWithTorch || CanUse(CanUseItem::Bow);}),
+                  ItemLocationPairing(&DekuTree_MQ_BasementChest,          []{return HasFireSourceWithTorch || CanUse(CanUseItem::Bow);}),
+                  ItemLocationPairing(&DekuTree_MQ_GS_Lobby,               []{return IsAdult || CanChildAttack;}),
   }, {
-    //Exits
-    ExitPairing(&KF_OutsideDekuTree,            []{return true;}),
-    ExitPairing(&DekuTree_MQ_CompassRoom,       []{return (CanUse(CanUseItem::Slingshot) || CanUse(CanUseItem::Bow)) && (HasFireSourceWithTorch || CanUse(CanUseItem::Bow));}),
-    ExitPairing(&DekuTree_MQ_BasementWaterRoom, []{return (CanUse(CanUseItem::Slingshot) || CanUse(CanUseItem::Bow)) && HasFireSourceWithTorch;}),
-    ExitPairing(&DekuTree_MQ_BasementLedge,     []{return LogicDekuB1Skip || IsAdult;}),
+                  //Exits
+                  ExitPairing(&KF_OutsideDekuTree,            []{return true;}),
+                  ExitPairing(&DekuTree_MQ_CompassRoom,       []{return (CanUse(CanUseItem::Slingshot) || CanUse(CanUseItem::Bow)) && (HasFireSourceWithTorch || CanUse(CanUseItem::Bow));}),
+                  ExitPairing(&DekuTree_MQ_BasementWaterRoom, []{return (CanUse(CanUseItem::Slingshot) || CanUse(CanUseItem::Bow)) && HasFireSourceWithTorch;}),
+                  ExitPairing(&DekuTree_MQ_BasementLedge,     []{return LogicDekuB1Skip || IsAdult;}),
   });
 
   Exit DekuTree_MQ_CompassRoom = Exit("Deku Tree MQ Compass Room", "Deku Tree", "", NO_DAY_NIGHT_CYCLE, {}, {
-    //Locations
-    ItemLocationPairing(&DekuTree_MQ_CompassChest, []{return true;}),
-    ItemLocationPairing(&DekuTree_MQ_GS_CompassRoom, []{return (CanUse(CanUseItem::Hookshot) || CanUse(CanUseItem::Boomerang)) && (HasBombchus || (Bombs && (IsAdult || CanPlay(SongOfTime))));}),
+                  //Locations
+                  ItemLocationPairing(&DekuTree_MQ_CompassChest, []{return true;}),
+                  ItemLocationPairing(&DekuTree_MQ_GS_CompassRoom, []{return (CanUse(CanUseItem::Hookshot) || CanUse(CanUseItem::Boomerang)) && (HasBombchus || (Bombs && (IsAdult || CanPlay(SongOfTime))));}),
   }, {
-    //Exits
-    ExitPairing(&DekuTree_MQ_Lobby, []{return true;}),
+                  //Exits
+                  ExitPairing(&DekuTree_MQ_Lobby, []{return true;}),
   });
 
   Exit DekuTree_MQ_BasementWaterRoom = Exit("Deku Tree MQ Basement Water Room", "Deku Tree", "", NO_DAY_NIGHT_CYCLE, {}, {
-    //Locations
-    ItemLocationPairing(&DekuTree_MQ_BeforeSpinningLogChest, []{return true;}),
-    ItemLocationPairing(&DekuTree_MQ_AfterSpinningLowChest,  []{return true;}),
+                  //Locations
+                  ItemLocationPairing(&DekuTree_MQ_BeforeSpinningLogChest, []{return true;}),
+                  ItemLocationPairing(&DekuTree_MQ_AfterSpinningLowChest,  []{return true;}),
   }, {
-    //Exits
-    ExitPairing(&DekuTree_MQ_BasementBackRoom, []{return true;}),
-    ExitPairing(&DekuTree_MQ_Lobby,            []{return true;}),
+                  //Exits
+                  ExitPairing(&DekuTree_MQ_BasementBackRoom, []{return true;}),
+                  ExitPairing(&DekuTree_MQ_Lobby,            []{return true;}),
   });
 
   Exit DekuTree_MQ_BasementBackRoom = Exit("Deku Tree MQ Basement Back Room", "Deku Tree", "", NO_DAY_NIGHT_CYCLE, {}, {
-    //Locations
-    ItemLocationPairing(&DekuTree_MQ_GS_BasementGravesRoom, []{return CanUse(CanUseItem::Longshot) || (CanPlay(SongOfTime) && HookshotOrBoomerang);}),
-    ItemLocationPairing(&DekuTree_MQ_GS_BasementBackRoom,   []{return HasFireSourceWithTorch && HookshotOrBoomerang;})
+                  //Locations
+                  ItemLocationPairing(&DekuTree_MQ_GS_BasementGravesRoom, []{return CanUse(CanUseItem::Longshot) || (CanPlay(SongOfTime) && HookshotOrBoomerang);}),
+                  ItemLocationPairing(&DekuTree_MQ_GS_BasementBackRoom,   []{return HasFireSourceWithTorch && HookshotOrBoomerang;})
   }, {
-    //Exits
-    ExitPairing(&DekuTree_MQ_BasementLedge,     []{return IsChild;}),
-    ExitPairing(&DekuTree_MQ_BasementWaterRoom, []{return CanUse(CanUseItem::Kokiri_Sword) || CanUseProjectile || (Nuts && CanUse(CanUseItem::Sticks));}),
+                  //Exits
+                  ExitPairing(&DekuTree_MQ_BasementLedge,     []{return IsChild;}),
+                  ExitPairing(&DekuTree_MQ_BasementWaterRoom, []{return CanUse(CanUseItem::Kokiri_Sword) || CanUseProjectile || (Nuts && CanUse(CanUseItem::Sticks));}),
   });
 
   Exit DekuTree_MQ_BasementLedge = Exit("Deku Tree MQ Basement Ledge", "Deku Tree", "", NO_DAY_NIGHT_CYCLE, {
-    //Events
-    EventPairing(&DekuTreeClear, []{return DekuTreeClear || (HasFireSourceWithTorch && HasShield && (IsAdult || KokiriSword || Sticks));}),
+                  //Events
+                  EventPairing(&DekuTreeClear, []{return DekuTreeClear || (HasFireSourceWithTorch && HasShield && (IsAdult || KokiriSword || Sticks));}),
   }, {
-    //Locations
-    ItemLocationPairing(&DekuTree_MQ_DekuScrub,    []{return CanStunDeku;}),
-    ItemLocationPairing(&DekuTree_QueenGohmaHeart, []{return HasFireSourceWithTorch && HasShield && (IsAdult || KokiriSword || Sticks);}),
-    ItemLocationPairing(&QueenGohma,               []{return HasFireSourceWithTorch && HasShield && (IsAdult || KokiriSword || Sticks);}),
+                  //Locations
+                  ItemLocationPairing(&DekuTree_MQ_DekuScrub,    []{return CanStunDeku;}),
+                  ItemLocationPairing(&DekuTree_QueenGohmaHeart, []{return HasFireSourceWithTorch && HasShield && (IsAdult || KokiriSword || Sticks);}),
+                  ItemLocationPairing(&QueenGohma,               []{return HasFireSourceWithTorch && HasShield && (IsAdult || KokiriSword || Sticks);}),
   }, {
-    //Exits
-    ExitPairing(&DekuTree_MQ_BasementBackRoom, []{return IsChild;}),
-    ExitPairing(&DekuTree_MQ_Lobby,            []{return true;}),
+                  //Exits
+                  ExitPairing(&DekuTree_MQ_BasementBackRoom, []{return IsChild;}),
+                  ExitPairing(&DekuTree_MQ_Lobby,            []{return true;}),
   });
 
   Exit DodongosCavern_MQ_Beginning = Exit("Dodongos Cavern MQ Beginning", "Dodongos Cavern", "", NO_DAY_NIGHT_CYCLE, {}, {}, {
-    //Exits
-    ExitPairing::Both(&DodongosCavern_Entryway, []{return true;}),
-    ExitPairing::Both(&DodongosCavern_MQ_Lobby, []{return CanBlastOrSmash || GoronBracelet;})
+                  //Exits
+                  ExitPairing::Both(&DodongosCavern_Entryway, []{return true;}),
+                  ExitPairing::Both(&DodongosCavern_MQ_Lobby, []{return CanBlastOrSmash || GoronBracelet;})
   });
 
   Exit DodongosCavern_MQ_Lobby = Exit("Dodongos Cavern MQ Lobby", "Dodongos Cavern", "", NO_DAY_NIGHT_CYCLE, {
-    //Events
-    EventPairing(&DekuBabaSticks,   []{return DekuBabaSticks || (IsAdult || KokiriSword || Boomerang);}),
-    EventPairing(&GossipStoneFairy, []{return GossipStoneFairy || CanSummonGossipFairy;}),
+                  //Events
+                  EventPairing(&DekuBabaSticks,   []{return DekuBabaSticks || (IsAdult || KokiriSword || Boomerang);}),
+                  EventPairing(&GossipStoneFairy, []{return GossipStoneFairy || CanSummonGossipFairy;}),
   }, {
-    //Locations
-    ItemLocationPairing(&DodongosCavern_MQ_MapChest,               []{return true;}),
-    ItemLocationPairing(&DodongosCavern_MQ_CompassChest,           []{return IsAdult || CanChildAttack || Nuts;}),
-    ItemLocationPairing(&DodongosCavern_MQ_LarvaeRoomChest,        []{return CanUse(CanUseItem::Sticks) || HasFireSource;}),
-    ItemLocationPairing(&DodongosCavern_MQ_TorchPuzzleRoomChest,   []{return CanBlastOrSmash || CanUse(CanUseItem::Sticks) || CanUse(CanUseItem::Dins_Fire) || (IsAdult && (LogicDCJump || HoverBoots || Hookshot));}),
-    ItemLocationPairing(&DodongosCavern_MQ_GS_SongOfTimeBlockRoom, []{return CanPlay(SongOfTime) && (CanChildAttack || IsAdult);}),
-    ItemLocationPairing(&DodongosCavern_MQ_GS_LarvaeRoom,          []{return CanUse(CanUseItem::Sticks) || HasFireSource;}),
-    ItemLocationPairing(&DodongosCavern_MQ_GS_LizalfosRoom,        []{return CanBlastOrSmash;}),
-    ItemLocationPairing(&DodongosCavern_MQ_DekuScrubLobbyRear,     []{return CanStunDeku;}),
-    ItemLocationPairing(&DodongosCavern_MQ_DekuScrubLobbyFront,    []{return CanStunDeku;}),
-    ItemLocationPairing(&DodongosCavern_MQ_DekuScrubStaircase,     []{return CanStunDeku;}),
-    //Dodongos Cavern Gossip Stone
+                  //Locations
+                  ItemLocationPairing(&DodongosCavern_MQ_MapChest,               []{return true;}),
+                  ItemLocationPairing(&DodongosCavern_MQ_CompassChest,           []{return IsAdult || CanChildAttack || Nuts;}),
+                  ItemLocationPairing(&DodongosCavern_MQ_LarvaeRoomChest,        []{return CanUse(CanUseItem::Sticks) || HasFireSource;}),
+                  ItemLocationPairing(&DodongosCavern_MQ_TorchPuzzleRoomChest,   []{return CanBlastOrSmash || CanUse(CanUseItem::Sticks) || CanUse(CanUseItem::Dins_Fire) || (IsAdult && (LogicDCJump || HoverBoots || Hookshot));}),
+                  ItemLocationPairing(&DodongosCavern_MQ_GS_SongOfTimeBlockRoom, []{return CanPlay(SongOfTime) && (CanChildAttack || IsAdult);}),
+                  ItemLocationPairing(&DodongosCavern_MQ_GS_LarvaeRoom,          []{return CanUse(CanUseItem::Sticks) || HasFireSource;}),
+                  ItemLocationPairing(&DodongosCavern_MQ_GS_LizalfosRoom,        []{return CanBlastOrSmash;}),
+                  ItemLocationPairing(&DodongosCavern_MQ_DekuScrubLobbyRear,     []{return CanStunDeku;}),
+                  ItemLocationPairing(&DodongosCavern_MQ_DekuScrubLobbyFront,    []{return CanStunDeku;}),
+                  ItemLocationPairing(&DodongosCavern_MQ_DekuScrubStaircase,     []{return CanStunDeku;}),
+                  //Dodongos Cavern Gossip Stone
   }, {
-    //Exits
-    ExitPairing::Both(&DodongosCavern_MQ_LowerRightSide,  []{return CanBlastOrSmash || ((CanUse(CanUseItem::Sticks) || CanUse(CanUseItem::Dins_Fire)) && DamageMultiplier.IsNot(DAMAGEMULTIPLIER_OHKO));}),
-    ExitPairing::Both(&DodongosCavern_MQ_BombBagArea,     []{return IsAdult || HasExplosives;}),
-      //Trick: IsAdult || HasExplosives || (LogicDCMQChildBombs && (KokiriSword || Sticks) && DamageMultiplier.IsNot(DAMAGEMULTIPLIER_OHKO))
-    ExitPairing::Both(&DodongosCavern_MQ_BossArea,        []{return HasExplosives;}),
-      //Trick: HasExplosives || (LogicDCMQEyes && GoronBracelet && (IsAdult || LogicDCMQChildBack) && (CanUse(CanUseItem::Sticks) || CanUse(CanUseItem::Dins_Fire) || (IsAdult && (LogicDCJump || Hammer || HoverBoots || Hookshot))))
+                  //Exits
+                  ExitPairing::Both(&DodongosCavern_MQ_LowerRightSide,  []{return CanBlastOrSmash || ((CanUse(CanUseItem::Sticks) || CanUse(CanUseItem::Dins_Fire)) && DamageMultiplier.IsNot(DAMAGEMULTIPLIER_OHKO));}),
+                  ExitPairing::Both(&DodongosCavern_MQ_BombBagArea,     []{return IsAdult || HasExplosives;}),
+                    //Trick: IsAdult || HasExplosives || (LogicDCMQChildBombs && (KokiriSword || Sticks) && DamageMultiplier.IsNot(DAMAGEMULTIPLIER_OHKO))
+                  ExitPairing::Both(&DodongosCavern_MQ_BossArea,        []{return HasExplosives;}),
+                    //Trick: HasExplosives || (LogicDCMQEyes && GoronBracelet && (IsAdult || LogicDCMQChildBack) && (CanUse(CanUseItem::Sticks) || CanUse(CanUseItem::Dins_Fire) || (IsAdult && (LogicDCJump || Hammer || HoverBoots || Hookshot))))
   });
 
   Exit DodongosCavern_MQ_LowerRightSide = Exit("Dodongos Cavern MQ Lower Right Side", "Dodongos Cavern", "", NO_DAY_NIGHT_CYCLE, {}, {
-    //Locations
-    ItemLocationPairing(&DodongosCavern_MQ_DekuScrubSideRoomNearLowerLizalfos, []{return CanStunDeku;}),
+                  //Locations
+                  ItemLocationPairing(&DodongosCavern_MQ_DekuScrubSideRoomNearLowerLizalfos, []{return CanStunDeku;}),
   }, {
-    //Exits
-    ExitPairing::Both(&DodongosCavern_MQ_BombBagArea, []{return (CanUse(CanUseItem::Bow) || GoronBracelet || CanUse(CanUseItem::Dins_Fire) || HasExplosives) && CanUse(CanUseItem::Slingshot);}),
+                  //Exits
+                  ExitPairing::Both(&DodongosCavern_MQ_BombBagArea, []{return (CanUse(CanUseItem::Bow) || GoronBracelet || CanUse(CanUseItem::Dins_Fire) || HasExplosives) && CanUse(CanUseItem::Slingshot);}),
   });
 
   Exit DodongosCavern_MQ_BombBagArea = Exit("Dodongos Cavern MQ Bomb Bag Area", "Dodongos Cavern", "", NO_DAY_NIGHT_CYCLE, {}, {
-    //Locations
-    ItemLocationPairing(&DodongosCavern_MQ_BombBagChest, []{return true;}),
-    ItemLocationPairing(&DodongosCavern_MQ_GS_ScrubRoom, []{return (CanUse(CanUseItem::Bow) ||  GoronBracelet || CanUse(CanUseItem::Dins_Fire) || HasExplosives) && (CanUse(CanUseItem::Hookshot) || CanUse(CanUseItem::Boomerang));}),
+                  //Locations
+                  ItemLocationPairing(&DodongosCavern_MQ_BombBagChest, []{return true;}),
+                  ItemLocationPairing(&DodongosCavern_MQ_GS_ScrubRoom, []{return (CanUse(CanUseItem::Bow) ||  GoronBracelet || CanUse(CanUseItem::Dins_Fire) || HasExplosives) && (CanUse(CanUseItem::Hookshot) || CanUse(CanUseItem::Boomerang));}),
   }, {
-    //Exits
-    ExitPairing::Both(&DodongosCavern_MQ_LowerRightSide, []{return true;}),
+                  //Exits
+                  ExitPairing::Both(&DodongosCavern_MQ_LowerRightSide, []{return true;}),
   });
 
   Exit DodongosCavern_MQ_BossArea = Exit("Dodongos Cavern MQ BossArea", "Dodongos Cavern", "", NO_DAY_NIGHT_CYCLE, {
-    //Events
-    EventPairing(&FairyPot,            []{return true;}),
-    EventPairing(&DodongosCavernClear, []{return DodongosCavernClear || (CanBlastOrSmash && (Bombs || GoronBracelet) && (IsAdult || Sticks || KokiriSword));}),
+                  //Events
+                  EventPairing(&FairyPot,            []{return true;}),
+                  EventPairing(&DodongosCavernClear, []{return DodongosCavernClear || (CanBlastOrSmash && (Bombs || GoronBracelet) && (IsAdult || Sticks || KokiriSword));}),
   }, {
-    //Locations
-    ItemLocationPairing(&DodongosCavern_MQ_UnderGraveChest, []{return true;}),
-    ItemLocationPairing(&DodongosCavern_BossRoomChest,      []{return true;}),
-    ItemLocationPairing(&DodongosCavern_KingDodongoHeart,   []{return CanBlastOrSmash && (Bombs || GoronBracelet) && (IsAdult || Sticks || KokiriSword);}),
-    ItemLocationPairing(&KingDodongo,                       []{return CanBlastOrSmash && (Bombs || GoronBracelet) && (IsAdult || Sticks || KokiriSword);}),
-    ItemLocationPairing(&DodongosCavern_MQ_GS_BackRoom,     []{return true;}),
+                  //Locations
+                  ItemLocationPairing(&DodongosCavern_MQ_UnderGraveChest, []{return true;}),
+                  ItemLocationPairing(&DodongosCavern_BossRoomChest,      []{return true;}),
+                  ItemLocationPairing(&DodongosCavern_KingDodongoHeart,   []{return CanBlastOrSmash && (Bombs || GoronBracelet) && (IsAdult || Sticks || KokiriSword);}),
+                  ItemLocationPairing(&KingDodongo,                       []{return CanBlastOrSmash && (Bombs || GoronBracelet) && (IsAdult || Sticks || KokiriSword);}),
+                  ItemLocationPairing(&DodongosCavern_MQ_GS_BackRoom,     []{return true;}),
   }, {});
 
   Exit JabuJabusBelly_MQ_Beginning = Exit("Jabu Jabus Belly MQ Beginning", "Jabu Jabus Belly", "", NO_DAY_NIGHT_CYCLE, {
-    //Events
-    EventPairing(&NutPot, []{return true;}),
+                  //Events
+                  EventPairing(&NutPot, []{return true;}),
   }, {
-    //Locations
-    ItemLocationPairing(&JabuJabusBelly_MQ_MapChest,           []{return CanBlastOrSmash;}),
-    ItemLocationPairing(&JabuJabusBelly_MQ_FirstRoomSideChest, []{return CanUse(CanUseItem::Slingshot);}),
+                  //Locations
+                  ItemLocationPairing(&JabuJabusBelly_MQ_MapChest,           []{return CanBlastOrSmash;}),
+                  ItemLocationPairing(&JabuJabusBelly_MQ_FirstRoomSideChest, []{return CanUse(CanUseItem::Slingshot);}),
   }, {
-    //Exits
-    ExitPairing::Both(&ZF_Main,                []{return true;}),
-    ExitPairing::Both(&JabuJabusBelly_MQ_Main, []{return IsChild && CanUse(CanUseItem::Slingshot);}),
+                  //Exits
+                  ExitPairing::Both(&ZF_Main,                []{return true;}),
+                  ExitPairing::Both(&JabuJabusBelly_MQ_Main, []{return IsChild && CanUse(CanUseItem::Slingshot);}),
   });
 
   Exit JabuJabusBelly_MQ_Main = Exit("Jabu Jabus Belly MQ Main", "Jabu Jabus Belly", "", NO_DAY_NIGHT_CYCLE, {}, {
-    //Locations
-    ItemLocationPairing(&JabuJabusBelly_MQ_SecondRoomLowerChest,      []{return true;}),
-    ItemLocationPairing(&JabuJabusBelly_MQ_SecondRoomUpperChest,      []{return CanUse(CanUseItem::Hover_Boots) || CanUse(CanUseItem::Hookshot) || JabuJabusBelly_MQ_BossArea.Child();}),
-    ItemLocationPairing(&JabuJabusBelly_MQ_CompassChest,              []{return true;}),
-    ItemLocationPairing(&JabuJabusBelly_MQ_BasementNearVinesChest,    []{return true;}),
-    ItemLocationPairing(&JabuJabusBelly_MQ_BasementNearSwitchesChest, []{return true;}),
-    ItemLocationPairing(&JabuJabusBelly_MQ_BoomerangRoomSmallChest,   []{return true;}),
-    ItemLocationPairing(&JabuJabusBelly_MQ_BoomerangChest,            []{return true;}),
-    ItemLocationPairing(&JabuJabusBelly_MQ_GS_BoomerangChestRoom,     []{return CanPlay(SongOfTime);}),
-      //Trick: CanPlay(SongOfTime) || (LogicJabuMQSoTGS && CanUse(CanUseItem::Boomerang))
+                  //Locations
+                  ItemLocationPairing(&JabuJabusBelly_MQ_SecondRoomLowerChest,      []{return true;}),
+                  ItemLocationPairing(&JabuJabusBelly_MQ_SecondRoomUpperChest,      []{return CanUse(CanUseItem::Hover_Boots) || CanUse(CanUseItem::Hookshot) || JabuJabusBelly_MQ_BossArea.Child();}),
+                  ItemLocationPairing(&JabuJabusBelly_MQ_CompassChest,              []{return true;}),
+                  ItemLocationPairing(&JabuJabusBelly_MQ_BasementNearVinesChest,    []{return true;}),
+                  ItemLocationPairing(&JabuJabusBelly_MQ_BasementNearSwitchesChest, []{return true;}),
+                  ItemLocationPairing(&JabuJabusBelly_MQ_BoomerangRoomSmallChest,   []{return true;}),
+                  ItemLocationPairing(&JabuJabusBelly_MQ_BoomerangChest,            []{return true;}),
+                  ItemLocationPairing(&JabuJabusBelly_MQ_GS_BoomerangChestRoom,     []{return CanPlay(SongOfTime);}),
+                    //Trick: CanPlay(SongOfTime) || (LogicJabuMQSoTGS && CanUse(CanUseItem::Boomerang))
   }, {
-    //Exits
-    ExitPairing::Both(&JabuJabusBelly_MQ_Beginning, []{return true;}),
-    ExitPairing::Both(&JabuJabusBelly_MQ_Depths,    []{return HasExplosives && CanUse(CanUseItem::Boomerang);}),
+                  //Exits
+                  ExitPairing::Both(&JabuJabusBelly_MQ_Beginning, []{return true;}),
+                  ExitPairing::Both(&JabuJabusBelly_MQ_Depths,    []{return HasExplosives && CanUse(CanUseItem::Boomerang);}),
   });
 
   Exit JabuJabusBelly_MQ_Depths = Exit("Jabu Jabus Belly MQ Depths", "Jabu Jabus Belly", "", NO_DAY_NIGHT_CYCLE, {}, {
-    //Locations
-    ItemLocationPairing(&JabuJabusBelly_MQ_FallingLikeLikeRoomChest, []{return true;}),
-    ItemLocationPairing(&JabuJabusBelly_MQ_GS_TailPasaranRoom,       []{return Sticks || CanUse(CanUseItem::Dins_Fire);}),
-    ItemLocationPairing(&JabuJabusBelly_MQ_GS_InvisibleEnemiesRoom,  []{return (LogicLensJabuMQ || CanUse(CanUseItem::Lens_of_Truth)) || (JabuJabusBelly_MQ_Main.Adult() && CanUse(CanUseItem::Hover_Boots) && CanUse(CanUseItem::Hookshot));}),
+                  //Locations
+                  ItemLocationPairing(&JabuJabusBelly_MQ_FallingLikeLikeRoomChest, []{return true;}),
+                  ItemLocationPairing(&JabuJabusBelly_MQ_GS_TailPasaranRoom,       []{return Sticks || CanUse(CanUseItem::Dins_Fire);}),
+                  ItemLocationPairing(&JabuJabusBelly_MQ_GS_InvisibleEnemiesRoom,  []{return (LogicLensJabuMQ || CanUse(CanUseItem::Lens_of_Truth)) || (JabuJabusBelly_MQ_Main.Adult() && CanUse(CanUseItem::Hover_Boots) && CanUse(CanUseItem::Hookshot));}),
   }, {
-    //Exits
-    ExitPairing::Both(&JabuJabusBelly_MQ_Main,     []{return true;}),
-    ExitPairing::Both(&JabuJabusBelly_MQ_BossArea, []{return Sticks || (CanUse(CanUseItem::Dins_Fire) && KokiriSword);}),
+                  //Exits
+                  ExitPairing::Both(&JabuJabusBelly_MQ_Main,     []{return true;}),
+                  ExitPairing::Both(&JabuJabusBelly_MQ_BossArea, []{return Sticks || (CanUse(CanUseItem::Dins_Fire) && KokiriSword);}),
   });
 
   Exit JabuJabusBelly_MQ_BossArea = Exit("Jabu Jabus Belly MQ Boss Area", "Jabu Jabus Belly", "", NO_DAY_NIGHT_CYCLE, {
-    //Events
-    EventPairing(&FairyPot,            []{return true;}),
-    EventPairing(&JabuJabusBellyClear, []{return true;}),
+                  //Events
+                  EventPairing(&FairyPot,            []{return true;}),
+                  EventPairing(&JabuJabusBellyClear, []{return true;}),
   }, {
-    //Locations
-    ItemLocationPairing(&JabuJabusBelly_MQ_Cow,           []{return CanPlay(EponasSong);}),
-    ItemLocationPairing(&JabuJabusBelly_MQ_NearBossChest, []{return true;}),
-    ItemLocationPairing(&JabuJabusBelly_BarinadeHeart,    []{return true;}),
-    ItemLocationPairing(&Barinade,                        []{return true;}),
-    ItemLocationPairing(&JabuJabusBelly_MQ_GS_NearBoss,   []{return true;}),
+                  //Locations
+                  ItemLocationPairing(&JabuJabusBelly_MQ_Cow,           []{return CanPlay(EponasSong);}),
+                  ItemLocationPairing(&JabuJabusBelly_MQ_NearBossChest, []{return true;}),
+                  ItemLocationPairing(&JabuJabusBelly_BarinadeHeart,    []{return true;}),
+                  ItemLocationPairing(&Barinade,                        []{return true;}),
+                  ItemLocationPairing(&JabuJabusBelly_MQ_GS_NearBoss,   []{return true;}),
   }, {
-    //Exits
-    ExitPairing::Both(&JabuJabusBelly_MQ_Main, []{return true;}),
+                  //Exits
+                  ExitPairing::Both(&JabuJabusBelly_MQ_Main, []{return true;}),
   });
 
   Exit ForestTemple_MQ_Lobby = Exit("Forest Temple MQ Lobby", "Forest Temple", "", NO_DAY_NIGHT_CYCLE, {}, {
-    //Locations
-    ItemLocationPairing(&ForestTemple_MQ_FirstRoomChest,  []{return IsAdult || Bombs || CanUse(CanUseItem::Sticks) || Nuts || CanUse(CanUseItem::Boomerang) || CanUse(CanUseItem::Dins_Fire) || KokiriSword || CanUse(CanUseItem::Slingshot);}),
-    ItemLocationPairing(&ForestTemple_MQ_GS_FirstHallway, []{return CanUse(CanUseItem::Hookshot) || CanUse(CanUseItem::Boomerang);}),
+                  //Locations
+                  ItemLocationPairing(&ForestTemple_MQ_FirstRoomChest,  []{return IsAdult || Bombs || CanUse(CanUseItem::Sticks) || Nuts || CanUse(CanUseItem::Boomerang) || CanUse(CanUseItem::Dins_Fire) || KokiriSword || CanUse(CanUseItem::Slingshot);}),
+                  ItemLocationPairing(&ForestTemple_MQ_GS_FirstHallway, []{return CanUse(CanUseItem::Hookshot) || CanUse(CanUseItem::Boomerang);}),
   }, {
-    //Exits
-    ExitPairing::Both(&SFM_Main,                    []{return true;}),
-    ExitPairing::Both(&ForestTemple_MQ_CentralArea, []{return SmallKeys(ForestTempleKeys, 1) && (IsAdult || CanChildAttack || Nuts);}),
+                  //Exits
+                  ExitPairing::Both(&SFM_Main,                    []{return true;}),
+                  ExitPairing::Both(&ForestTemple_MQ_CentralArea, []{return SmallKeys(ForestTempleKeys, 1) && (IsAdult || CanChildAttack || Nuts);}),
   });
 
   Exit ForestTemple_MQ_CentralArea = Exit("Forest Temple MQ Central Area", "Forest Temple", "", NO_DAY_NIGHT_CYCLE, {
-    //Events
-    EventPairing(&FairyPot, []{return true;}),
+                  //Events
+                  EventPairing(&FairyPot, []{return true;}),
   }, {
-    //Locations
-    ItemLocationPairing(&ForestTemple_MQ_WolfosChest,      []{return (CanPlay(SongOfTime) || IsChild) && (IsAdult || CanUse(CanUseItem::Dins_Fire) || CanUse(CanUseItem::Sticks) || CanUse(CanUseItem::Slingshot) || KokiriSword);}),
-    ItemLocationPairing(&ForestTemple_MQ_GS_BlockPushRoom, []{return IsAdult || KokiriSword;}),
+                  //Locations
+                  ItemLocationPairing(&ForestTemple_MQ_WolfosChest,      []{return (CanPlay(SongOfTime) || IsChild) && (IsAdult || CanUse(CanUseItem::Dins_Fire) || CanUse(CanUseItem::Sticks) || CanUse(CanUseItem::Slingshot) || KokiriSword);}),
+                  ItemLocationPairing(&ForestTemple_MQ_GS_BlockPushRoom, []{return IsAdult || KokiriSword;}),
   }, {
-    //Exits
-    ExitPairing::Both(&ForestTemple_MQ_NWOutdoors,       []{return CanUse(CanUseItem::Bow) || CanUse(CanUseItem::Slingshot);}),
-    ExitPairing::Both(&ForestTemple_MQ_NEOutdoors,       []{return CanUse(CanUseItem::Bow) || CanUse(CanUseItem::Slingshot);}), //This is as far as child can get
-    ExitPairing::Both(&ForestTemple_MQ_AfterBlockPuzzle, []{return IsAdult && GoronBracelet;}),
-      //Trick: IsAdult && (GoronBracelet || (LogicForestMQBlockPuzzle && HasBombchus && CanUse(CanUseItem::Hookshot)))
-    ExitPairing::Both(&ForestTemple_MQ_OutdoorLedge,     []{return false;}),
-      //Trick: (LogicForestMQHallwaySwitchJumpslash && CanUse(CanUseItem::Hover_Boots)) || (LogicForestMQHallwaySwitchHookshot && CanUse(CanUseItem::Hookshot))
-    ExitPairing::Both(&ForestTemple_MQ_BossRegion,       []{return ForestTempleJoAndBeth && ForestTempleAmyAndMeg;}),
+                  //Exits
+                  ExitPairing::Both(&ForestTemple_MQ_NWOutdoors,       []{return CanUse(CanUseItem::Bow) || CanUse(CanUseItem::Slingshot);}),
+                  ExitPairing::Both(&ForestTemple_MQ_NEOutdoors,       []{return CanUse(CanUseItem::Bow) || CanUse(CanUseItem::Slingshot);}), //This is as far as child can get
+                  ExitPairing::Both(&ForestTemple_MQ_AfterBlockPuzzle, []{return IsAdult && GoronBracelet;}),
+                    //Trick: IsAdult && (GoronBracelet || (LogicForestMQBlockPuzzle && HasBombchus && CanUse(CanUseItem::Hookshot)))
+                  ExitPairing::Both(&ForestTemple_MQ_OutdoorLedge,     []{return false;}),
+                    //Trick: (LogicForestMQHallwaySwitchJumpslash && CanUse(CanUseItem::Hover_Boots)) || (LogicForestMQHallwaySwitchHookshot && CanUse(CanUseItem::Hookshot))
+                  ExitPairing::Both(&ForestTemple_MQ_BossRegion,       []{return ForestTempleJoAndBeth && ForestTempleAmyAndMeg;}),
   });
 
   Exit ForestTemple_MQ_AfterBlockPuzzle = Exit("Forest Temple MQ After Block Puzzle", "Forest Temple", "", NO_DAY_NIGHT_CYCLE, {}, {
-    //Locations
-    ItemLocationPairing(&ForestTemple_MQ_BossKeyChest, []{return SmallKeys(ForestTempleKeys, 3);}),
+                  //Locations
+                  ItemLocationPairing(&ForestTemple_MQ_BossKeyChest, []{return SmallKeys(ForestTempleKeys, 3);}),
   }, {
-    //Exits
-    ExitPairing::Both(&ForestTemple_MQ_BowRegion,    []{return SmallKeys(ForestTempleKeys, 4);}),
-    ExitPairing::Both(&ForestTemple_MQ_OutdoorLedge, []{return SmallKeys(ForestTempleKeys, 3);}),
-      //Trick: SmallKeys(ForestTempleKeys, 3) || (LogicForestMQHallwaySwitchJumpslash && (CanUse(CanUseItem::Hookshot) || LogicForestOutsideBackdoor))
-    ExitPairing::Both(&ForestTemple_MQ_NWOutdoors,   []{return SmallKeys(ForestTempleKeys, 2);}),
+                  //Exits
+                  ExitPairing::Both(&ForestTemple_MQ_BowRegion,    []{return SmallKeys(ForestTempleKeys, 4);}),
+                  ExitPairing::Both(&ForestTemple_MQ_OutdoorLedge, []{return SmallKeys(ForestTempleKeys, 3);}),
+                    //Trick: SmallKeys(ForestTempleKeys, 3) || (LogicForestMQHallwaySwitchJumpslash && (CanUse(CanUseItem::Hookshot) || LogicForestOutsideBackdoor))
+                  ExitPairing::Both(&ForestTemple_MQ_NWOutdoors,   []{return SmallKeys(ForestTempleKeys, 2);}),
   });
 
   Exit ForestTemple_MQ_OutdoorLedge = Exit("Forest Temple MQ Outdoor Ledge", "Forest Temple", "", NO_DAY_NIGHT_CYCLE, {}, {
-    //Locations
-    ItemLocationPairing(&ForestTemple_MQ_RedeadChest, []{return true;}),
+                  //Locations
+                  ItemLocationPairing(&ForestTemple_MQ_RedeadChest, []{return true;}),
   }, {
-    //Exits
-    ExitPairing::Both(&ForestTemple_MQ_NWOutdoors, []{return true;}),
+                  //Exits
+                  ExitPairing::Both(&ForestTemple_MQ_NWOutdoors, []{return true;}),
   });
 
   Exit ForestTemple_MQ_NWOutdoors = Exit("Forest Temple MQ NW Outdoors", "Forest Temple", "", NO_DAY_NIGHT_CYCLE, {}, {
-    //Locations
-    ItemLocationPairing(&ForestTemple_MQ_GS_LevelIslandCourtyard, []{return true;}),
+                  //Locations
+                  ItemLocationPairing(&ForestTemple_MQ_GS_LevelIslandCourtyard, []{return true;}),
   }, {
-    //Exits
-    ExitPairing::Both(&ForestTemple_MQ_NEOutdoors,        []{return CanUse(CanUseItem::Iron_Boots) || CanUse(CanUseItem::Longshot) || ProgressiveScale >= 2;}),
-      //Trick: CanUse(CanUseItem::Iron_Boots) || CanUse(CanUseItem::Longshot) || ProgressiveScale >= 2 || (LogicForestMQWellSwim && CanUse(CanUseItem::Hookshot))
-    ExitPairing::Both(&ForestTemple_MQ_OutdoorsTopLedges, []{return CanUse(CanUseItem::Fire_Arrows);}),
+                  //Exits
+                  ExitPairing::Both(&ForestTemple_MQ_NEOutdoors,        []{return CanUse(CanUseItem::Iron_Boots) || CanUse(CanUseItem::Longshot) || ProgressiveScale >= 2;}),
+                    //Trick: CanUse(CanUseItem::Iron_Boots) || CanUse(CanUseItem::Longshot) || ProgressiveScale >= 2 || (LogicForestMQWellSwim && CanUse(CanUseItem::Hookshot))
+                  ExitPairing::Both(&ForestTemple_MQ_OutdoorsTopLedges, []{return CanUse(CanUseItem::Fire_Arrows);}),
   });
 
   Exit ForestTemple_MQ_NEOutdoors = Exit("Forest Temple MQ NE Outdoors", "Forest Temple", "", NO_DAY_NIGHT_CYCLE, {
-    //Events
-    EventPairing(&DekuBabaSticks, []{return DekuBabaSticks || (IsAdult || KokiriSword || Boomerang);}),
-    EventPairing(&DekuBabaNuts,   []{return DekuBabaNuts   || (IsAdult || KokiriSword || Slingshot || Sticks || HasExplosives || CanUse(CanUseItem::Dins_Fire));}),
+                  //Events
+                  EventPairing(&DekuBabaSticks, []{return DekuBabaSticks || (IsAdult || KokiriSword || Boomerang);}),
+                  EventPairing(&DekuBabaNuts,   []{return DekuBabaNuts   || (IsAdult || KokiriSword || Slingshot || Sticks || HasExplosives || CanUse(CanUseItem::Dins_Fire));}),
   }, {
-    //Locations
-    ItemLocationPairing(&ForestTemple_MQ_WellChest,                []{return CanUse(CanUseItem::Bow) || CanUse(CanUseItem::Slingshot);}),
-    ItemLocationPairing(&ForestTemple_MQ_GS_RaisedIslandCourtyard, []{return CanUse(CanUseItem::Hookshot) || CanUse(CanUseItem::Boomerang) || (CanUse(CanUseItem::Fire_Arrows) && (CanPlay(SongOfTime) || (CanUse(CanUseItem::Hover_Boots) && LogicForestDoorFrame)));}),
-    ItemLocationPairing(&ForestTemple_MQ_GS_Well,                  []{return (CanUse(CanUseItem::Iron_Boots) && CanUse(CanUseItem::Hookshot)) || CanUse(CanUseItem::Bow) || CanUse(CanUseItem::Slingshot);}),
+                  //Locations
+                  ItemLocationPairing(&ForestTemple_MQ_WellChest,                []{return CanUse(CanUseItem::Bow) || CanUse(CanUseItem::Slingshot);}),
+                  ItemLocationPairing(&ForestTemple_MQ_GS_RaisedIslandCourtyard, []{return CanUse(CanUseItem::Hookshot) || CanUse(CanUseItem::Boomerang) || (CanUse(CanUseItem::Fire_Arrows) && (CanPlay(SongOfTime) || (CanUse(CanUseItem::Hover_Boots) && LogicForestDoorFrame)));}),
+                  ItemLocationPairing(&ForestTemple_MQ_GS_Well,                  []{return (CanUse(CanUseItem::Iron_Boots) && CanUse(CanUseItem::Hookshot)) || CanUse(CanUseItem::Bow) || CanUse(CanUseItem::Slingshot);}),
   }, {
-    //Exits
-    ExitPairing::Both(&ForestTemple_MQ_OutdoorsTopLedges, []{return CanUse(CanUseItem::Hookshot) && (CanUse(CanUseItem::Longshot) || CanUse(CanUseItem::Hover_Boots) || CanPlay(SongOfTime));}),
-    ExitPairing::Both(&ForestTemple_MQ_NEOutdoorsLedge,   []{return CanUse(CanUseItem::Longshot);}),
+                  //Exits
+                  ExitPairing::Both(&ForestTemple_MQ_OutdoorsTopLedges, []{return CanUse(CanUseItem::Hookshot) && (CanUse(CanUseItem::Longshot) || CanUse(CanUseItem::Hover_Boots) || CanPlay(SongOfTime));}),
+                  ExitPairing::Both(&ForestTemple_MQ_NEOutdoorsLedge,   []{return CanUse(CanUseItem::Longshot);}),
   });
 
   Exit ForestTemple_MQ_OutdoorsTopLedges = Exit("Forest Temple MQ Outdoors Top Ledges", "Forest Temple", "", NO_DAY_NIGHT_CYCLE, {}, {
-    //Locations
-    ItemLocationPairing(&ForestTemple_MQ_RaisedIslandCourtyardUpperChest, []{return true;}),
+                  //Locations
+                  ItemLocationPairing(&ForestTemple_MQ_RaisedIslandCourtyardUpperChest, []{return true;}),
   }, {
-    //Exits
-    ExitPairing::Both(&ForestTemple_MQ_NEOutdoors,      []{return true;}),
-    ExitPairing::Both(&ForestTemple_MQ_NEOutdoorsLedge, []{return false;}),
-      //Trick: LogicForestOutdoorsLedge && CanUse(CanUseItem::Hover_Boots)
+                  //Exits
+                  ExitPairing::Both(&ForestTemple_MQ_NEOutdoors,      []{return true;}),
+                  ExitPairing::Both(&ForestTemple_MQ_NEOutdoorsLedge, []{return false;}),
+                    //Trick: LogicForestOutdoorsLedge && CanUse(CanUseItem::Hover_Boots)
   });
 
   Exit ForestTemple_MQ_NEOutdoorsLedge = Exit("Forest Temple MQ NE Outdoors Ledge", "Forest Temple", "", NO_DAY_NIGHT_CYCLE, {}, {
-    //Locations
-    ItemLocationPairing(&ForestTemple_MQ_RaisedIslandCourtyardLowerChest, []{return true;}),
+                  //Locations
+                  ItemLocationPairing(&ForestTemple_MQ_RaisedIslandCourtyardLowerChest, []{return true;}),
   }, {
-    //Exits
-    ExitPairing::Both(&ForestTemple_MQ_NEOutdoors,  []{return true;}),
-    ExitPairing::Both(&ForestTemple_MQ_FallingRoom, []{return CanPlay(SongOfTime);}),
+                  //Exits
+                  ExitPairing::Both(&ForestTemple_MQ_NEOutdoors,  []{return true;}),
+                  ExitPairing::Both(&ForestTemple_MQ_FallingRoom, []{return CanPlay(SongOfTime);}),
   });
 
   Exit ForestTemple_MQ_BowRegion = Exit("Forest Temple MQ Bow Region", "Forest Temple", "", NO_DAY_NIGHT_CYCLE, {
-    //Events
-    EventPairing(&ForestTempleJoAndBeth, []{return ForestTempleJoAndBeth || CanUse(CanUseItem::Bow);}),
+                  //Events
+                  EventPairing(&ForestTempleJoAndBeth, []{return ForestTempleJoAndBeth || CanUse(CanUseItem::Bow);}),
   }, {
-    //Locations
-    ItemLocationPairing(&ForestTemple_MQ_BowChest,     []{return true;}),
-    ItemLocationPairing(&ForestTemple_MQ_MapChest,     []{return CanUse(CanUseItem::Bow);}),
-    ItemLocationPairing(&ForestTemple_MQ_CompassChest, []{return CanUse(CanUseItem::Bow);}),
+                  //Locations
+                  ItemLocationPairing(&ForestTemple_MQ_BowChest,     []{return true;}),
+                  ItemLocationPairing(&ForestTemple_MQ_MapChest,     []{return CanUse(CanUseItem::Bow);}),
+                  ItemLocationPairing(&ForestTemple_MQ_CompassChest, []{return CanUse(CanUseItem::Bow);}),
   }, {
-    //Exits
-    ExitPairing::Both(&ForestTemple_MQ_FallingRoom, []{return SmallKeys(ForestTempleKeys, 5) && (CanUse(CanUseItem::Bow) || CanUse(CanUseItem::Dins_Fire));}),
+                  //Exits
+                  ExitPairing::Both(&ForestTemple_MQ_FallingRoom, []{return SmallKeys(ForestTempleKeys, 5) && (CanUse(CanUseItem::Bow) || CanUse(CanUseItem::Dins_Fire));}),
   });
 
   Exit ForestTemple_MQ_FallingRoom = Exit("Forest Temple MQ Falling Room", "Forest Temple", "", NO_DAY_NIGHT_CYCLE, {
-    //Events
-    EventPairing(&ForestTempleAmyAndMeg, []{return ForestTempleAmyAndMeg || (CanUse(CanUseItem::Bow) && SmallKeys(ForestTempleKeys, 6));}),
+                  //Events
+                  EventPairing(&ForestTempleAmyAndMeg, []{return ForestTempleAmyAndMeg || (CanUse(CanUseItem::Bow) && SmallKeys(ForestTempleKeys, 6));}),
   }, {
-    //Locations
-    ItemLocationPairing(&ForestTemple_MQ_FallingCeilingRoomChest, []{return true;}),
+                  //Locations
+                  ItemLocationPairing(&ForestTemple_MQ_FallingCeilingRoomChest, []{return true;}),
   }, {
-    //Exits
-    ExitPairing::Both(&ForestTemple_MQ_NEOutdoorsLedge, []{return true;}),
+                  //Exits
+                  ExitPairing::Both(&ForestTemple_MQ_NEOutdoorsLedge, []{return true;}),
   });
 
   Exit ForestTemple_MQ_BossRegion = Exit("Forest Temple MQ Boss Region", "Forest Temple", "", NO_DAY_NIGHT_CYCLE, {
-    //Events
-    EventPairing(&ForestTempleClear, []{return ForestTempleClear || BossKeyForestTemple;}),
+                  //Events
+                  EventPairing(&ForestTempleClear, []{return ForestTempleClear || BossKeyForestTemple;}),
   }, {
-    //Locations
-    ItemLocationPairing(&ForestTemple_MQ_BasementChest,  []{return true;}),
-    ItemLocationPairing(&ForestTemple_PhantomGanonHeart, []{return BossKeyForestTemple;}),
-    ItemLocationPairing(&PhantomGanon,                   []{return BossKeyForestTemple;}),
+                  //Locations
+                  ItemLocationPairing(&ForestTemple_MQ_BasementChest,  []{return true;}),
+                  ItemLocationPairing(&ForestTemple_PhantomGanonHeart, []{return BossKeyForestTemple;}),
+                  ItemLocationPairing(&PhantomGanon,                   []{return BossKeyForestTemple;}),
   }, {});
 
   Exit FireTemple_MQ_Lower = Exit("Fire Temple MQ Lower", "Fire Temple", "", NO_DAY_NIGHT_CYCLE, {}, {
-    //Locations
-    ItemLocationPairing(&FireTemple_MQ_MapRoomSideChest, []{return IsAdult || KokiriSword || Sticks || Slingshot || Bombs || CanUse(CanUseItem::Dins_Fire);}),
-    ItemLocationPairing(&FireTemple_MQ_NearBossChest,    []{return (LogicFewerTunicRequirements || CanUse(CanUseItem::Goron_Tunic)) && (CanUse(CanUseItem::Hover_Boots) || (CanUse(CanUseItem::Hookshot) && (CanUse(CanUseItem::Fire_Arrows) || (CanUse(CanUseItem::Dins_Fire) && ((DamageMultiplier.IsNot(DAMAGEMULTIPLIER_OHKO) && DamageMultiplier.IsNot(DAMAGEMULTIPLIER_QUADRUPLE)) || CanUse(CanUseItem::Goron_Tunic) || CanUse(CanUseItem::Bow) || CanUse(CanUseItem::Longshot))))));}),
-      //Trick: (LogicFewerTunicRequirements || CanUse(CanUseItem::Goron_Tunic)) && (((CanUse(CanUseItem::Hover_Boots) || (LogicFireMQNearBoss && CanUse(CanUseItem::Bow))) && HasFireSource) || (CanUse(CanUseItem::Hookshot) && CanUse(CanUseItem::Fire_Arrows) || (CanUse(CanUseItem::Dins_Fire) && ((DamageMultiplier.IsNot(DAMAGEMULTIPLIER_OHKO) && DamageMultiplier.IsNot(DAMAGEMULTIPLIER_QUADRUPLE)) || CanUse(CanUseItem::Goron_Tunic) || CanUse(CanUseItem::Bow) || CanUse(CanUseItem::Longshot)))))
+                  //Locations
+                  ItemLocationPairing(&FireTemple_MQ_MapRoomSideChest, []{return IsAdult || KokiriSword || Sticks || Slingshot || Bombs || CanUse(CanUseItem::Dins_Fire);}),
+                  ItemLocationPairing(&FireTemple_MQ_NearBossChest,    []{return (LogicFewerTunicRequirements || CanUse(CanUseItem::Goron_Tunic)) && (CanUse(CanUseItem::Hover_Boots) || (CanUse(CanUseItem::Hookshot) && (CanUse(CanUseItem::Fire_Arrows) || (CanUse(CanUseItem::Dins_Fire) && ((DamageMultiplier.IsNot(DAMAGEMULTIPLIER_OHKO) && DamageMultiplier.IsNot(DAMAGEMULTIPLIER_QUADRUPLE)) || CanUse(CanUseItem::Goron_Tunic) || CanUse(CanUseItem::Bow) || CanUse(CanUseItem::Longshot))))));}),
+                    //Trick: (LogicFewerTunicRequirements || CanUse(CanUseItem::Goron_Tunic)) && (((CanUse(CanUseItem::Hover_Boots) || (LogicFireMQNearBoss && CanUse(CanUseItem::Bow))) && HasFireSource) || (CanUse(CanUseItem::Hookshot) && CanUse(CanUseItem::Fire_Arrows) || (CanUse(CanUseItem::Dins_Fire) && ((DamageMultiplier.IsNot(DAMAGEMULTIPLIER_OHKO) && DamageMultiplier.IsNot(DAMAGEMULTIPLIER_QUADRUPLE)) || CanUse(CanUseItem::Goron_Tunic) || CanUse(CanUseItem::Bow) || CanUse(CanUseItem::Longshot)))))
   }, {
-    //Exits
-    ExitPairing::Both(&FireTemple_Entrance,           []{return true;}),
-    ExitPairing::Both(&FireTemple_MQ_BossRoom,        []{return CanUse(CanUseItem::Goron_Tunic) && CanUse(CanUseItem::Hammer) && BossKeyFireTemple && ((HasFireSource && (LogicFireBossDoorJump || HoverBoots)) || FireTemple_MQ_Upper.Adult());}),
-    ExitPairing::Both(&FireTemple_MQ_LowerLockedDoor, []{return SmallKeys(FireTempleKeys, 5) && (IsAdult || KokiriSword);}),
-    ExitPairing::Both(&FireTemple_MQ_BigLavaRoom,     []{return (LogicFewerTunicRequirements || CanUse(CanUseItem::Goron_Tunic)) && CanUse(CanUseItem::Hammer);}),
+                  //Exits
+                  ExitPairing::Both(&FireTemple_Entrance,           []{return true;}),
+                  ExitPairing::Both(&FireTemple_MQ_BossRoom,        []{return CanUse(CanUseItem::Goron_Tunic) && CanUse(CanUseItem::Hammer) && BossKeyFireTemple && ((HasFireSource && (LogicFireBossDoorJump || HoverBoots)) || FireTemple_MQ_Upper.Adult());}),
+                  ExitPairing::Both(&FireTemple_MQ_LowerLockedDoor, []{return SmallKeys(FireTempleKeys, 5) && (IsAdult || KokiriSword);}),
+                  ExitPairing::Both(&FireTemple_MQ_BigLavaRoom,     []{return (LogicFewerTunicRequirements || CanUse(CanUseItem::Goron_Tunic)) && CanUse(CanUseItem::Hammer);}),
   });
 
   Exit FireTemple_MQ_LowerLockedDoor = Exit("Fire Temple MQ Lower Locked Door", "Fire Temple", "", NO_DAY_NIGHT_CYCLE, {
-    //Events
-    EventPairing(&FairyPot, []{return true;}),
+                  //Events
+                  EventPairing(&FairyPot, []{return true;}),
   }, {
-    //Locations
-    ItemLocationPairing(&FireTemple_MQ_MegatonHammerChest, []{return IsAdult && (HasExplosives || Hammer || Hookshot);}),
-    ItemLocationPairing(&FireTemple_MQ_MapChest,           []{return CanUse(CanUseItem::Hammer);}),
+                  //Locations
+                  ItemLocationPairing(&FireTemple_MQ_MegatonHammerChest, []{return IsAdult && (HasExplosives || Hammer || Hookshot);}),
+                  ItemLocationPairing(&FireTemple_MQ_MapChest,           []{return CanUse(CanUseItem::Hammer);}),
   }, {});
 
   Exit FireTemple_MQ_BigLavaRoom = Exit("Fire Temple MQ Big Lava Room", "Fire Temple", "", NO_DAY_NIGHT_CYCLE, {
-    //Events
-    EventPairing(&FairyPot, []{return FairyPot || (HasFireSource && Bow && (CanUse(CanUseItem::Hookshot) || LogicFireSongOfTime));}),
-      //Trick: HasFireSource && (Bow || LogicFireMQBKChest) && (CanUse(CanUseItem::Hookshot) || LogicFireSongOfTime)
+                  //Events
+                  EventPairing(&FairyPot, []{return FairyPot || (HasFireSource && Bow && (CanUse(CanUseItem::Hookshot) || LogicFireSongOfTime));}),
+                    //Trick: HasFireSource && (Bow || LogicFireMQBKChest) && (CanUse(CanUseItem::Hookshot) || LogicFireSongOfTime)
   }, {
-    //Locations
-    ItemLocationPairing(&FireTemple_MQ_BossKeyChest,                []{return HasFireSource && Bow && CanUse(CanUseItem::Hookshot);}),
-      //Trick: HasFireSource && (Bow || LogicFireMQBKChest) && CanUse(CanUseItem::Hookshot)
-    ItemLocationPairing(&FireTemple_MQ_BigLavaRoomBlockedDoorChest, []{return HasFireSource && HasExplosives && CanUse(CanUseItem::Hookshot);}),
-      //Trick: HasFireSource && HasExplosives && (CanUse(CanUseItem::Hookshot) || LogicFireMQBlockedChest)
-    ItemLocationPairing(&FireTemple_MQ_GS_BigLavaRoomOpenDoor,      []{return true;}),
+                  //Locations
+                  ItemLocationPairing(&FireTemple_MQ_BossKeyChest,                []{return HasFireSource && Bow && CanUse(CanUseItem::Hookshot);}),
+                    //Trick: HasFireSource && (Bow || LogicFireMQBKChest) && CanUse(CanUseItem::Hookshot)
+                  ItemLocationPairing(&FireTemple_MQ_BigLavaRoomBlockedDoorChest, []{return HasFireSource && HasExplosives && CanUse(CanUseItem::Hookshot);}),
+                    //Trick: HasFireSource && HasExplosives && (CanUse(CanUseItem::Hookshot) || LogicFireMQBlockedChest)
+                  ItemLocationPairing(&FireTemple_MQ_GS_BigLavaRoomOpenDoor,      []{return true;}),
   }, {
-    //Exits
-    ExitPairing::Both(&FireTemple_MQ_LowerMaze, []{return CanUse(CanUseItem::Goron_Tunic) && SmallKeys(FireTempleKeys, 2) && HasFireSource;}),
-      //Trick: CanUse(CanUseItem::Goron_Tunic) && SmallKeys(FireTempleKeys, 2) && (HasFireSource || (LogicFireMQClimb && HoverBoots))
+                  //Exits
+                  ExitPairing::Both(&FireTemple_MQ_LowerMaze, []{return CanUse(CanUseItem::Goron_Tunic) && SmallKeys(FireTempleKeys, 2) && HasFireSource;}),
+                    //Trick: CanUse(CanUseItem::Goron_Tunic) && SmallKeys(FireTempleKeys, 2) && (HasFireSource || (LogicFireMQClimb && HoverBoots))
   });
 
   Exit FireTemple_MQ_LowerMaze = Exit("Fire Temple MQ Lower Maze", "Fire Temple", "", NO_DAY_NIGHT_CYCLE, {}, {
-    //Locations
-    ItemLocationPairing(&FireTemple_MQ_LizalfosMazeLowerChest,    []{return true;}),
-    ItemLocationPairing(&FireTemple_MQ_LizalfosMazeSideRoomChest, []{return HasExplosives && FireTemple_MQ_UpperMaze.Adult();}),
-      //Trick: HasExplosives && (LogicFireMQMazeSideRoom || FireTemple_MQ_UpperMaze.Adult())
+                  //Locations
+                  ItemLocationPairing(&FireTemple_MQ_LizalfosMazeLowerChest,    []{return true;}),
+                  ItemLocationPairing(&FireTemple_MQ_LizalfosMazeSideRoomChest, []{return HasExplosives && FireTemple_MQ_UpperMaze.Adult();}),
+                    //Trick: HasExplosives && (LogicFireMQMazeSideRoom || FireTemple_MQ_UpperMaze.Adult())
    }, {
-    //Exits
-    ExitPairing::Both(&FireTemple_MQ_UpperMaze, []{return HasExplosives && CanUse(CanUseItem::Hookshot);}),
-      //Trick: (HasExplosives && CanUse(CanUseItem::Hookshot)) || (LogicFireMQMazeHovers && CanUse(CanUseItem::Hover_Boots)) || LogicFireMQMazeJump
+                  //Exits
+                  ExitPairing::Both(&FireTemple_MQ_UpperMaze, []{return HasExplosives && CanUse(CanUseItem::Hookshot);}),
+                    //Trick: (HasExplosives && CanUse(CanUseItem::Hookshot)) || (LogicFireMQMazeHovers && CanUse(CanUseItem::Hover_Boots)) || LogicFireMQMazeJump
   });
 
   Exit FireTemple_MQ_UpperMaze = Exit("Fire Temple MQ Upper Maze", "Fire Temple", "", NO_DAY_NIGHT_CYCLE, {
-    //Events
-    //EventPairing(&WallFairy, []{return WallFairy || ((CanPlay(SongOfTime) && CanUse(CanUseItem::Hookshot) && HasExplosives) || CanUse(CanUseItem::Longshot));}),
-    EventPairing(&FairyPot,  []{return SmallKeys(FireTempleKeys, 3);}),
+                  //Events
+                  //EventPairing(&WallFairy, []{return WallFairy || ((CanPlay(SongOfTime) && CanUse(CanUseItem::Hookshot) && HasExplosives) || CanUse(CanUseItem::Longshot));}),
+                  EventPairing(&FairyPot,  []{return SmallKeys(FireTempleKeys, 3);}),
   }, {
-    //Locations
-    ItemLocationPairing(&FireTemple_MQ_LizalfosMazeUpperChest, []{return true;}),
-    ItemLocationPairing(&FireTemple_MQ_CompassChest,           []{return HasExplosives;}),
-    ItemLocationPairing(&FireTemple_MQ_GS_SkullOnFire,         []{return (CanPlay(SongOfTime) && CanUse(CanUseItem::Hookshot) && HasExplosives) || CanUse(CanUseItem::Longshot);}),
+                  //Locations
+                  ItemLocationPairing(&FireTemple_MQ_LizalfosMazeUpperChest, []{return true;}),
+                  ItemLocationPairing(&FireTemple_MQ_CompassChest,           []{return HasExplosives;}),
+                  ItemLocationPairing(&FireTemple_MQ_GS_SkullOnFire,         []{return (CanPlay(SongOfTime) && CanUse(CanUseItem::Hookshot) && HasExplosives) || CanUse(CanUseItem::Longshot);}),
   }, {
-    //Exits
-    ExitPairing::Both(&FireTemple_MQ_Upper, []{return SmallKeys(FireTempleKeys, 3) && ((CanUse(CanUseItem::Bow) && CanUse(CanUseItem::Hookshot)) || CanUse(CanUseItem::Fire_Arrows));}),
+                  //Exits
+                  ExitPairing::Both(&FireTemple_MQ_Upper, []{return SmallKeys(FireTempleKeys, 3) && ((CanUse(CanUseItem::Bow) && CanUse(CanUseItem::Hookshot)) || CanUse(CanUseItem::Fire_Arrows));}),
   });
 
   Exit FireTemple_MQ_Upper = Exit("Fire Temple MQ Upper", "Fire Temple", "", NO_DAY_NIGHT_CYCLE, {}, {
-    //Locations
-    ItemLocationPairing(&FireTemple_MQ_FreestandingKey,         []{return CanUse(CanUseItem::Hookshot);}),
-      //Trick: CanUse(CanUseItem::Hookshot) || LogicFireMQFlameMaze
-    ItemLocationPairing(&FireTemple_MQ_ChestOnFire,             []{return CanUse(CanUseItem::Hookshot) && SmallKeys(FireTempleKeys, 4);}),
-      //Trick: (CanUse(CanUseItem::Hookshot) || LogicFireMQFlameMaze) && SmallKeys(FireTempleKeys, 4)
-    ItemLocationPairing(&FireTemple_MQ_GS_FireWallMazeSideRoom, []{return CanPlay(SongOfTime) || HoverBoots;}),
-      //Trick: CanPlay(SongOfTime) || HoverBoots || LogicFireMQFlameMaze
-    ItemLocationPairing(&FireTemple_MQ_GS_FireWallMazeCenter,   []{return HasExplosives;}),
-    ItemLocationPairing(&FireTemple_MQ_GS_AboveFireWallMaze,    []{return CanUse(CanUseItem::Hookshot) && SmallKeys(FireTempleKeys, 5);}),
-      //Trick: (CanUse(CanUseItem::Hookshot) && SmallKeys(FireTempleKeys, 5)) || (LogicFireMQAboveMazeGS && CanUse(CanUseItem::Longshot))
+                  //Locations
+                  ItemLocationPairing(&FireTemple_MQ_FreestandingKey,         []{return CanUse(CanUseItem::Hookshot);}),
+                    //Trick: CanUse(CanUseItem::Hookshot) || LogicFireMQFlameMaze
+                  ItemLocationPairing(&FireTemple_MQ_ChestOnFire,             []{return CanUse(CanUseItem::Hookshot) && SmallKeys(FireTempleKeys, 4);}),
+                    //Trick: (CanUse(CanUseItem::Hookshot) || LogicFireMQFlameMaze) && SmallKeys(FireTempleKeys, 4)
+                  ItemLocationPairing(&FireTemple_MQ_GS_FireWallMazeSideRoom, []{return CanPlay(SongOfTime) || HoverBoots;}),
+                    //Trick: CanPlay(SongOfTime) || HoverBoots || LogicFireMQFlameMaze
+                  ItemLocationPairing(&FireTemple_MQ_GS_FireWallMazeCenter,   []{return HasExplosives;}),
+                  ItemLocationPairing(&FireTemple_MQ_GS_AboveFireWallMaze,    []{return CanUse(CanUseItem::Hookshot) && SmallKeys(FireTempleKeys, 5);}),
+                    //Trick: (CanUse(CanUseItem::Hookshot) && SmallKeys(FireTempleKeys, 5)) || (LogicFireMQAboveMazeGS && CanUse(CanUseItem::Longshot))
   }, {});
 
   Exit FireTemple_MQ_BossRoom = Exit("Fire Temple MQ Boss Room", "Fire Temple", "", NO_DAY_NIGHT_CYCLE, {
-    //Events
-    EventPairing(&FireTempleClear, []{return true;}),
+                  //Events
+                  EventPairing(&FireTempleClear, []{return true;}),
   }, {
-    //Locations
-    ItemLocationPairing(&FireTemple_VolvagiaHeart, []{return true;}),
-    ItemLocationPairing(&Volvagia, []{return true;}),
+                  //Locations
+                  ItemLocationPairing(&FireTemple_VolvagiaHeart, []{return true;}),
+                  ItemLocationPairing(&Volvagia, []{return true;}),
   }, {});
 
   Exit WaterTemple_MQ_Lobby = Exit("Water Temple MQ Lobby", "Water Temple", "", NO_DAY_NIGHT_CYCLE, {
-    //Events
-    EventPairing(&WaterTempleClear, []{return BossKeyWaterTemple && CanUse(CanUseItem::Longshot);}),
+                  //Events
+                  EventPairing(&WaterTempleClear, []{return BossKeyWaterTemple && CanUse(CanUseItem::Longshot);}),
   }, {
-    //Locations
-    ItemLocationPairing(&WaterTemple_MorphaHeart, []{return BossKeyWaterTemple && CanUse(CanUseItem::Longshot);}),
-    ItemLocationPairing(&Morpha,                  []{return BossKeyWaterTemple && CanUse(CanUseItem::Longshot);}),
+                  //Locations
+                  ItemLocationPairing(&WaterTemple_MorphaHeart, []{return BossKeyWaterTemple && CanUse(CanUseItem::Longshot);}),
+                  ItemLocationPairing(&Morpha,                  []{return BossKeyWaterTemple && CanUse(CanUseItem::Longshot);}),
   }, {
-    //Exits
-    ExitPairing::Both(&LH_Main,                       []{return true;}),
-    ExitPairing::Both(&WaterTemple_MQ_Dive,           []{return (CanUse(CanUseItem::Zora_Tunic) || LogicFewerTunicRequirements) && CanUse(CanUseItem::Iron_Boots);}),
-    ExitPairing::Both(&WaterTemple_MQ_DarkLinkRegion, []{return SmallKeys(WaterTempleKeys, 1) && CanUse(CanUseItem::Longshot);}),
+                  //Exits
+                  ExitPairing::Both(&LH_Main,                       []{return true;}),
+                  ExitPairing::Both(&WaterTemple_MQ_Dive,           []{return (CanUse(CanUseItem::Zora_Tunic) || LogicFewerTunicRequirements) && CanUse(CanUseItem::Iron_Boots);}),
+                  ExitPairing::Both(&WaterTemple_MQ_DarkLinkRegion, []{return SmallKeys(WaterTempleKeys, 1) && CanUse(CanUseItem::Longshot);}),
   });
 
   Exit WaterTemple_MQ_Dive = Exit("Water Temple MQ Dive", "Water Temple", "", NO_DAY_NIGHT_CYCLE, {}, {
-    //Locations
-    ItemLocationPairing(&WaterTemple_MQ_MapChest,           []{return HasFireSource && CanUse(CanUseItem::Hookshot);}),
-    ItemLocationPairing(&WaterTemple_MQ_CentralPillarChest, []{return CanUse(CanUseItem::Zora_Tunic) && CanUse(CanUseItem::Hookshot) && (CanUse(CanUseItem::Dins_Fire) && CanPlay(SongOfTime));}),
-      //Trick: CanUse(CanUseItem::Zora_Tunic) && CanUse(CanUseItem::Hookshot) && ((LogicWaterMQCentralPillar && CanUse(CanUseItem::Fire_Arrows)) || (CanUse(CanUseItem::Dins_Fire) && CanPlay(SongOfTime)))
+                  //Locations
+                  ItemLocationPairing(&WaterTemple_MQ_MapChest,           []{return HasFireSource && CanUse(CanUseItem::Hookshot);}),
+                  ItemLocationPairing(&WaterTemple_MQ_CentralPillarChest, []{return CanUse(CanUseItem::Zora_Tunic) && CanUse(CanUseItem::Hookshot) && (CanUse(CanUseItem::Dins_Fire) && CanPlay(SongOfTime));}),
+                    //Trick: CanUse(CanUseItem::Zora_Tunic) && CanUse(CanUseItem::Hookshot) && ((LogicWaterMQCentralPillar && CanUse(CanUseItem::Fire_Arrows)) || (CanUse(CanUseItem::Dins_Fire) && CanPlay(SongOfTime)))
   }, {
-    //Exits
-    ExitPairing::Both(&WaterTemple_MQ_LoweredWaterLevels, []{return CanPlay(ZeldasLullaby);}),
+                  //Exits
+                  ExitPairing::Both(&WaterTemple_MQ_LoweredWaterLevels, []{return CanPlay(ZeldasLullaby);}),
   });
 
   Exit WaterTemple_MQ_LoweredWaterLevels = Exit("Water Temple MQ Lowered Water Levels", "Water Temple", "", NO_DAY_NIGHT_CYCLE, {}, {
-    //Locations
-    ItemLocationPairing(&WaterTemple_MQ_CompassChest,              []{return CanUse(CanUseItem::Bow) || CanUse(CanUseItem::Dins_Fire) || (WaterTemple_MQ_Lobby.Child() && CanUse(CanUseItem::Sticks) && HasExplosives);}),
-    ItemLocationPairing(&WaterTemple_MQ_LongshotChest,             []{return CanUse(CanUseItem::Hookshot);}),
-    ItemLocationPairing(&WaterTemple_MQ_GS_LizalfosHallway,        []{return CanUse(CanUseItem::Dins_Fire);}),
-    ItemLocationPairing(&WaterTemple_MQ_GS_BeforeUpperWaterSwitch, []{return CanUse(CanUseItem::Longshot);}),
+                  //Locations
+                  ItemLocationPairing(&WaterTemple_MQ_CompassChest,              []{return CanUse(CanUseItem::Bow) || CanUse(CanUseItem::Dins_Fire) || (WaterTemple_MQ_Lobby.Child() && CanUse(CanUseItem::Sticks) && HasExplosives);}),
+                  ItemLocationPairing(&WaterTemple_MQ_LongshotChest,             []{return CanUse(CanUseItem::Hookshot);}),
+                  ItemLocationPairing(&WaterTemple_MQ_GS_LizalfosHallway,        []{return CanUse(CanUseItem::Dins_Fire);}),
+                  ItemLocationPairing(&WaterTemple_MQ_GS_BeforeUpperWaterSwitch, []{return CanUse(CanUseItem::Longshot);}),
   }, {});
 
   Exit WaterTemple_MQ_DarkLinkRegion = Exit("Water Temple MQ Dark Link Region", "Water Temple", "", NO_DAY_NIGHT_CYCLE, {
-    //Events
-    EventPairing(&FairyPot, []{return true;}),
-    EventPairing(&NutPot,   []{return true;}),
+                  //Events
+                  EventPairing(&FairyPot, []{return true;}),
+                  EventPairing(&NutPot,   []{return true;}),
   }, {
-    //Locations
-    ItemLocationPairing(&WaterTemple_MQ_BossKeyChest, []{return (CanUse(CanUseItem::Zora_Tunic) || LogicFewerTunicRequirements) && CanUse(CanUseItem::Dins_Fire) && (LogicWaterDragonJumpDive || CanDive || CanUse(CanUseItem::Iron_Boots));}),
-    ItemLocationPairing(&WaterTemple_MQ_GS_River,     []{return true;}),
+                  //Locations
+                  ItemLocationPairing(&WaterTemple_MQ_BossKeyChest, []{return (CanUse(CanUseItem::Zora_Tunic) || LogicFewerTunicRequirements) && CanUse(CanUseItem::Dins_Fire) && (LogicWaterDragonJumpDive || CanDive || CanUse(CanUseItem::Iron_Boots));}),
+                  ItemLocationPairing(&WaterTemple_MQ_GS_River,     []{return true;}),
   }, {
-    //Exits
-    ExitPairing::Both(&WaterTemple_MQ_BasementGatedAreas, []{return (CanUse(CanUseItem::Zora_Tunic) || LogicFewerTunicRequirements) && CanUse(CanUseItem::Dins_Fire) && CanUse(CanUseItem::Iron_Boots);}),
+                  //Exits
+                  ExitPairing::Both(&WaterTemple_MQ_BasementGatedAreas, []{return (CanUse(CanUseItem::Zora_Tunic) || LogicFewerTunicRequirements) && CanUse(CanUseItem::Dins_Fire) && CanUse(CanUseItem::Iron_Boots);}),
   });
 
   Exit WaterTemple_MQ_BasementGatedAreas = Exit("Water Temple MQ Basement Gated Areas", "Water Temple", "", NO_DAY_NIGHT_CYCLE, {}, {
-    //Locations
-    ItemLocationPairing(&WaterTemple_MQ_FreestandingKey,        []{return HoverBoots || CanUse(CanUseItem::Scarecrow) || LogicWaterNorthBasementLedgeJump;}),
-    ItemLocationPairing(&WaterTemple_MQ_GS_TripleWallTorch,     []{return CanUse(CanUseItem::Fire_Arrows) && (HoverBoots || CanUse(CanUseItem::Scarecrow));}),
-    ItemLocationPairing(&WaterTemple_MQ_GS_FreestandingKeyArea, []{return SmallKeys(WaterTempleKeys, 2) && (HoverBoots || CanUse(CanUseItem::Scarecrow) || LogicWaterNorthBasementLedgeJump);}),
-      //Trick: LogicWaterMQLockedGS || (SmallKeys(WaterTempleKeys, 2) && (HoverBoots || CanUse(CanUseItem::Scarecrow) || LogicWaterNorthBasementLedgeJump))
+                  //Locations
+                  ItemLocationPairing(&WaterTemple_MQ_FreestandingKey,        []{return HoverBoots || CanUse(CanUseItem::Scarecrow) || LogicWaterNorthBasementLedgeJump;}),
+                  ItemLocationPairing(&WaterTemple_MQ_GS_TripleWallTorch,     []{return CanUse(CanUseItem::Fire_Arrows) && (HoverBoots || CanUse(CanUseItem::Scarecrow));}),
+                  ItemLocationPairing(&WaterTemple_MQ_GS_FreestandingKeyArea, []{return SmallKeys(WaterTempleKeys, 2) && (HoverBoots || CanUse(CanUseItem::Scarecrow) || LogicWaterNorthBasementLedgeJump);}),
+                    //Trick: LogicWaterMQLockedGS || (SmallKeys(WaterTempleKeys, 2) && (HoverBoots || CanUse(CanUseItem::Scarecrow) || LogicWaterNorthBasementLedgeJump))
   }, {});
 
   Exit SpiritTemple_MQ_Lobby = Exit("Spirit Temple MQ Lobby", "Spirit Temple", "", NO_DAY_NIGHT_CYCLE, {}, {
-    //Locations
-    ItemLocationPairing(&SpiritTemple_MQ_EntranceFrontLeftChest, []{return true;}),
-    ItemLocationPairing(&SpiritTemple_MQ_EntranceBackLeftChest,  []{return CanBlastOrSmash && (CanUse(CanUseItem::Slingshot) || CanUse(CanUseItem::Bow));}),
-    ItemLocationPairing(&SpiritTemple_MQ_EntranceBackRightChest, []{return HasBombchus || CanUse(CanUseItem::Bow) || CanUse(CanUseItem::Hookshot) || CanUse(CanUseItem::Slingshot) || CanUse(CanUseItem::Boomerang);}),
+                  //Locations
+                  ItemLocationPairing(&SpiritTemple_MQ_EntranceFrontLeftChest, []{return true;}),
+                  ItemLocationPairing(&SpiritTemple_MQ_EntranceBackLeftChest,  []{return CanBlastOrSmash && (CanUse(CanUseItem::Slingshot) || CanUse(CanUseItem::Bow));}),
+                  ItemLocationPairing(&SpiritTemple_MQ_EntranceBackRightChest, []{return HasBombchus || CanUse(CanUseItem::Bow) || CanUse(CanUseItem::Hookshot) || CanUse(CanUseItem::Slingshot) || CanUse(CanUseItem::Boomerang);}),
   }, {
-    //Exits
-    ExitPairing::Both(&Colossus_Main,         []{return true;}),
-    ExitPairing::Both(&SpiritTemple_MQ_Child, []{return IsChild;}),
-    ExitPairing::Both(&SpiritTemple_MQ_Adult, []{return HasBombchus && CanUse(CanUseItem::Longshot) && CanUse(CanUseItem::Silver_Gauntlets);}),
+                  //Exits
+                  ExitPairing::Both(&Colossus_Main,         []{return true;}),
+                  ExitPairing::Both(&SpiritTemple_MQ_Child, []{return IsChild;}),
+                  ExitPairing::Both(&SpiritTemple_MQ_Adult, []{return HasBombchus && CanUse(CanUseItem::Longshot) && CanUse(CanUseItem::Silver_Gauntlets);}),
   });
 
   Exit SpiritTemple_MQ_Child = Exit("Spirit Temple MQ Child", "Spirit Temple", "", NO_DAY_NIGHT_CYCLE, {
-    //Events
-    EventPairing(&FairyPot, []{return FairyPot || ((Sticks || KokiriSword) && HasBombchus && Slingshot);}),
+                  //Events
+                  EventPairing(&FairyPot, []{return FairyPot || ((Sticks || KokiriSword) && HasBombchus && Slingshot);}),
   }, {
-    //Locations
-    ItemLocationPairing(&SpiritTemple_MQ_ChildHammerSwitchChest, []{return SpiritTemple_MQ_Adult.Adult() && SmallKeys(SpiritTempleKeys, 7) && Hammer;}),
-    ItemLocationPairing(&SpiritTemple_MQ_MapRoomEnemyChest, []{return (Sticks || KokiriSword) && HasBombchus && Slingshot && CanUse(CanUseItem::Dins_Fire);}),
-    ItemLocationPairing(&SpiritTemple_MQ_MapChest, []{return Sticks || KokiriSword || Bombs;}),
-    ItemLocationPairing(&SpiritTemple_MQ_SilverBlockHallwayChest, []{return HasBombchus && SmallKeys(SpiritTempleKeys, 7) && Slingshot && (CanUse(CanUseItem::Dins_Fire) || (SpiritTemple_MQ_Adult.Adult() && CanUse(CanUseItem::Fire_Arrows)));}),
-      //Trick: HasBombchus && SmallKeys(SpiritTempleKeys, 7) && Slingshot && (CanUse(CanUseItem::Dins_Fire) || (SpiritTemple_MQ_Adult.Adult() && (CanUse(CanUseItem::Fire_Arrows) || (LogicSpiritMQFrozenEye && CanUse(CanUseItem::Bow) && CanPlay(SongOfTime)))))
+                  //Locations
+                  ItemLocationPairing(&SpiritTemple_MQ_ChildHammerSwitchChest, []{return SpiritTemple_MQ_Adult.Adult() && SmallKeys(SpiritTempleKeys, 7) && Hammer;}),
+                  ItemLocationPairing(&SpiritTemple_MQ_MapRoomEnemyChest, []{return (Sticks || KokiriSword) && HasBombchus && Slingshot && CanUse(CanUseItem::Dins_Fire);}),
+                  ItemLocationPairing(&SpiritTemple_MQ_MapChest, []{return Sticks || KokiriSword || Bombs;}),
+                  ItemLocationPairing(&SpiritTemple_MQ_SilverBlockHallwayChest, []{return HasBombchus && SmallKeys(SpiritTempleKeys, 7) && Slingshot && (CanUse(CanUseItem::Dins_Fire) || (SpiritTemple_MQ_Adult.Adult() && CanUse(CanUseItem::Fire_Arrows)));}),
+                    //Trick: HasBombchus && SmallKeys(SpiritTempleKeys, 7) && Slingshot && (CanUse(CanUseItem::Dins_Fire) || (SpiritTemple_MQ_Adult.Adult() && (CanUse(CanUseItem::Fire_Arrows) || (LogicSpiritMQFrozenEye && CanUse(CanUseItem::Bow) && CanPlay(SongOfTime)))))
   }, {
-    //Exits
-    ExitPairing::Both(&SpiritTemple_MQ_Shared, []{return HasBombchus && SmallKeys(SpiritTempleKeys, 2);}),
+                  //Exits
+                  ExitPairing::Both(&SpiritTemple_MQ_Shared, []{return HasBombchus && SmallKeys(SpiritTempleKeys, 2);}),
   });
 
   Exit SpiritTemple_MQ_Adult = Exit("Spirit Temple MQ Adult", "Spirit Temple", "", NO_DAY_NIGHT_CYCLE, {}, {
-    //Locations
-    ItemLocationPairing(&SpiritTemple_MQ_ChildClimbSouthChest,     []{return SmallKeys(SpiritTempleKeys, 7);}),
-    ItemLocationPairing(&SpiritTemple_MQ_StatueRoomLullabyChest,   []{return CanPlay(ZeldasLullaby);}),
-    ItemLocationPairing(&SpiritTemple_MQ_StatueRoomInvisibleChest, []{return (LogicLensSpiritMQ || CanUse(CanUseItem::Lens_of_Truth));}),
-    ItemLocationPairing(&SpiritTemple_MQ_BeamosRoomChest,          []{return SmallKeys(SpiritTempleKeys, 5);}),
-    ItemLocationPairing(&SpiritTemple_MQ_ChestSwitchChest,         []{return SmallKeys(SpiritTempleKeys, 5) && CanPlay(SongOfTime);}),
-    ItemLocationPairing(&SpiritTemple_MQ_BossKeyChest,             []{return SmallKeys(SpiritTempleKeys, 5) && CanPlay(SongOfTime) && MirrorShield;}),
-    ItemLocationPairing(&SpiritTemple_MQ_GS_NineThronesRoomWest,   []{return SmallKeys(SpiritTempleKeys, 7);}),
-    ItemLocationPairing(&SpiritTemple_MQ_GS_NineThronesRoomNorth,  []{return SmallKeys(SpiritTempleKeys, 7);}),
+                  //Locations
+                  ItemLocationPairing(&SpiritTemple_MQ_ChildClimbSouthChest,     []{return SmallKeys(SpiritTempleKeys, 7);}),
+                  ItemLocationPairing(&SpiritTemple_MQ_StatueRoomLullabyChest,   []{return CanPlay(ZeldasLullaby);}),
+                  ItemLocationPairing(&SpiritTemple_MQ_StatueRoomInvisibleChest, []{return (LogicLensSpiritMQ || CanUse(CanUseItem::Lens_of_Truth));}),
+                  ItemLocationPairing(&SpiritTemple_MQ_BeamosRoomChest,          []{return SmallKeys(SpiritTempleKeys, 5);}),
+                  ItemLocationPairing(&SpiritTemple_MQ_ChestSwitchChest,         []{return SmallKeys(SpiritTempleKeys, 5) && CanPlay(SongOfTime);}),
+                  ItemLocationPairing(&SpiritTemple_MQ_BossKeyChest,             []{return SmallKeys(SpiritTempleKeys, 5) && CanPlay(SongOfTime) && MirrorShield;}),
+                  ItemLocationPairing(&SpiritTemple_MQ_GS_NineThronesRoomWest,   []{return SmallKeys(SpiritTempleKeys, 7);}),
+                  ItemLocationPairing(&SpiritTemple_MQ_GS_NineThronesRoomNorth,  []{return SmallKeys(SpiritTempleKeys, 7);}),
   }, {
-    //Exits
-    ExitPairing::Both(&SpiritTemple_MQ_LowerAdult,       []{return MirrorShield && CanUse(CanUseItem::Fire_Arrows);}),
-      //Trick: MirrorShield && (CanUse(CanUseItem::Fire_Arrows) || (LogicSpiritMQLowerAdult && CanUse(CanUseItem::Dins_Fire) && Bow))
-    ExitPairing::Both(&SpiritTemple_MQ_Shared,           []{return true;}),
-    ExitPairing::Both(&SpiritTemple_MQ_BossArea,         []{return SmallKeys(SpiritTempleKeys, 6) && CanPlay(ZeldasLullaby) && Hammer;}),
-    ExitPairing::Both(&SpiritTemple_MQ_MirrorShieldHand, []{return SmallKeys(SpiritTempleKeys, 5) && CanPlay(SongOfTime) && (LogicLensSpiritMQ || CanUse(CanUseItem::Lens_of_Truth));}),
+                  //Exits
+                  ExitPairing::Both(&SpiritTemple_MQ_LowerAdult,       []{return MirrorShield && CanUse(CanUseItem::Fire_Arrows);}),
+                    //Trick: MirrorShield && (CanUse(CanUseItem::Fire_Arrows) || (LogicSpiritMQLowerAdult && CanUse(CanUseItem::Dins_Fire) && Bow))
+                  ExitPairing::Both(&SpiritTemple_MQ_Shared,           []{return true;}),
+                  ExitPairing::Both(&SpiritTemple_MQ_BossArea,         []{return SmallKeys(SpiritTempleKeys, 6) && CanPlay(ZeldasLullaby) && Hammer;}),
+                  ExitPairing::Both(&SpiritTemple_MQ_MirrorShieldHand, []{return SmallKeys(SpiritTempleKeys, 5) && CanPlay(SongOfTime) && (LogicLensSpiritMQ || CanUse(CanUseItem::Lens_of_Truth));}),
   });
 
   Exit SpiritTemple_MQ_Shared = Exit("Spirit Temple MQ Shared", "Spirit Temple", "", NO_DAY_NIGHT_CYCLE, {}, {
-    //Locations
-    ItemLocationPairing(&SpiritTemple_MQ_ChildClimbNorthChest, []{return SmallKeys(SpiritTempleKeys, 6);}),
-    ItemLocationPairing(&SpiritTemple_MQ_CompassChest,         []{return (CanUse(CanUseItem::Slingshot) && SmallKeys(SpiritTempleKeys, 7)) || CanUse(CanUseItem::Bow) || (Bow && Slingshot);}),
-    ItemLocationPairing(&SpiritTemple_MQ_SunBlockRoomChest,    []{return CanPlay(SongOfTime) || IsAdult;}),
-      //Trick: CanPlay(SongOfTime) || LogicSpiritMQSunBlockSoT || IsAdult
-    ItemLocationPairing(&SpiritTemple_MQ_GS_SunBlockRoom,      []{return IsAdult;}),
-      //Trick: (LogicSpiritMQSunBlockGS && Boomerange && (CanPlay(SongOfTime) || LogicSpiritMQSunBlockSoT)) || IsAdult
+                  //Locations
+                  ItemLocationPairing(&SpiritTemple_MQ_ChildClimbNorthChest, []{return SmallKeys(SpiritTempleKeys, 6);}),
+                  ItemLocationPairing(&SpiritTemple_MQ_CompassChest,         []{return (CanUse(CanUseItem::Slingshot) && SmallKeys(SpiritTempleKeys, 7)) || CanUse(CanUseItem::Bow) || (Bow && Slingshot);}),
+                  ItemLocationPairing(&SpiritTemple_MQ_SunBlockRoomChest,    []{return CanPlay(SongOfTime) || IsAdult;}),
+                    //Trick: CanPlay(SongOfTime) || LogicSpiritMQSunBlockSoT || IsAdult
+                  ItemLocationPairing(&SpiritTemple_MQ_GS_SunBlockRoom,      []{return IsAdult;}),
+                    //Trick: (LogicSpiritMQSunBlockGS && Boomerange && (CanPlay(SongOfTime) || LogicSpiritMQSunBlockSoT)) || IsAdult
    }, {
-    //Exits
-    ExitPairing::Both(&SpiritTemple_MQ_SilverGauntletsHand, []{return (SmallKeys(SpiritTempleKeys, 7) && (CanPlay(SongOfTime) || IsAdult)) || (SmallKeys(SpiritTempleKeys, 4) && CanPlay(SongOfTime) && (LogicLensSpiritMQ || CanUse(CanUseItem::Lens_of_Truth)));}),
-      //Trick: (SmallKeys(SpiritTempleKeys, 7) && (CanPlay(SongOfTime) || LogicSpiritMQSunBlockSoT || IsAdult)) || (SmallKeys(SpiritTempleKeys, 4) && CanPlay(SongOfTime) && (LogicLensSpiritMQ || CanUse(CanUseItem::Lens_of_Truth)))
-    ExitPairing::Both(&Colossus_Main,                       []{return (SmallKeys(SpiritTempleKeys, 7) && (CanPlay(SongOfTime) || IsAdult)) || (SmallKeys(SpiritTempleKeys, 4) && CanPlay(SongOfTime) && (LogicLensSpiritMQ || CanUse(CanUseItem::Lens_of_Truth)) && IsAdult);}),
-      //Trick: (SmallKeys(SpiritTempleKeys, 7) && (CanPlay(SongOfTime) || LogicSpiritMQSunBlockSoT || IsAdult)) || (SmallKeys(SpiritTempleKeys, 4) && CanPlay(SongOfTime) && (LogicLensSpiritMQ || CanUse(CanUseItem::Lens_of_Truth)) && IsAdult)
+                  //Exits
+                  ExitPairing::Both(&SpiritTemple_MQ_SilverGauntletsHand, []{return (SmallKeys(SpiritTempleKeys, 7) && (CanPlay(SongOfTime) || IsAdult)) || (SmallKeys(SpiritTempleKeys, 4) && CanPlay(SongOfTime) && (LogicLensSpiritMQ || CanUse(CanUseItem::Lens_of_Truth)));}),
+                    //Trick: (SmallKeys(SpiritTempleKeys, 7) && (CanPlay(SongOfTime) || LogicSpiritMQSunBlockSoT || IsAdult)) || (SmallKeys(SpiritTempleKeys, 4) && CanPlay(SongOfTime) && (LogicLensSpiritMQ || CanUse(CanUseItem::Lens_of_Truth)))
+                  ExitPairing::Both(&Colossus_Main,                       []{return (SmallKeys(SpiritTempleKeys, 7) && (CanPlay(SongOfTime) || IsAdult)) || (SmallKeys(SpiritTempleKeys, 4) && CanPlay(SongOfTime) && (LogicLensSpiritMQ || CanUse(CanUseItem::Lens_of_Truth)) && IsAdult);}),
+                    //Trick: (SmallKeys(SpiritTempleKeys, 7) && (CanPlay(SongOfTime) || LogicSpiritMQSunBlockSoT || IsAdult)) || (SmallKeys(SpiritTempleKeys, 4) && CanPlay(SongOfTime) && (LogicLensSpiritMQ || CanUse(CanUseItem::Lens_of_Truth)) && IsAdult)
   });
 
   Exit SpiritTemple_MQ_LowerAdult = Exit("Spirit Temple MQ Lower Adult", "Spirit Temple", "", NO_DAY_NIGHT_CYCLE, {}, {
-    //Locations
-    ItemLocationPairing(&SpiritTemple_MQ_LeeverRoomChest,         []{return true;}),
-    ItemLocationPairing(&SpiritTemple_MQ_SymphonyRoomChest,       []{return SmallKeys(SpiritTempleKeys, 7) && Hammer && Ocarina && SongOfTime && EponasSong && SunsSong && SongOfStorms && ZeldasLullaby;}),
-    ItemLocationPairing(&SpiritTemple_MQ_EntranceFrontRightChest, []{return Hammer;}),
-    ItemLocationPairing(&SpiritTemple_MQ_GS_LeeverRoom,           []{return true;}),
-    ItemLocationPairing(&SpiritTemple_MQ_GS_SymphonyRoom,         []{return SmallKeys(SpiritTempleKeys, 7) && Hammer && Ocarina && SongOfTime && EponasSong && SunsSong && SongOfStorms && ZeldasLullaby;}),
+                  //Locations
+                  ItemLocationPairing(&SpiritTemple_MQ_LeeverRoomChest,         []{return true;}),
+                  ItemLocationPairing(&SpiritTemple_MQ_SymphonyRoomChest,       []{return SmallKeys(SpiritTempleKeys, 7) && Hammer && Ocarina && SongOfTime && EponasSong && SunsSong && SongOfStorms && ZeldasLullaby;}),
+                  ItemLocationPairing(&SpiritTemple_MQ_EntranceFrontRightChest, []{return Hammer;}),
+                  ItemLocationPairing(&SpiritTemple_MQ_GS_LeeverRoom,           []{return true;}),
+                  ItemLocationPairing(&SpiritTemple_MQ_GS_SymphonyRoom,         []{return SmallKeys(SpiritTempleKeys, 7) && Hammer && Ocarina && SongOfTime && EponasSong && SunsSong && SongOfStorms && ZeldasLullaby;}),
   }, {});
 
   Exit SpiritTemple_MQ_BossArea = Exit("Spirit Temple MQ Boss Area", "Spirit Temple", "", NO_DAY_NIGHT_CYCLE, {
-    //Events
-    EventPairing(&SpiritTempleClear, []{return SpiritTempleClear || (MirrorShield && BossKeySpiritTemple);})
+                  //Events
+                  EventPairing(&SpiritTempleClear, []{return SpiritTempleClear || (MirrorShield && BossKeySpiritTemple);})
   }, {
-    //Locations
-    ItemLocationPairing(&SpiritTemple_MQ_MirrorPuzzleInvisibleChest, []{return LogicLensSpiritMQ || CanUse(CanUseItem::Lens_of_Truth);}),
-    ItemLocationPairing(&SpiritTemple_TwinrovaHeart,                 []{return MirrorShield && BossKeySpiritTemple;}),
-    ItemLocationPairing(&Twinrova,                                   []{return MirrorShield && BossKeySpiritTemple;}),
+                  //Locations
+                  ItemLocationPairing(&SpiritTemple_MQ_MirrorPuzzleInvisibleChest, []{return LogicLensSpiritMQ || CanUse(CanUseItem::Lens_of_Truth);}),
+                  ItemLocationPairing(&SpiritTemple_TwinrovaHeart,                 []{return MirrorShield && BossKeySpiritTemple;}),
+                  ItemLocationPairing(&Twinrova,                                   []{return MirrorShield && BossKeySpiritTemple;}),
   }, {});
 
   Exit SpiritTemple_MQ_MirrorShieldHand = Exit("Spirit Temple MQ Mirror Shield Hand", "Spirit Temple", "", NO_DAY_NIGHT_CYCLE, {}, {
-    //Locations
-    ItemLocationPairing(&SpiritTemple_MirrorShieldChest, []{return true;}),
+                  //Locations
+                  ItemLocationPairing(&SpiritTemple_MirrorShieldChest, []{return true;}),
   }, {});
 
   Exit SpiritTemple_MQ_SilverGauntletsHand = Exit("Spirit Temple MQ Silver Gauntlets Hand", "Spirit Temple", "", NO_DAY_NIGHT_CYCLE, {}, {
-    //Locations
-    ItemLocationPairing(&SpiritTemple_SilverGauntletsChest, []{return true;}),
+                  //Locations
+                  ItemLocationPairing(&SpiritTemple_SilverGauntletsChest, []{return true;}),
   }, {});
 
   Exit ShadowTemple_MQ_Entryway = Exit("Shadow Temple MQ Entryway", "Shadow Temple", "", NO_DAY_NIGHT_CYCLE, {}, {}, {
-    //Exits
-    ExitPairing::Both(&GY_WarpPadRegion,          []{return true;}),
-    ExitPairing::Both(&ShadowTemple_MQ_Beginning, []{return (LogicLensShadowMQ || CanUse(CanUseItem::Lens_of_Truth)) && (CanUse(CanUseItem::Hover_Boots) || CanUse(CanUseItem::Hookshot));}),
+                  //Exits
+                  ExitPairing::Both(&GY_WarpPadRegion,          []{return true;}),
+                  ExitPairing::Both(&ShadowTemple_MQ_Beginning, []{return (LogicLensShadowMQ || CanUse(CanUseItem::Lens_of_Truth)) && (CanUse(CanUseItem::Hover_Boots) || CanUse(CanUseItem::Hookshot));}),
   });
 
   Exit ShadowTemple_MQ_Beginning = Exit("Shadow Temple MQ Beginning", "Shadow Temple", "", NO_DAY_NIGHT_CYCLE, {}, {}, {
-    //Exits
-    ExitPairing::Both(&ShadowTemple_MQ_Entryway,     []{return true;}),
-    ExitPairing::Both(&ShadowTemple_MQ_FirstBeamos,  []{return CanUse(CanUseItem::Fire_Arrows) || HoverBoots;}),
-      //Trick: CanUse(CanUseItem::Fire_Arrows) || HoverBoots || (LogicShadowMQGap && CanUse(CanUseItem::Longshot))
-    ExitPairing::Both(&ShadowTemple_MQ_DeadHandArea, []{return HasExplosives && SmallKeys(ShadowTempleKeys, 6);}),
+                  //Exits
+                  ExitPairing::Both(&ShadowTemple_MQ_Entryway,     []{return true;}),
+                  ExitPairing::Both(&ShadowTemple_MQ_FirstBeamos,  []{return CanUse(CanUseItem::Fire_Arrows) || HoverBoots;}),
+                    //Trick: CanUse(CanUseItem::Fire_Arrows) || HoverBoots || (LogicShadowMQGap && CanUse(CanUseItem::Longshot))
+                  ExitPairing::Both(&ShadowTemple_MQ_DeadHandArea, []{return HasExplosives && SmallKeys(ShadowTempleKeys, 6);}),
   });
 
   Exit ShadowTemple_MQ_DeadHandArea = Exit("Shadow Temple MQ Dead Hand Area", "Shadow Temple", "", NO_DAY_NIGHT_CYCLE, {}, {
-    //Locations
-    ItemLocationPairing(&ShadowTemple_MQ_CompassChest,    []{return true;}),
-    ItemLocationPairing(&ShadowTemple_MQ_HoverBootsChest, []{return CanPlay(SongOfTime) && Bow;}),
+                  //Locations
+                  ItemLocationPairing(&ShadowTemple_MQ_CompassChest,    []{return true;}),
+                  ItemLocationPairing(&ShadowTemple_MQ_HoverBootsChest, []{return CanPlay(SongOfTime) && Bow;}),
   }, {});
 
   Exit ShadowTemple_MQ_FirstBeamos = Exit("Shadow Temple MQ First Beamos", "Shadow Temple", "", NO_DAY_NIGHT_CYCLE, {}, {
-    //Locations
-    ItemLocationPairing(&ShadowTemple_MQ_MapChest,               []{return true;}),
-    ItemLocationPairing(&ShadowTemple_MQ_EarlyGibdosChest,       []{return true;}),
-    ItemLocationPairing(&ShadowTemple_MQ_NearShipInvisibleChest, []{return true;}),
+                  //Locations
+                  ItemLocationPairing(&ShadowTemple_MQ_MapChest,               []{return true;}),
+                  ItemLocationPairing(&ShadowTemple_MQ_EarlyGibdosChest,       []{return true;}),
+                  ItemLocationPairing(&ShadowTemple_MQ_NearShipInvisibleChest, []{return true;}),
   }, {
-    //Exits
-    ExitPairing::Both(&ShadowTemple_MQ_UpperHugePit, []{return HasExplosives && SmallKeys(ShadowTempleKeys, 2);}),
+                  //Exits
+                  ExitPairing::Both(&ShadowTemple_MQ_UpperHugePit, []{return HasExplosives && SmallKeys(ShadowTempleKeys, 2);}),
   });
 
   Exit ShadowTemple_MQ_UpperHugePit = Exit("Shadow Temple MQ Upper Huge Pit", "Shadow Temple", "", NO_DAY_NIGHT_CYCLE, {}, {
-    //Locations
-    ItemLocationPairing(&ShadowTemple_MQ_InvisibleBladesVisibleChest,   []{return CanPlay(SongOfTime);}),
-      //Trick: CanPlay(SongOfTime) || (LogicShadowMQInvisibleBlades && DamageMultiplier.IsNot(DAMAGEMULTIPLIER_OHKO))
-    ItemLocationPairing(&ShadowTemple_MQ_InvisibleBladesInvisibleChest, []{return CanPlay(SongOfTime);}),
-      //Trick: CanPlay(SongOfTime) || (LogicShadowMQInvisibleBlades && DamageMultiplier.IsNot(DAMAGEMULTIPLIER_OHKO))
+                  //Locations
+                  ItemLocationPairing(&ShadowTemple_MQ_InvisibleBladesVisibleChest,   []{return CanPlay(SongOfTime);}),
+                    //Trick: CanPlay(SongOfTime) || (LogicShadowMQInvisibleBlades && DamageMultiplier.IsNot(DAMAGEMULTIPLIER_OHKO))
+                  ItemLocationPairing(&ShadowTemple_MQ_InvisibleBladesInvisibleChest, []{return CanPlay(SongOfTime);}),
+                    //Trick: CanPlay(SongOfTime) || (LogicShadowMQInvisibleBlades && DamageMultiplier.IsNot(DAMAGEMULTIPLIER_OHKO))
   }, {
-    //Exits
-    ExitPairing::Both(&ShadowTemple_MQ_LowerHugePit, []{return HasFireSource;}),
-      //Trick: HasFireSource || LogicShadowMQHugePit
+                  //Exits
+                  ExitPairing::Both(&ShadowTemple_MQ_LowerHugePit, []{return HasFireSource;}),
+                    //Trick: HasFireSource || LogicShadowMQHugePit
   });
 
   Exit ShadowTemple_MQ_LowerHugePit = Exit("Shadow Temple MQ Lower Huge Pit", "Shadow Temple", "", NO_DAY_NIGHT_CYCLE, {}, {
-    //Locations
-    ItemLocationPairing(&ShadowTemple_MQ_BeamosSilverRupeesChest,  []{return CanUse(CanUseItem::Longshot);}),
-    ItemLocationPairing(&ShadowTemple_MQ_FallingSpikesLowerChest,  []{return true;}),
-    ItemLocationPairing(&ShadowTemple_MQ_FallingSpikesUpperChest,  []{return (LogicShadowUmbrella && HoverBoots) || GoronBracelet;}),
-    ItemLocationPairing(&ShadowTemple_MQ_FallingSpikesSwitchChest, []{return (LogicShadowUmbrella && HoverBoots) || GoronBracelet;}),
-    ItemLocationPairing(&ShadowTemple_MQ_InvisibleSpikesChest,     []{return HoverBoots && SmallKeys(ShadowTempleKeys, 3) && (LogicLensShadowMQBack || CanUse(CanUseItem::Lens_of_Truth));}),
-    ItemLocationPairing(&ShadowTemple_MQ_StalfosRoomChest,         []{return HoverBoots && SmallKeys(ShadowTempleKeys, 3) && Hookshot && (LogicLensShadowMQBack || CanUse(CanUseItem::Lens_of_Truth));}),
-    ItemLocationPairing(&ShadowTemple_MQ_GS_FallingSpikesRoom,     []{return Hookshot;}),
+                  //Locations
+                  ItemLocationPairing(&ShadowTemple_MQ_BeamosSilverRupeesChest,  []{return CanUse(CanUseItem::Longshot);}),
+                  ItemLocationPairing(&ShadowTemple_MQ_FallingSpikesLowerChest,  []{return true;}),
+                  ItemLocationPairing(&ShadowTemple_MQ_FallingSpikesUpperChest,  []{return (LogicShadowUmbrella && HoverBoots) || GoronBracelet;}),
+                  ItemLocationPairing(&ShadowTemple_MQ_FallingSpikesSwitchChest, []{return (LogicShadowUmbrella && HoverBoots) || GoronBracelet;}),
+                  ItemLocationPairing(&ShadowTemple_MQ_InvisibleSpikesChest,     []{return HoverBoots && SmallKeys(ShadowTempleKeys, 3) && (LogicLensShadowMQBack || CanUse(CanUseItem::Lens_of_Truth));}),
+                  ItemLocationPairing(&ShadowTemple_MQ_StalfosRoomChest,         []{return HoverBoots && SmallKeys(ShadowTempleKeys, 3) && Hookshot && (LogicLensShadowMQBack || CanUse(CanUseItem::Lens_of_Truth));}),
+                  ItemLocationPairing(&ShadowTemple_MQ_GS_FallingSpikesRoom,     []{return Hookshot;}),
   }, {
-    //Exits
-    ExitPairing::Both(&ShadowTemple_MQ_WindTunnel, []{return HoverBoots && (LogicLensShadowMQBack || CanUse(CanUseItem::Lens_of_Truth)) && Hookshot && SmallKeys(ShadowTempleKeys, 4);}),
+                  //Exits
+                  ExitPairing::Both(&ShadowTemple_MQ_WindTunnel, []{return HoverBoots && (LogicLensShadowMQBack || CanUse(CanUseItem::Lens_of_Truth)) && Hookshot && SmallKeys(ShadowTempleKeys, 4);}),
   });
 
   Exit ShadowTemple_MQ_WindTunnel = Exit("Shadow Temple MQ Wind Tunnel", "Shadow Temple", "", NO_DAY_NIGHT_CYCLE, {
-    //Events
-    EventPairing(&NutPot, []{return true;}),
+                  //Events
+                  EventPairing(&NutPot, []{return true;}),
   }, {
-    //Locations
-    ItemLocationPairing(&ShadowTemple_MQ_WindHintChest,        []{return true;}),
-    ItemLocationPairing(&ShadowTemple_MQ_AfterWindEnemyChest,  []{return true;}),
-    ItemLocationPairing(&ShadowTemple_MQ_AfterWindHiddenChest, []{return true;}),
-    ItemLocationPairing(&ShadowTemple_MQ_GS_WindHintRoom,      []{return true;}),
-    ItemLocationPairing(&ShadowTemple_MQ_GS_AfterWind,         []{return true;}),
+                  //Locations
+                  ItemLocationPairing(&ShadowTemple_MQ_WindHintChest,        []{return true;}),
+                  ItemLocationPairing(&ShadowTemple_MQ_AfterWindEnemyChest,  []{return true;}),
+                  ItemLocationPairing(&ShadowTemple_MQ_AfterWindHiddenChest, []{return true;}),
+                  ItemLocationPairing(&ShadowTemple_MQ_GS_WindHintRoom,      []{return true;}),
+                  ItemLocationPairing(&ShadowTemple_MQ_GS_AfterWind,         []{return true;}),
   }, {
-    //Exits
-    ExitPairing::Both(&ShadowTemple_MQ_BeyondBoat, []{return CanPlay(ZeldasLullaby) && SmallKeys(ShadowTempleKeys, 5);}),
+                  //Exits
+                  ExitPairing::Both(&ShadowTemple_MQ_BeyondBoat, []{return CanPlay(ZeldasLullaby) && SmallKeys(ShadowTempleKeys, 5);}),
   });
 
   Exit ShadowTemple_MQ_BeyondBoat = Exit("Shadow Temple MQ Beyond Boat", "Shadow Temple", "", NO_DAY_NIGHT_CYCLE, {
-    //Events
-    EventPairing(&ShadowTempleClear, []{return ShadowTempleClear || ((Bow || (LogicShadowStatue && HasBombchus)) && BossKeyShadowTemple);})
+                  //Events
+                  EventPairing(&ShadowTempleClear, []{return ShadowTempleClear || ((Bow || (LogicShadowStatue && HasBombchus)) && BossKeyShadowTemple);})
   }, {
-    //Locations
-    ItemLocationPairing(&ShadowTemple_BongoBongoHeart, []{return (Bow || (LogicShadowStatue && HasBombchus)) && BossKeyShadowTemple;}),
-    ItemLocationPairing(&BongoBongo,                   []{return (Bow || (LogicShadowStatue && HasBombchus)) && BossKeyShadowTemple;}),
-    ItemLocationPairing(&ShadowTemple_MQ_GS_AfterShip, []{return true;}),
-    ItemLocationPairing(&ShadowTemple_MQ_GS_NearBoss,  []{return Bow || (LogicShadowStatue && HasBombchus);}),
+                  //Locations
+                  ItemLocationPairing(&ShadowTemple_BongoBongoHeart, []{return (Bow || (LogicShadowStatue && HasBombchus)) && BossKeyShadowTemple;}),
+                  ItemLocationPairing(&BongoBongo,                   []{return (Bow || (LogicShadowStatue && HasBombchus)) && BossKeyShadowTemple;}),
+                  ItemLocationPairing(&ShadowTemple_MQ_GS_AfterShip, []{return true;}),
+                  ItemLocationPairing(&ShadowTemple_MQ_GS_NearBoss,  []{return Bow || (LogicShadowStatue && HasBombchus);}),
   }, {
-    //Exits
-    ExitPairing::Both(&ShadowTemple_MQ_InvisibleMaze, []{return Bow && CanPlay(SongOfTime) && CanUse(CanUseItem::Longshot);}),
+                  //Exits
+                  ExitPairing::Both(&ShadowTemple_MQ_InvisibleMaze, []{return Bow && CanPlay(SongOfTime) && CanUse(CanUseItem::Longshot);}),
   });
 
   Exit ShadowTemple_MQ_InvisibleMaze = Exit("Shadow Temple MQ Invisible Maze", "Shadow Temple", "", NO_DAY_NIGHT_CYCLE, {}, {
-    //Locations
-    ItemLocationPairing(&ShadowTemple_MQ_SpikeWallsLeftChest, []{return CanUse(CanUseItem::Dins_Fire) && SmallKeys(ShadowTempleKeys, 6);}),
-    ItemLocationPairing(&ShadowTemple_MQ_BossKeyChest,        []{return CanUse(CanUseItem::Dins_Fire) && SmallKeys(ShadowTempleKeys, 6);}),
-    ItemLocationPairing(&ShadowTemple_MQ_BombFlowerChest,     []{return true;}),
-    ItemLocationPairing(&ShadowTemple_MQ_FreestandingKey,     []{return true;}),
+                  //Locations
+                  ItemLocationPairing(&ShadowTemple_MQ_SpikeWallsLeftChest, []{return CanUse(CanUseItem::Dins_Fire) && SmallKeys(ShadowTempleKeys, 6);}),
+                  ItemLocationPairing(&ShadowTemple_MQ_BossKeyChest,        []{return CanUse(CanUseItem::Dins_Fire) && SmallKeys(ShadowTempleKeys, 6);}),
+                  ItemLocationPairing(&ShadowTemple_MQ_BombFlowerChest,     []{return true;}),
+                  ItemLocationPairing(&ShadowTemple_MQ_FreestandingKey,     []{return true;}),
   }, {});
 
   Exit BottomOfTheWell_MQ = Exit("Bottom of the Well MQ", "Bottom of the Well", "", NO_DAY_NIGHT_CYCLE, {}, {}, {
-    //Exits
-    ExitPairing::Both(&Kak_Main,                     []{return true;}),
-    ExitPairing::Both(&BottomOfTheWell_MQ_Perimeter, []{return IsChild;}),
+                  //Exits
+                  ExitPairing::Both(&Kak_Main,                     []{return true;}),
+                  ExitPairing::Both(&BottomOfTheWell_MQ_Perimeter, []{return IsChild;}),
   });
 
   Exit BottomOfTheWell_MQ_Perimeter = Exit("Bottom of the Well MQ Perimeter", "Bottom of the Well", "", NO_DAY_NIGHT_CYCLE, {
-    //Events
-    //EventPairing(&WallFairy, []{return WallFairy || Slingshot;}),
+                  //Events
+                  //EventPairing(&WallFairy, []{return WallFairy || Slingshot;}),
   }, {
-    //Locations
-    ItemLocationPairing(&BottomOfTheWell_MQ_CompassChest,            []{return KokiriSword || (Sticks && LogicChildDeadhand);}),
-    ItemLocationPairing(&BottomOfTheWell_MQ_DeadHandFreestandingKey, []{return HasExplosives;}),
-      //Trick: HasExplosives || (LogicBotWMQDeadHandKey && Boomerang)
-    ItemLocationPairing(&BottomOfTheWell_MQ_GS_Basement,             []{return CanChildAttack;}),
-    ItemLocationPairing(&BottomOfTheWell_MQ_GS_CoffinRoom,           []{return CanChildAttack && SmallKeys(BottomOfTheWellKeys, 2);}),
+                  //Locations
+                  ItemLocationPairing(&BottomOfTheWell_MQ_CompassChest,            []{return KokiriSword || (Sticks && LogicChildDeadhand);}),
+                  ItemLocationPairing(&BottomOfTheWell_MQ_DeadHandFreestandingKey, []{return HasExplosives;}),
+                    //Trick: HasExplosives || (LogicBotWMQDeadHandKey && Boomerang)
+                  ItemLocationPairing(&BottomOfTheWell_MQ_GS_Basement,             []{return CanChildAttack;}),
+                  ItemLocationPairing(&BottomOfTheWell_MQ_GS_CoffinRoom,           []{return CanChildAttack && SmallKeys(BottomOfTheWellKeys, 2);}),
   }, {
-    //Exits
-    ExitPairing::Both(&BottomOfTheWell_MQ,        []{return true;}),
-    ExitPairing::Both(&BottomOfTheWell_MQ_Middle, []{return CanPlay(ZeldasLullaby);}),
-      //Trick: CanPlay(ZeldasLullaby) || (LogicBotWMQPits && HasExplosives)
+                  //Exits
+                  ExitPairing::Both(&BottomOfTheWell_MQ,        []{return true;}),
+                  ExitPairing::Both(&BottomOfTheWell_MQ_Middle, []{return CanPlay(ZeldasLullaby);}),
+                    //Trick: CanPlay(ZeldasLullaby) || (LogicBotWMQPits && HasExplosives)
   });
 
   Exit BottomOfTheWell_MQ_Middle = Exit("Bottom of the Well MQ Middle", "Bottom of the Well", "", NO_DAY_NIGHT_CYCLE, {}, {
-    //Locations
-    ItemLocationPairing(&BottomOfTheWell_MQ_MapChest,                     []{return true;}),
-    ItemLocationPairing(&BottomOfTheWell_MQ_LensOfTruthChest,             []{return HasExplosives && SmallKeys(BottomOfTheWellKeys, 2);}),
-    ItemLocationPairing(&BottomOfTheWell_MQ_EastInnerRoomFreestandingKey, []{return true;}),
-    ItemLocationPairing(&BottomOfTheWell_MQ_GS_WestInnerRoom,             []{return CanChildAttack && HasExplosives;}),
-      //Trick: CanChildAttack && (LogicBotWMQPits || HasExplosives)
+                  //Locations
+                  ItemLocationPairing(&BottomOfTheWell_MQ_MapChest,                     []{return true;}),
+                  ItemLocationPairing(&BottomOfTheWell_MQ_LensOfTruthChest,             []{return HasExplosives && SmallKeys(BottomOfTheWellKeys, 2);}),
+                  ItemLocationPairing(&BottomOfTheWell_MQ_EastInnerRoomFreestandingKey, []{return true;}),
+                  ItemLocationPairing(&BottomOfTheWell_MQ_GS_WestInnerRoom,             []{return CanChildAttack && HasExplosives;}),
+                    //Trick: CanChildAttack && (LogicBotWMQPits || HasExplosives)
   }, {
-    //Exits
-    ExitPairing::Both(&BottomOfTheWell_MQ_Perimeter, []{return true;}),
+                  //Exits
+                  ExitPairing::Both(&BottomOfTheWell_MQ_Perimeter, []{return true;}),
   });
 
   Exit IceCavern_MQ_Beginning = Exit("Ice Cavern MQ Beginning", "Ice Cavern", "", NO_DAY_NIGHT_CYCLE, {
-    //Events
-    EventPairing(&FairyPot, []{return true;}),
+                  //Events
+                  EventPairing(&FairyPot, []{return true;}),
   }, {}, {
-    //Exits
-    ExitPairing::Both(&ZF_Main,                      []{return true;}),
-    ExitPairing::Both(&IceCavern_MQ_MapRoom,         []{return IsAdult || CanUse(CanUseItem::Dins_Fire) || (HasExplosives && (CanUse(CanUseItem::Sticks) || CanUse(CanUseItem::Slingshot) || KokiriSword));}),
-    ExitPairing::Both(&IceCavern_MQ_CompassRoom,     []{return IsAdult && BlueFire;}),
-    ExitPairing::Both(&IceCavern_MQ_IronBootsRegion, []{return BlueFire;}),
+                  //Exits
+                  ExitPairing::Both(&ZF_Main,                      []{return true;}),
+                  ExitPairing::Both(&IceCavern_MQ_MapRoom,         []{return IsAdult || CanUse(CanUseItem::Dins_Fire) || (HasExplosives && (CanUse(CanUseItem::Sticks) || CanUse(CanUseItem::Slingshot) || KokiriSword));}),
+                  ExitPairing::Both(&IceCavern_MQ_CompassRoom,     []{return IsAdult && BlueFire;}),
+                  ExitPairing::Both(&IceCavern_MQ_IronBootsRegion, []{return BlueFire;}),
   });
 
   Exit IceCavern_MQ_MapRoom = Exit("Ice Cavern MQ Map Room", "Ice Cavern", "", NO_DAY_NIGHT_CYCLE, {
-    //Events
-    EventPairing(&BlueFireAccess,  []{return BlueFireAccess || HasBottle;}),
+                  //Events
+                  EventPairing(&BlueFireAccess,  []{return BlueFireAccess || HasBottle;}),
   }, {
-    //Locations
-    ItemLocationPairing(&IceCavern_MQ_MapChest, []{return BlueFire && (IsAdult || CanUse(CanUseItem::Sticks) || KokiriSword || CanUseProjectile);}),
+                  //Locations
+                  ItemLocationPairing(&IceCavern_MQ_MapChest, []{return BlueFire && (IsAdult || CanUse(CanUseItem::Sticks) || KokiriSword || CanUseProjectile);}),
   }, {});
 
   Exit IceCavern_MQ_IronBootsRegion = Exit("Ice Cavern MQ Iron Boots Region", "Ice Cavern", "", NO_DAY_NIGHT_CYCLE, {}, {
-    //Locations
-    ItemLocationPairing(&IceCavern_MQ_IronBootsChest, []{return IsAdult;}),
-    ItemLocationPairing(&SheikInIceCavern,            []{return IsAdult;}),
-    ItemLocationPairing(&IceCavern_MQ_GS_IceBlock,    []{return IsAdult || CanChildAttack;}),
-    ItemLocationPairing(&IceCavern_MQ_GS_Scarecrow,   []{return CanUse(CanUseItem::Scarecrow) || (HoverBoots && CanUse(CanUseItem::Longshot));}),
-      //Tricks: CanUse(CanUseItem::Scarecrow) || (HoverBoots && CanUse(CanUseItem::Longshot)) || (LogicIceMQScarecrow && IsAdult)
+                  //Locations
+                  ItemLocationPairing(&IceCavern_MQ_IronBootsChest, []{return IsAdult;}),
+                  ItemLocationPairing(&SheikInIceCavern,            []{return IsAdult;}),
+                  ItemLocationPairing(&IceCavern_MQ_GS_IceBlock,    []{return IsAdult || CanChildAttack;}),
+                  ItemLocationPairing(&IceCavern_MQ_GS_Scarecrow,   []{return CanUse(CanUseItem::Scarecrow) || (HoverBoots && CanUse(CanUseItem::Longshot));}),
+                    //Tricks: CanUse(CanUseItem::Scarecrow) || (HoverBoots && CanUse(CanUseItem::Longshot)) || (LogicIceMQScarecrow && IsAdult)
   }, {});
 
   Exit IceCavern_MQ_CompassRoom = Exit("Ice Cavern MQ Compass Room", "Ice Cavern", "", NO_DAY_NIGHT_CYCLE, {}, {
-    //Locations
-    ItemLocationPairing(&IceCavern_MQ_CompassChest,    []{return true;}),
-    ItemLocationPairing(&IceCavern_MQ_FreestandingPoH, []{return HasExplosives;}),
-    ItemLocationPairing(&IceCavern_MQ_GS_RedIce,       []{return CanPlay(SongOfTime);}),
-      //Trick: CanPlay(SongOfTime) || LogicIceMQRedIceGS
+                  //Locations
+                  ItemLocationPairing(&IceCavern_MQ_CompassChest,    []{return true;}),
+                  ItemLocationPairing(&IceCavern_MQ_FreestandingPoH, []{return HasExplosives;}),
+                  ItemLocationPairing(&IceCavern_MQ_GS_RedIce,       []{return CanPlay(SongOfTime);}),
+                    //Trick: CanPlay(SongOfTime) || LogicIceMQRedIceGS
   }, {});
 
   Exit GerudoTrainingGrounds_MQ_Lobby = Exit("Gerudo Training Grounds MQ Lobby", "Gerudo Training Grounds", "", NO_DAY_NIGHT_CYCLE, {}, {
-    //Locations
-    ItemLocationPairing(&GerudoTrainingGrounds_MQ_LobbyLeftChest,      []{return true;}),
-    ItemLocationPairing(&GerudoTrainingGrounds_MQ_LobbyRightChest,     []{return true;}),
-    ItemLocationPairing(&GerudoTrainingGrounds_MQ_HiddenCeilingChest,  []{return LogicLensGtgMQ || CanUse(CanUseItem::Lens_of_Truth);}),
-    ItemLocationPairing(&GerudoTrainingGrounds_MQ_MazePathFirstChest,  []{return true;}),
-    ItemLocationPairing(&GerudoTrainingGrounds_MQ_MazePathSecondChest, []{return true;}),
-    ItemLocationPairing(&GerudoTrainingGrounds_MQ_MazePathThirdChest,  []{return SmallKeys(GerudoTrainingGroundsKeys, 1);}),
+                  //Locations
+                  ItemLocationPairing(&GerudoTrainingGrounds_MQ_LobbyLeftChest,      []{return true;}),
+                  ItemLocationPairing(&GerudoTrainingGrounds_MQ_LobbyRightChest,     []{return true;}),
+                  ItemLocationPairing(&GerudoTrainingGrounds_MQ_HiddenCeilingChest,  []{return LogicLensGtgMQ || CanUse(CanUseItem::Lens_of_Truth);}),
+                  ItemLocationPairing(&GerudoTrainingGrounds_MQ_MazePathFirstChest,  []{return true;}),
+                  ItemLocationPairing(&GerudoTrainingGrounds_MQ_MazePathSecondChest, []{return true;}),
+                  ItemLocationPairing(&GerudoTrainingGrounds_MQ_MazePathThirdChest,  []{return SmallKeys(GerudoTrainingGroundsKeys, 1);}),
   }, {
-    //Exits
-    ExitPairing::Both(&GF_Main,                            []{return true;}),
-    ExitPairing::Both(&GerudoTrainingGrounds_MQ_LeftSide,  []{return HasFireSource;}),
-    ExitPairing::Both(&GerudoTrainingGrounds_MQ_RightSide, []{return CanUse(CanUseItem::Bow) || CanUse(CanUseItem::Slingshot);}),
+                  //Exits
+                  ExitPairing::Both(&GF_Main,                            []{return true;}),
+                  ExitPairing::Both(&GerudoTrainingGrounds_MQ_LeftSide,  []{return HasFireSource;}),
+                  ExitPairing::Both(&GerudoTrainingGrounds_MQ_RightSide, []{return CanUse(CanUseItem::Bow) || CanUse(CanUseItem::Slingshot);}),
   });
 
   Exit GerudoTrainingGrounds_MQ_RightSide = Exit("Gerudo Training Grounds MQ Right Side", "Gerudo Training Grounds", "", NO_DAY_NIGHT_CYCLE, {
-    //Events
-    //EventPairing(&WallFairy, []{return WallFairy || CanUse(CanUseItem::Bow);}),
+                  //Events
+                  //EventPairing(&WallFairy, []{return WallFairy || CanUse(CanUseItem::Bow);}),
   }, {
-    //Locations
-    ItemLocationPairing(&GerudoTrainingGrounds_MQ_DinolfosChest, []{return IsAdult;}),
+                  //Locations
+                  ItemLocationPairing(&GerudoTrainingGrounds_MQ_DinolfosChest, []{return IsAdult;}),
   }, {
-    //Exits
-    ExitPairing::Both(&GerudoTrainingGrounds_MQ_Underwater, []{return (Bow || CanUse(CanUseItem::Longshot)) && CanUse(CanUseItem::Hover_Boots);}),
+                  //Exits
+                  ExitPairing::Both(&GerudoTrainingGrounds_MQ_Underwater, []{return (Bow || CanUse(CanUseItem::Longshot)) && CanUse(CanUseItem::Hover_Boots);}),
   });
 
   Exit GerudoTrainingGrounds_MQ_Underwater = Exit("Gerudo Training Grounds MQ Underwater", "Gerudo Training Grounds", "", NO_DAY_NIGHT_CYCLE, {}, {
-    //Locations
-    ItemLocationPairing(&GerudoTrainingGrounds_MQ_UnderwaterSilverRupeeChest, []{return HasFireSource && CanUse(CanUseItem::Iron_Boots) && (LogicFewerTunicRequirements || CanUse(CanUseItem::Zora_Tunic)) && DamageMultiplier.IsNot(DAMAGEMULTIPLIER_OHKO);}),
+                  //Locations
+                  ItemLocationPairing(&GerudoTrainingGrounds_MQ_UnderwaterSilverRupeeChest, []{return HasFireSource && CanUse(CanUseItem::Iron_Boots) && (LogicFewerTunicRequirements || CanUse(CanUseItem::Zora_Tunic)) && DamageMultiplier.IsNot(DAMAGEMULTIPLIER_OHKO);}),
   }, {});
 
   Exit GerudoTrainingGrounds_MQ_LeftSide = Exit("Gerudo Training Grounds MQ Left Side", "Gerudo Training Grounds", "", NO_DAY_NIGHT_CYCLE, {}, {
-    //Locations
-    ItemLocationPairing(&GerudoTrainingGrounds_MQ_FirstIronKnuckleChest, []{return IsAdult || KokiriSword || HasExplosives;}),
+                  //Locations
+                  ItemLocationPairing(&GerudoTrainingGrounds_MQ_FirstIronKnuckleChest, []{return IsAdult || KokiriSword || HasExplosives;}),
   }, {
-    //Exits
-    ExitPairing::Both(&GerudoTrainingGrounds_MQ_StalfosRoom, []{return CanUse(CanUseItem::Longshot);}),
-      //Trick: CanUse(CanUseItem::Longshot) || LogicGtgMQWithoutHookshot || (LogicGtgMQWithHookshot && CanUse(CanUseItem::Hookshot))
+                  //Exits
+                  ExitPairing::Both(&GerudoTrainingGrounds_MQ_StalfosRoom, []{return CanUse(CanUseItem::Longshot);}),
+                    //Trick: CanUse(CanUseItem::Longshot) || LogicGtgMQWithoutHookshot || (LogicGtgMQWithHookshot && CanUse(CanUseItem::Hookshot))
   });
 
   Exit GerudoTrainingGrounds_MQ_StalfosRoom = Exit("Gerudo Training Grounds MQ Stalfos Room", "Gerudo Training Grounds", "", NO_DAY_NIGHT_CYCLE, {
-    //Events
-    EventPairing(&BlueFireAccess,  []{return BlueFireAccess || HasBottle;}),
+                  //Events
+                  EventPairing(&BlueFireAccess,  []{return BlueFireAccess || HasBottle;}),
   }, {
-    //Locations
-    ItemLocationPairing(&GerudoTrainingGrounds_MQ_BeforeHeavyBlockChest, []{return IsAdult;}),
-    ItemLocationPairing(&GerudoTrainingGrounds_MQ_HeavyBlockChest,       []{return CanUse(CanUseItem::Silver_Gauntlets);}),
+                  //Locations
+                  ItemLocationPairing(&GerudoTrainingGrounds_MQ_BeforeHeavyBlockChest, []{return IsAdult;}),
+                  ItemLocationPairing(&GerudoTrainingGrounds_MQ_HeavyBlockChest,       []{return CanUse(CanUseItem::Silver_Gauntlets);}),
   }, {
-    //Exits
-    ExitPairing::Both(&GerudoTrainingGrounds_MQ_BackAreas, []{return IsAdult && (LogicLensGtgMQ || CanUse(CanUseItem::Lens_of_Truth)) && BlueFire && CanPlay(SongOfTime);}),
-      //Trick: IsAdult && (LogicLensGtgMQ || CanUse(CanUseItem::Lens_of_Truth)) && BlueFire && (CanPlay(SongOfTime) || (LogicGtgFakeWall && CanUse(CanUseItem::Hover_Boots)))
+                  //Exits
+                  ExitPairing::Both(&GerudoTrainingGrounds_MQ_BackAreas, []{return IsAdult && (LogicLensGtgMQ || CanUse(CanUseItem::Lens_of_Truth)) && BlueFire && CanPlay(SongOfTime);}),
+                    //Trick: IsAdult && (LogicLensGtgMQ || CanUse(CanUseItem::Lens_of_Truth)) && BlueFire && (CanPlay(SongOfTime) || (LogicGtgFakeWall && CanUse(CanUseItem::Hover_Boots)))
   });
 
   Exit GerudoTrainingGrounds_MQ_BackAreas = Exit("Gerudo Training Grounds MQ Back Areas", "Gerudo Training Grounds", "", NO_DAY_NIGHT_CYCLE, {}, {
-    //Locations
-    ItemLocationPairing(&GerudoTrainingGrounds_MQ_EyeStatueChest,         []{return Bow;}),
-    ItemLocationPairing(&GerudoTrainingGrounds_MQ_SecondIronKnuckleChest, []{return true;}),
-    ItemLocationPairing(&GerudoTrainingGrounds_MQ_FlameCircleChest,       []{return CanUse(CanUseItem::Hookshot) || Bow || HasExplosives;}),
+                  //Locations
+                  ItemLocationPairing(&GerudoTrainingGrounds_MQ_EyeStatueChest,         []{return Bow;}),
+                  ItemLocationPairing(&GerudoTrainingGrounds_MQ_SecondIronKnuckleChest, []{return true;}),
+                  ItemLocationPairing(&GerudoTrainingGrounds_MQ_FlameCircleChest,       []{return CanUse(CanUseItem::Hookshot) || Bow || HasExplosives;}),
   }, {
-    //Exits
-    ExitPairing::Both(&GerudoTrainingGrounds_MQ_CentralMazeRight, []{return Hammer;}),
-    ExitPairing::Both(&GerudoTrainingGrounds_MQ_RightSide,        []{return CanUse(CanUseItem::Longshot);}),
+                  //Exits
+                  ExitPairing::Both(&GerudoTrainingGrounds_MQ_CentralMazeRight, []{return Hammer;}),
+                  ExitPairing::Both(&GerudoTrainingGrounds_MQ_RightSide,        []{return CanUse(CanUseItem::Longshot);}),
   });
 
   Exit GerudoTrainingGrounds_MQ_CentralMazeRight = Exit("Gerudo Training Grounds MQ Central Maze Right", "Gerudo Training Grounds", "", NO_DAY_NIGHT_CYCLE, {}, {
-    //Locations
-    ItemLocationPairing(&GerudoTrainingGrounds_MQ_MazeRightCentralChest, []{return true;}),
-    ItemLocationPairing(&GerudoTrainingGrounds_MQ_MazeRightSideChest,    []{return true;}),
-    ItemLocationPairing(&GerudoTrainingGrounds_MQ_IceArrowsChest,        []{return SmallKeys(GerudoTrainingGroundsKeys, 3);}),
+                  //Locations
+                  ItemLocationPairing(&GerudoTrainingGrounds_MQ_MazeRightCentralChest, []{return true;}),
+                  ItemLocationPairing(&GerudoTrainingGrounds_MQ_MazeRightSideChest,    []{return true;}),
+                  ItemLocationPairing(&GerudoTrainingGrounds_MQ_IceArrowsChest,        []{return SmallKeys(GerudoTrainingGroundsKeys, 3);}),
   }, {
-    //Exits
-    ExitPairing::Both(&GerudoTrainingGrounds_MQ_Underwater, []{return CanUse(CanUseItem::Longshot) || (CanUse(CanUseItem::Hookshot) && Bow);}),
-    ExitPairing::Both(&GerudoTrainingGrounds_MQ_RightSide,  []{return CanUse(CanUseItem::Hookshot);}),
+                  //Exits
+                  ExitPairing::Both(&GerudoTrainingGrounds_MQ_Underwater, []{return CanUse(CanUseItem::Longshot) || (CanUse(CanUseItem::Hookshot) && Bow);}),
+                  ExitPairing::Both(&GerudoTrainingGrounds_MQ_RightSide,  []{return CanUse(CanUseItem::Hookshot);}),
   });
 
   Exit GanonsCastle_MQ_Lobby = Exit("Ganon's Castle MQ Lobby", "Ganons Castle", "", NO_DAY_NIGHT_CYCLE, {}, {}, {
-    //Exits
-    ExitPairing::Both(&OGC_Grounds,                 []{return true;}),
-    ExitPairing::Both(&GanonsCastle_MQ_ForestTrial, []{return true;}),
-    ExitPairing::Both(&GanonsCastle_MQ_FireTrial,   []{return true;}),
-    ExitPairing::Both(&GanonsCastle_MQ_WaterTrial,  []{return true;}),
-    ExitPairing::Both(&GanonsCastle_MQ_ShadowTrial, []{return true;}),
-    ExitPairing::Both(&GanonsCastle_MQ_SpiritTrial, []{return true;}),
-    ExitPairing::Both(&GanonsCastle_MQ_LightTrial,  []{return CanUse(CanUseItem::Golden_Gauntlets);}),
-    ExitPairing::Both(&GanonsCastle_Tower,          []{return (ForestTrialClear || ForestTrialSkip) &&
-                                                              (FireTrialClear   || FireTrialSkip)   &&
-                                                              (WaterTrialClear  || WaterTrialSkip)  &&
-                                                              (ShadowTrialClear || ShadowTrialSkip) &&
-                                                              (SpiritTrialClear || SpiritTrialSkip) &&
-                                                              (LightTrialClear  || LightTrialSkip);}),
-    ExitPairing::Both(&GanonsCastle_MQ_DekuScrubs,  []{return LogicLensCastleMQ || CanUse(CanUseItem::Lens_of_Truth);}),
+                  //Exits
+                  ExitPairing::Both(&OGC_Grounds,                 []{return true;}),
+                  ExitPairing::Both(&GanonsCastle_MQ_ForestTrial, []{return true;}),
+                  ExitPairing::Both(&GanonsCastle_MQ_FireTrial,   []{return true;}),
+                  ExitPairing::Both(&GanonsCastle_MQ_WaterTrial,  []{return true;}),
+                  ExitPairing::Both(&GanonsCastle_MQ_ShadowTrial, []{return true;}),
+                  ExitPairing::Both(&GanonsCastle_MQ_SpiritTrial, []{return true;}),
+                  ExitPairing::Both(&GanonsCastle_MQ_LightTrial,  []{return CanUse(CanUseItem::Golden_Gauntlets);}),
+                  ExitPairing::Both(&GanonsCastle_Tower,          []{return (ForestTrialClear || ForestTrialSkip) &&
+                                                                            (FireTrialClear   || FireTrialSkip)   &&
+                                                                            (WaterTrialClear  || WaterTrialSkip)  &&
+                                                                            (ShadowTrialClear || ShadowTrialSkip) &&
+                                                                            (SpiritTrialClear || SpiritTrialSkip) &&
+                                                                            (LightTrialClear  || LightTrialSkip);}),
+                  ExitPairing::Both(&GanonsCastle_MQ_DekuScrubs,  []{return LogicLensCastleMQ || CanUse(CanUseItem::Lens_of_Truth);}),
   });
 
   Exit GanonsCastle_MQ_DekuScrubs = Exit("Ganon's Castle MQ Deku Scrubs", "Ganon's Castle", "", NO_DAY_NIGHT_CYCLE, {
-    //Events
-    EventPairing(&FreeFairies, []{return true;}),
+                  //Events
+                  EventPairing(&FreeFairies, []{return true;}),
   }, {
-    //Locations
-    ItemLocationPairing(&GanonsCastle_MQ_DekuScrubCenterLeft,  []{return true;}),
-    ItemLocationPairing(&GanonsCastle_MQ_DekuScrubCenter,      []{return true;}),
-    ItemLocationPairing(&GanonsCastle_MQ_DekuScrubCenterRight, []{return true;}),
-    ItemLocationPairing(&GanonsCastle_MQ_DekuScrubLeft,        []{return true;}),
-    ItemLocationPairing(&GanonsCastle_MQ_DekuScrubRight,       []{return true;}),
+                  //Locations
+                  ItemLocationPairing(&GanonsCastle_MQ_DekuScrubCenterLeft,  []{return true;}),
+                  ItemLocationPairing(&GanonsCastle_MQ_DekuScrubCenter,      []{return true;}),
+                  ItemLocationPairing(&GanonsCastle_MQ_DekuScrubCenterRight, []{return true;}),
+                  ItemLocationPairing(&GanonsCastle_MQ_DekuScrubLeft,        []{return true;}),
+                  ItemLocationPairing(&GanonsCastle_MQ_DekuScrubRight,       []{return true;}),
   }, {});
 
   Exit GanonsCastle_MQ_ForestTrial = Exit("Ganon's Castle MQ Forest Trial", "Ganons Castle", "", NO_DAY_NIGHT_CYCLE, {
-    //Events
-    EventPairing(&ForestTrialClear, []{return CanUse(CanUseItem::Light_Arrows) && CanPlay(SongOfTime);}),
+                  //Events
+                  EventPairing(&ForestTrialClear, []{return CanUse(CanUseItem::Light_Arrows) && CanPlay(SongOfTime);}),
   }, {
-    //Locations
-    ItemLocationPairing(&GanonsCastle_MQ_ForestTrialEyeSwitchChest,       []{return Bow;}),
-    ItemLocationPairing(&GanonsCastle_MQ_ForestTrialFrozenEyeSwitchChest, []{return HasFireSource;}),
-    ItemLocationPairing(&GanonsCastle_MQ_ForestTrialFreestandingKey,      []{return Hookshot;}),
+                  //Locations
+                  ItemLocationPairing(&GanonsCastle_MQ_ForestTrialEyeSwitchChest,       []{return Bow;}),
+                  ItemLocationPairing(&GanonsCastle_MQ_ForestTrialFrozenEyeSwitchChest, []{return HasFireSource;}),
+                  ItemLocationPairing(&GanonsCastle_MQ_ForestTrialFreestandingKey,      []{return Hookshot;}),
   }, {});
 
   Exit GanonsCastle_MQ_FireTrial = Exit("Ganon's Castle MQ Fire Trial", "Ganons Castle", "", NO_DAY_NIGHT_CYCLE, {
-    //Events
-    EventPairing(&FireTrialClear, []{return CanUse(CanUseItem::Goron_Tunic) && CanUse(CanUseItem::Golden_Gauntlets) && CanUse(CanUseItem::Light_Arrows) && (CanUse(CanUseItem::Longshot) || HoverBoots);}),
-      //Trick: CanUse(CanUseItem::Goron_Tunic) && CanUse(CanUseItem::Golden_Gauntlets) && CanUse(CanUseItem::Light_Arrows) && (CanUse(CanUseItem::Longshot) || HoverBoots || (LogicFireTrialMQ && CanUse(CanUseItem::Hookshot)))
+                  //Events
+                  EventPairing(&FireTrialClear, []{return CanUse(CanUseItem::Goron_Tunic) && CanUse(CanUseItem::Golden_Gauntlets) && CanUse(CanUseItem::Light_Arrows) && (CanUse(CanUseItem::Longshot) || HoverBoots);}),
+                    //Trick: CanUse(CanUseItem::Goron_Tunic) && CanUse(CanUseItem::Golden_Gauntlets) && CanUse(CanUseItem::Light_Arrows) && (CanUse(CanUseItem::Longshot) || HoverBoots || (LogicFireTrialMQ && CanUse(CanUseItem::Hookshot)))
   }, {}, {});
 
   Exit GanonsCastle_MQ_WaterTrial = Exit("Ganon's Castle MQ Water Trial", "Ganons Castle", "", NO_DAY_NIGHT_CYCLE, {
-    //Events
-    EventPairing(&WaterTrialClear, []{return BlueFire && CanUse(CanUseItem::Light_Arrows) && SmallKeys(GanonsCastleKeys, 3);}),
-    EventPairing(&BlueFireAccess,  []{return BlueFireAccess || HasBottle;}),
+                  //Events
+                  EventPairing(&WaterTrialClear, []{return BlueFire && CanUse(CanUseItem::Light_Arrows) && SmallKeys(GanonsCastleKeys, 3);}),
+                  EventPairing(&BlueFireAccess,  []{return BlueFireAccess || HasBottle;}),
   }, {
-    //Locations
-    ItemLocationPairing(&GanonsCastle_MQ_WaterTrialChest, []{return BlueFire;}),
+                  //Locations
+                  ItemLocationPairing(&GanonsCastle_MQ_WaterTrialChest, []{return BlueFire;}),
   }, {});
 
   Exit GanonsCastle_MQ_ShadowTrial = Exit("Ganon's Castle MQ Shadow Trial", "Ganons Castle", "", NO_DAY_NIGHT_CYCLE, {
-    //Events
-    EventPairing(&ShadowTrialClear, []{return CanUse(CanUseItem::Light_Arrows) && (LogicLensCastleMQ || CanUse(CanUseItem::Lens_of_Truth)) && (HoverBoots || (Hookshot && HasFireSource));}),
-      //Trick: CanUse(CanUseItem::Light_Arrows) && (LogicLensCastleMQ || CanUse(CanUseItem::Lens_of_Truth)) && (HoverBoots || (Hookshot && (HasFireSource || LogicShadowTrialMQ)))
+                  //Events
+                  EventPairing(&ShadowTrialClear, []{return CanUse(CanUseItem::Light_Arrows) && (LogicLensCastleMQ || CanUse(CanUseItem::Lens_of_Truth)) && (HoverBoots || (Hookshot && HasFireSource));}),
+                    //Trick: CanUse(CanUseItem::Light_Arrows) && (LogicLensCastleMQ || CanUse(CanUseItem::Lens_of_Truth)) && (HoverBoots || (Hookshot && (HasFireSource || LogicShadowTrialMQ)))
   }, {
-    //Locations
-    ItemLocationPairing(&GanonsCastle_MQ_ShadowTrialBombFlowerChest, []{return (Bow && (Hookshot || HoverBoots)) || (HoverBoots && (LogicLensCastleMQ || CanUse(CanUseItem::Lens_of_Truth)) && (HasExplosives || GoronBracelet || CanUse(CanUseItem::Dins_Fire)));}),
-    ItemLocationPairing(&GanonsCastle_MQ_ShadowTrialEyeSwitchChest,  []{return Bow && (LogicLensCastleMQ || CanUse(CanUseItem::Lens_of_Truth)) && (HoverBoots || (Hookshot && HasFireSource));}),
-      //Trick: Bow && (LogicLensCastleMQ || CanUse(CanUseItem::Lens_of_Truth)) && (HoverBoots || (Hookshot && (HasFireSource || LogicShadowTrialMQ)))
+                  //Locations
+                  ItemLocationPairing(&GanonsCastle_MQ_ShadowTrialBombFlowerChest, []{return (Bow && (Hookshot || HoverBoots)) || (HoverBoots && (LogicLensCastleMQ || CanUse(CanUseItem::Lens_of_Truth)) && (HasExplosives || GoronBracelet || CanUse(CanUseItem::Dins_Fire)));}),
+                  ItemLocationPairing(&GanonsCastle_MQ_ShadowTrialEyeSwitchChest,  []{return Bow && (LogicLensCastleMQ || CanUse(CanUseItem::Lens_of_Truth)) && (HoverBoots || (Hookshot && HasFireSource));}),
+                    //Trick: Bow && (LogicLensCastleMQ || CanUse(CanUseItem::Lens_of_Truth)) && (HoverBoots || (Hookshot && (HasFireSource || LogicShadowTrialMQ)))
   }, {});
 
   Exit GanonsCastle_MQ_SpiritTrial = Exit("Ganon's Castle MQ Spirit Castle", "Ganons Castle", "", NO_DAY_NIGHT_CYCLE, {
-    //Events
-    EventPairing(&SpiritTrialClear, []{return CanUse(CanUseItem::Light_Arrows) && Hammer && HasBombchus && FireArrows && MirrorShield;}),
-    EventPairing(&NutPot,           []{return NutPot || (Hammer && HasBombchus && CanUse(CanUseItem::Fire_Arrows) && MirrorShield);}),
+                  //Events
+                  EventPairing(&SpiritTrialClear, []{return CanUse(CanUseItem::Light_Arrows) && Hammer && HasBombchus && FireArrows && MirrorShield;}),
+                  EventPairing(&NutPot,           []{return NutPot || (Hammer && HasBombchus && CanUse(CanUseItem::Fire_Arrows) && MirrorShield);}),
   }, {
-    //Locations
-    ItemLocationPairing(&GanonsCastle_MQ_SpiritTrialFirstChest,           []{return Bow && Hammer;}),
-    ItemLocationPairing(&GanonsCastle_MQ_SpiritTrialInvisibleChest,       []{return Bow && Hammer && HasBombchus && (LogicLensCastleMQ || CanUse(CanUseItem::Lens_of_Truth));}),
-    ItemLocationPairing(&GanonsCastle_MQ_SpiritTrialSunFrontLeftChest,    []{return Hammer && HasBombchus && CanUse(CanUseItem::Fire_Arrows) && MirrorShield;}),
-    ItemLocationPairing(&GanonsCastle_MQ_SpiritTrialSunBackLeftChest,     []{return Hammer && HasBombchus && CanUse(CanUseItem::Fire_Arrows) && MirrorShield;}),
-    ItemLocationPairing(&GanonsCastle_MQ_SpiritTrialGoldenGauntletsChest, []{return Hammer && HasBombchus && CanUse(CanUseItem::Fire_Arrows) && MirrorShield;}),
-    ItemLocationPairing(&GanonsCastle_MQ_SpiritTrialSunBackRightChest,    []{return Hammer && HasBombchus && CanUse(CanUseItem::Fire_Arrows) && MirrorShield;}),
+                  //Locations
+                  ItemLocationPairing(&GanonsCastle_MQ_SpiritTrialFirstChest,           []{return Bow && Hammer;}),
+                  ItemLocationPairing(&GanonsCastle_MQ_SpiritTrialInvisibleChest,       []{return Bow && Hammer && HasBombchus && (LogicLensCastleMQ || CanUse(CanUseItem::Lens_of_Truth));}),
+                  ItemLocationPairing(&GanonsCastle_MQ_SpiritTrialSunFrontLeftChest,    []{return Hammer && HasBombchus && CanUse(CanUseItem::Fire_Arrows) && MirrorShield;}),
+                  ItemLocationPairing(&GanonsCastle_MQ_SpiritTrialSunBackLeftChest,     []{return Hammer && HasBombchus && CanUse(CanUseItem::Fire_Arrows) && MirrorShield;}),
+                  ItemLocationPairing(&GanonsCastle_MQ_SpiritTrialGoldenGauntletsChest, []{return Hammer && HasBombchus && CanUse(CanUseItem::Fire_Arrows) && MirrorShield;}),
+                  ItemLocationPairing(&GanonsCastle_MQ_SpiritTrialSunBackRightChest,    []{return Hammer && HasBombchus && CanUse(CanUseItem::Fire_Arrows) && MirrorShield;}),
   }, {});
 
   Exit GanonsCastle_MQ_LightTrial = Exit("Ganon's Castle MQ Light Trial", "Ganons Castle", "", NO_DAY_NIGHT_CYCLE, {
-    //Events
-    EventPairing(&LightTrialClear, []{return CanUse(CanUseItem::Light_Arrows) && SmallKeys(GanonsCastleKeys, 3) && (LogicLensCastleMQ || CanUse(CanUseItem::Lens_of_Truth)) && Hookshot;}),
-      //Trick: CanUse(CanUseItem::Light_Arrows) && SmallKeys(GanonsCastleKeys, 3) && (LogicLensCastleMQ || CanUse(CanUseItem::Lens_of_Truth)) && (Hookshot || LogicLightTrialMQ)
+                  //Events
+                  EventPairing(&LightTrialClear, []{return CanUse(CanUseItem::Light_Arrows) && SmallKeys(GanonsCastleKeys, 3) && (LogicLensCastleMQ || CanUse(CanUseItem::Lens_of_Truth)) && Hookshot;}),
+                    //Trick: CanUse(CanUseItem::Light_Arrows) && SmallKeys(GanonsCastleKeys, 3) && (LogicLensCastleMQ || CanUse(CanUseItem::Lens_of_Truth)) && (Hookshot || LogicLightTrialMQ)
   }, {
-    //Locations
-    ItemLocationPairing(&GanonsCastle_MQ_LightTrialLullabyChest, []{return CanPlay(ZeldasLullaby);}),
+                  //Locations
+                  ItemLocationPairing(&GanonsCastle_MQ_LightTrialLullabyChest, []{return CanPlay(ZeldasLullaby);}),
   }, {});
 
   /*

--- a/source/location_access.cpp
+++ b/source/location_access.cpp
@@ -1696,7 +1696,8 @@ namespace Exits { //name, scene, hint, events, locations, exits
 
   Exit DodongosCavern_BossArea = Exit("Dodongos Cavern Boss Area", "Dodongos Cavern", "", NO_DAY_NIGHT_CYCLE, {
                   //Events
-                  EventPairing(&FairyPot, []{return true;}),
+                  EventPairing(&FairyPot,            []{return true;}),
+                  EventPairing(&DodongosCavernClear, []{return DodongosCavernClear || ((Bombs || GoronBracelet) && (IsAdult || Sticks || KokiriSword));})
                 }, {
                   //Locations
                   ItemLocationPairing(&DodongosCavern_BossRoomChest,    []{return true;}),
@@ -1743,7 +1744,8 @@ namespace Exits { //name, scene, hint, events, locations, exits
 
   Exit JabuJabusBelly_BossArea = Exit("Jabu Jabus Belly Boss Area", "Jabu Jabus Belly", "", NO_DAY_NIGHT_CYCLE, {
                   //Events
-                  EventPairing(&NutPot, []{return true;}),
+                  EventPairing(&NutPot,              []{return true;}),
+                  EventPairing(&JabuJabusBellyClear, []{return JabuJabusBellyClear || CanUse(CanUseItem::Boomerang);}),
                 }, {
                   //Locations
                   ItemLocationPairing(&JabuJabusBelly_BarinadeHeart, []{return CanUse(CanUseItem::Boomerang);}),
@@ -1857,7 +1859,10 @@ namespace Exits { //name, scene, hint, events, locations, exits
                   ExitPairing::Both(&ForestTemple_FallingRoom, []{return SmallKeys(ForestTempleKeys, 5) && (Bow || CanUse(CanUseItem::Dins_Fire));})
   });
 
-  Exit ForestTemple_BossRegion = Exit("Forest Temple Boss Region", "Forest Temple", "", NO_DAY_NIGHT_CYCLE, {}, {
+  Exit ForestTemple_BossRegion = Exit("Forest Temple Boss Region", "Forest Temple", "", NO_DAY_NIGHT_CYCLE, {
+                  //Events
+                  EventPairing(&ForestTempleClear, []{return ForestTempleClear || (BossKeyForestTemple);}),
+  }, {
                   //Locations
                   ItemLocationPairing(&ForestTemple_BasementChest,     []{return true;}),
                   ItemLocationPairing(&ForestTemple_PhantomGanonHeart, []{return BossKeyForestTemple;}),
@@ -1868,7 +1873,10 @@ namespace Exits { //name, scene, hint, events, locations, exits
   //Fire Temple logic currently assumes that the lowest locked door is unlocked from the start
   Exit FireTemple_Lower = Exit("Fire Temple Lower", "Fire Temple", "", NO_DAY_NIGHT_CYCLE, {
                   //Events
-                  EventPairing(&FairyPot, []{return FairyPot || ((CanUse(CanUseItem::Hover_Boots) || CanUse(CanUseItem::Hookshot)) && (LogicFewerTunicRequirements || CanUse(CanUseItem::Goron_Tunic)));}),
+                  EventPairing(&FairyPot,        []{return FairyPot || ((CanUse(CanUseItem::Hover_Boots) || CanUse(CanUseItem::Hookshot)) && (LogicFewerTunicRequirements || CanUse(CanUseItem::Goron_Tunic)));}),
+                  EventPairing(&FireTempleClear, []{return FireTempleClear || (CanUse(CanUseItem::Goron_Tunic) && CanUse(CanUseItem::Hammer) && BossKeyFireTemple &&
+                                                                                (LogicFireBossDoorJump || HoverBoots ||
+                                                                                  (FireTemple_Upper.Adult() && (CanPlay(SongOfTime) || HasExplosives))));})
                 }, {
                   //Locations
                   ItemLocationPairing(&FireTemple_NearBossChest,    []{return LogicFewerTunicRequirements || CanUse(CanUseItem::Goron_Tunic);}),
@@ -1935,8 +1943,8 @@ namespace Exits { //name, scene, hint, events, locations, exits
 
   Exit WaterTemple_HighestWaterLevel = Exit("Water Temple Highest Water Level", "Water Temple", "", NO_DAY_NIGHT_CYCLE, {
                   //Events
-                  EventPairing(&FairyPot,         []{return FairyPot           || CanUse(CanUseItem::Longshot);}),
-                  EventPairing(&WaterTempleClear, []{return BossKeyWaterTemple && CanUse(CanUseItem::Longshot);})
+                  EventPairing(&FairyPot,         []{return FairyPot         || CanUse(CanUseItem::Longshot);}),
+                  EventPairing(&WaterTempleClear, []{return WaterTempleClear || (BossKeyWaterTemple && CanUse(CanUseItem::Longshot));})
                 }, {
                   //Locations
                   ItemLocationPairing(&Morpha,                  []{return BossKeyWaterTemple && CanUse(CanUseItem::Longshot);}),
@@ -2099,7 +2107,10 @@ namespace Exits { //name, scene, hint, events, locations, exits
                   ExitPairing::Both(&SpiritTemple_BeyondFinalLockedDoor, []{return SmallKeys(SpiritTempleKeys, 5) && (LogicSpiritWall || CanUse(CanUseItem::Longshot) || HasBombchus || ((Bombs || Nuts || CanUse(CanUseItem::Dins_Fire)) && (Bow || CanUse(CanUseItem::Hookshot) || Hammer)));}),
   });
 
-  Exit SpiritTemple_BeyondFinalLockedDoor = Exit("Spirit Temple Beyond Final Locked Door", "Spirit Temple", "", NO_DAY_NIGHT_CYCLE, {}, {
+  Exit SpiritTemple_BeyondFinalLockedDoor = Exit("Spirit Temple Beyond Final Locked Door", "Spirit Temple", "", NO_DAY_NIGHT_CYCLE, {
+                  //Events
+                  EventPairing(&SpiritTempleClear, []{return SpiritTempleClear || (MirrorShield && HasExplosives && Hookshot && BossKeySpiritTemple);}),
+  }, {
                   //Locations
                   ItemLocationPairing(&SpiritTemple_BossKeyChest,  []{return CanPlay(ZeldasLullaby) && Bow && Hookshot;}),
                   ItemLocationPairing(&SpiritTemple_TopmostChest,  []{return MirrorShield;}),
@@ -2166,7 +2177,10 @@ namespace Exits { //name, scene, hint, events, locations, exits
                   ExitPairing::Both(&ShadowTemple_BeyondBoat, []{return CanPlay(ZeldasLullaby) && SmallKeys(ShadowTempleKeys, 4);}),
   });
 
-  Exit ShadowTemple_BeyondBoat = Exit("Shadow Temple Beyond Boat", "Shadow Temple", "", NO_DAY_NIGHT_CYCLE, {}, {
+  Exit ShadowTemple_BeyondBoat = Exit("Shadow Temple Beyond Boat", "Shadow Temple", "", NO_DAY_NIGHT_CYCLE, {
+                  //Events
+                  EventPairing(&ShadowTempleClear, []{return ShadowTempleClear || (SmallKeys(ShadowTempleKeys, 5) && BossKeyShadowTemple && (Bow || CanUse(CanUseItem::Distant_Scarecrow) || (LogicShadowStatue && HasBombchus)));}),
+  }, {
                   //Locations
                   ItemLocationPairing(&ShadowTemple_SpikeWallsLeftChest,       []{return CanUse(CanUseItem::Dins_Fire);}),
                   ItemLocationPairing(&ShadowTemple_BossKeyChest,              []{return CanUse(CanUseItem::Dins_Fire);}),
@@ -2531,7 +2545,8 @@ namespace Exits { //name, scene, hint, events, locations, exits
 
   Exit DodongosCavern_MQ_BossArea = Exit("Dodongos Cavern MQ BossArea", "Dodongos Cavern", "", NO_DAY_NIGHT_CYCLE, {
     //Events
-    EventPairing(&FairyPot, []{return true;}),
+    EventPairing(&FairyPot,            []{return true;}),
+    EventPairing(&DodongosCavernClear, []{return DodongosCavernClear || (CanBlastOrSmash && (Bombs || GoronBracelet) && (IsAdult || Sticks || KokiriSword));}),
   }, {
     //Locations
     ItemLocationPairing(&DodongosCavern_MQ_UnderGraveChest, []{return true;}),
@@ -2584,7 +2599,8 @@ namespace Exits { //name, scene, hint, events, locations, exits
 
   Exit JabuJabusBelly_MQ_BossArea = Exit("Jabu Jabus Belly MQ Boss Area", "Jabu Jabus Belly", "", NO_DAY_NIGHT_CYCLE, {
     //Events
-    EventPairing(&FairyPot, []{return true;}),
+    EventPairing(&FairyPot,            []{return true;}),
+    EventPairing(&JabuJabusBellyClear, []{return true;}),
   }, {
     //Locations
     ItemLocationPairing(&JabuJabusBelly_MQ_Cow,           []{return CanPlay(EponasSong);}),
@@ -2712,7 +2728,10 @@ namespace Exits { //name, scene, hint, events, locations, exits
     ExitPairing::Both(&ForestTemple_MQ_NEOutdoorsLedge, []{return true;}),
   });
 
-  Exit ForestTemple_MQ_BossRegion = Exit("Forest Temple MQ Boss Region", "Forest Temple", "", NO_DAY_NIGHT_CYCLE, {}, {
+  Exit ForestTemple_MQ_BossRegion = Exit("Forest Temple MQ Boss Region", "Forest Temple", "", NO_DAY_NIGHT_CYCLE, {
+    //Events
+    EventPairing(&ForestTempleClear, []{return ForestTempleClear || BossKeyForestTemple;}),
+  }, {
     //Locations
     ItemLocationPairing(&ForestTemple_MQ_BasementChest,  []{return true;}),
     ItemLocationPairing(&ForestTemple_PhantomGanonHeart, []{return BossKeyForestTemple;}),
@@ -2796,7 +2815,10 @@ namespace Exits { //name, scene, hint, events, locations, exits
       //Trick: (CanUse(CanUseItem::Hookshot) && SmallKeys(FireTempleKeys, 5)) || (LogicFireMQAboveMazeGS && CanUse(CanUseItem::Longshot))
   }, {});
 
-  Exit FireTemple_MQ_BossRoom = Exit("Fire Temple MQ Boss Room", "Fire Temple", "", NO_DAY_NIGHT_CYCLE, {}, {
+  Exit FireTemple_MQ_BossRoom = Exit("Fire Temple MQ Boss Room", "Fire Temple", "", NO_DAY_NIGHT_CYCLE, {
+    //Events
+    EventPairing(&FireTempleClear, []{return true;}),
+  }, {
     //Locations
     ItemLocationPairing(&FireTemple_VolvagiaHeart, []{return true;}),
     ItemLocationPairing(&Volvagia, []{return true;}),
@@ -2926,7 +2948,10 @@ namespace Exits { //name, scene, hint, events, locations, exits
     ItemLocationPairing(&SpiritTemple_MQ_GS_SymphonyRoom,         []{return SmallKeys(SpiritTempleKeys, 7) && Hammer && Ocarina && SongOfTime && EponasSong && SunsSong && SongOfStorms && ZeldasLullaby;}),
   }, {});
 
-  Exit SpiritTemple_MQ_BossArea = Exit("Spirit Temple MQ Boss Area", "Spirit Temple", "", NO_DAY_NIGHT_CYCLE, {}, {
+  Exit SpiritTemple_MQ_BossArea = Exit("Spirit Temple MQ Boss Area", "Spirit Temple", "", NO_DAY_NIGHT_CYCLE, {
+    //Events
+    EventPairing(&SpiritTempleClear, []{return SpiritTempleClear || (MirrorShield && BossKeySpiritTemple);})
+  }, {
     //Locations
     ItemLocationPairing(&SpiritTemple_MQ_MirrorPuzzleInvisibleChest, []{return LogicLensSpiritMQ || CanUse(CanUseItem::Lens_of_Truth);}),
     ItemLocationPairing(&SpiritTemple_TwinrovaHeart,                 []{return MirrorShield && BossKeySpiritTemple;}),
@@ -3014,7 +3039,10 @@ namespace Exits { //name, scene, hint, events, locations, exits
     ExitPairing::Both(&ShadowTemple_MQ_BeyondBoat, []{return CanPlay(ZeldasLullaby) && SmallKeys(ShadowTempleKeys, 5);}),
   });
 
-  Exit ShadowTemple_MQ_BeyondBoat = Exit("Shadow Temple MQ Beyond Boat", "Shadow Temple", "", NO_DAY_NIGHT_CYCLE, {}, {
+  Exit ShadowTemple_MQ_BeyondBoat = Exit("Shadow Temple MQ Beyond Boat", "Shadow Temple", "", NO_DAY_NIGHT_CYCLE, {
+    //Events
+    EventPairing(&ShadowTempleClear, []{return ShadowTempleClear || ((Bow || (LogicShadowStatue && HasBombchus)) && BossKeyShadowTemple);})
+  }, {
     //Locations
     ItemLocationPairing(&ShadowTemple_BongoBongoHeart, []{return (Bow || (LogicShadowStatue && HasBombchus)) && BossKeyShadowTemple;}),
     ItemLocationPairing(&BongoBongo,                   []{return (Bow || (LogicShadowStatue && HasBombchus)) && BossKeyShadowTemple;}),

--- a/source/logic.cpp
+++ b/source/logic.cpp
@@ -247,6 +247,7 @@ namespace Logic {
   //Bridge and LACS Requirements
   u8 MedallionCount          = 0;
   u8 StoneCount              = 0;
+  u8 DungeonCount            = 0;
   bool HasAllStones          = false;
   bool HasAllMedallions      = false;
   bool CanBuildRainbowBridge = false;
@@ -469,6 +470,7 @@ namespace Logic {
     //Bridge and LACS Requirements
     MedallionCount        = (ForestMedallion ? 1:0) + (FireMedallion ? 1:0) + (WaterMedallion ? 1:0) + (SpiritMedallion ? 1:0) + (ShadowMedallion ? 1:0) + (LightMedallion ? 1:0);
     StoneCount            = (KokiriEmerald ? 1:0) + (GoronRuby ? 1:0) + (ZoraSapphire ? 1:0);
+    DungeonCount          = (DekuTreeClear ? 1:0) + (DodongosCavernClear ? 1:0) + (JabuJabusBellyClear ? 1:0) + (ForestTempleClear ? 1:0) + (FireTempleClear ? 1:0) + (WaterTempleClear ? 1:0) + (SpiritTempleClear ? 1:0) + (ShadowTempleClear ? 1:0);
     HasAllStones          = StoneCount == 3;
     HasAllMedallions      = MedallionCount == 6;
 
@@ -476,13 +478,15 @@ namespace Logic {
                            (Bridge.Is(RAINBOWBRIDGE_VANILLA)    && ShadowMedallion && SpiritMedallion && LightArrows)             ||
                            (Bridge.Is(RAINBOWBRIDGE_STONES)     && StoneCount >= BridgeStoneCount.Value<u8>())                    ||
                            (Bridge.Is(RAINBOWBRIDGE_MEDALLIONS) && MedallionCount >= BridgeMedallionCount.Value<u8>())            ||
-                           (Bridge.Is(RAINBOWBRIDGE_DUNGEONS)   && StoneCount + MedallionCount >= BridgeDungeonCount.Value<u8>()) ||
+                           (Bridge.Is(RAINBOWBRIDGE_REWARDS)    && StoneCount + MedallionCount >= BridgeRewardCount.Value<u8>())  ||
+                           (Bridge.Is(RAINBOWBRIDGE_DUNGEONS)   && DungeonCount >= BridgeDungeonCount.Value<u8>())                ||
                            (Bridge.Is(RAINBOWBRIDGE_TOKENS)     && GoldSkulltulaTokens >= BridgeTokenCount.Value<u8>());
 
     CanTriggerLACS = (LACSCondition == LACSCONDITION_VANILLA    && ShadowMedallion && SpiritMedallion)                          ||
                      (LACSCondition == LACSCONDITION_STONES     && StoneCount >= LACSStoneCount.Value<u8>())                    ||
                      (LACSCondition == LACSCONDITION_MEDALLIONS && MedallionCount >= LACSMedallionCount.Value<u8>())            ||
-                     (LACSCondition == LACSCONDITION_DUNGEONS   && StoneCount + MedallionCount >= LACSDungeonCount.Value<u8>()) ||
+                     (LACSCondition == LACSCONDITION_REWARDS    && StoneCount + MedallionCount >= LACSRewardCount.Value<u8>())  ||
+                     (LACSCondition == LACSCONDITION_DUNGEONS   && DungeonCount >= LACSDungeonCount.Value<u8>())                ||
                      (LACSCondition == LACSCONDITION_TOKENS     && GoldSkulltulaTokens >= LACSTokenCount.Value<u8>());
 
   }
@@ -521,7 +525,7 @@ namespace Logic {
      return false;
    }
 
-   //Reset All Logic to true or false
+   //Reset All Logic to false
    void LogicReset() {
      //Child item logic
      KokiriSword   = false;

--- a/source/setting_descriptions.cpp
+++ b/source/setting_descriptions.cpp
@@ -72,8 +72,13 @@ string_view bridgeStones              = "The Rainbow Bridge requires collecting 
                                         "configurable number of Spiritual Stones.";        //
 string_view bridgeMedallions          = "The Rainbow Bridge requires collecting a\n"       //
                                         "configurable number of Medallions.";              //
-string_view bridgeDungeons            = "The Rainbow Bridge requires collecting a\n"       //
+string_view bridgeRewards             = "The Rainbow Bridge requires collecting a\n"       //
                                         "configurable number of Dungeon Rewards.";         //
+string_view bridgeDungeons            = "The Rainbow Bridge requires completing a\n"       //
+                                        "configurable number of Dungeons.\n"               //
+                                        "\n"                                               //
+                                        "Dungeons are considered complete when Link steps\n"
+                                        "into the blue warp at the end of them.";          //
 string_view bridgeTokens              = "The Rainbow Bridge requires collecting a\n"       //
                                         "configurable number of Gold Skulltula Tokens.";   //
 /*------------------------------                                                           //
@@ -83,9 +88,11 @@ string_view bridgeStoneCountDesc      = "Set the number of Spiritual Stones requ
                                         "spawn the Rainbow Bridge.";                       //
 string_view bridgeMedallionCountDesc  = "Set the number of Medallions required to spawn the"
                                         "Rainbow Bridge.";                                 //
-string_view bridgeDungeonCountDesc    = "Set the number of Dungeon Rewards (Spiritual\n"   //
+string_view bridgeRewardCountDesc     = "Set the number of Dungeon Rewards (Spiritual\n"   //
                                         "Stones and Medallions) required to spawn the\n"   //
                                         "Rainbow Bridge.";                                 //
+string_view bridgeDungeonCountDesc    = "Set the number of completed dungeons required to\n"
+                                        "spawn the Rainbow Bridge.";                       //
 string_view bridgeTokenCountDesc      = "Set the number of Gold Skulltula Tokens required\n"
                                         "to spawn the Rainbow Bridge.";                    //
 /*------------------------------                                                           //
@@ -343,9 +350,14 @@ string_view lacsMedallionCountDesc    = "Set the number of Medallions required t
                                         "the Light Arrow Cutscene.";                       //
 string_view lacsStoneCountDesc        = "Set the number of Spiritual Stones required to\n" //
                                         "trigger the Light Arrow Cutscene.";               //
-string_view lacsDungeonCountDesc      = "Set the number of Dungeon Rewards (Spiritual\n"   //
+string_view lacsRewardCountDesc       = "Set the number of Dungeon Rewards (Spiritual\n"   //
                                         "Stones and Medallions) required to trigger the\n" //
                                         "Light Arrow Cutscene.";                           //
+string_view lacsDungeonCountDesc      = "Set the number of completed dungeons required to\n"
+                                        "trigger the Light Arrow Cutscene.\n"              //
+                                        "\n"                                               //
+                                        "Dungeons are considered complete when Link steps\n"
+                                        "into the blue warp at the end of them.";          //
 string_view lacsTokenCountDesc        = "Set the number of Gold Skulltula Tokens required\n"
                                         "to trigger the Light Arrow Cutscene.";            //
 /*------------------------------                                                           //

--- a/source/setting_descriptions.hpp
+++ b/source/setting_descriptions.hpp
@@ -26,11 +26,13 @@ extern string_view bridgeOpen;
 extern string_view bridgeVanilla;
 extern string_view bridgeStones;
 extern string_view bridgeMedallions;
+extern string_view bridgeRewards;
 extern string_view bridgeDungeons;
 extern string_view bridgeTokens;
 
 extern string_view bridgeStoneCountDesc;
 extern string_view bridgeMedallionCountDesc;
+extern string_view bridgeRewardCountDesc;
 extern string_view bridgeDungeonCountDesc;
 extern string_view bridgeTokenCountDesc;
 
@@ -122,6 +124,7 @@ extern string_view ganonKeyLACS;
 
 extern string_view lacsMedallionCountDesc;
 extern string_view lacsStoneCountDesc;
+extern string_view lacsRewardCountDesc;
 extern string_view lacsDungeonCountDesc;
 extern string_view lacsTokenCountDesc;
 

--- a/source/settings.cpp
+++ b/source/settings.cpp
@@ -17,21 +17,22 @@ namespace Settings {
   std::string version = RANDOMIZER_VERSION "-COMMITNUM";
   std::array<u8, 5> hashIconIndexes;
 
-  //                                        Setting name,              Options,                                                          Setting Descriptions (assigned in setting_descriptions.cpp)
-  //Open Settings                                                                                                                        Any option index past the last description will use the last description
-  Option Logic               = Option::U8  ("Logic",                  {"Glitchless", "No Logic"},                                        {logicGlitchless, logicNoLogic});
-  Option OpenForest          = Option::U8  ("Forest",                 {"Closed", "Open"},                                                {forestClosed, forestOpen});
-  Option OpenKakariko        = Option::U8  ("Kakariko Gate",          {"Closed", "Open"},                                                {kakGateClosed, kakGateOpen});
-  Option OpenDoorOfTime      = Option::Bool("Door of Time",           {"Closed", "Open"},                                                {doorOfTimeDesc});
-  Option ZorasFountain       = Option::U8  ("Zora's Fountain",        {"Normal", "Adult", "Open"},                                       {fountainNormal, fountainAdult, fountainOpen});
-  Option GerudoFortress      = Option::U8  ("Gerudo Fortress",        {"Normal", "Fast", "Open"},                                        {gerudoNormal, gerudoFast, gerudoOpen});
-  Option Bridge              = Option::U8  ("Rainbow Bridge",         {"Open", "Vanilla", "Stones", "Medallions", "Dungeons", "Tokens"}, {bridgeOpen, bridgeVanilla, bridgeStones, bridgeMedallions, bridgeDungeons, bridgeTokens});
-  Option BridgeStoneCount    = Option::U8  ("  Stone Count",          {"0", "1", "2", "3"},                                              {bridgeStoneCountDesc});
-  Option BridgeMedallionCount= Option::U8  ("  Medallion Count",      {"0", "1", "2", "3", "4", "5", "6"},                               {bridgeMedallionCountDesc});
-  Option BridgeDungeonCount  = Option::U8  ("  Dungeon Count",        {"0", "1", "2", "3", "4", "5", "6", "7", "8", "9"},                {bridgeDungeonCountDesc});
-  Option BridgeTokenCount    = Option::U8  ("  Token Count",          {/*Options 0-100 defined in SetDefaultSettings()*/},               {bridgeTokenCountDesc});
-  Option RandomGanonsTrials  = Option::Bool("Random Ganon's Trials",  {"Off", "On"},                                                     {randomGanonsTrialsDesc});
-  Option GanonsTrialsCount   = Option::U8  ("  Trial Count",          {"0", "1", "2", "3", "4", "5", "6"},                               {ganonsTrialCountDesc});
+  //                                        Setting name,              Options,                                                                     Setting Descriptions (assigned in setting_descriptions.cpp)
+  //Open Settings                                                                                                                                   Any option index past the last description will use the last description
+  Option Logic               = Option::U8  ("Logic",                  {"Glitchless", "No Logic"},                                                   {logicGlitchless, logicNoLogic});
+  Option OpenForest          = Option::U8  ("Forest",                 {"Closed", "Open"},                                                           {forestClosed, forestOpen});
+  Option OpenKakariko        = Option::U8  ("Kakariko Gate",          {"Closed", "Open"},                                                           {kakGateClosed, kakGateOpen});
+  Option OpenDoorOfTime      = Option::Bool("Door of Time",           {"Closed", "Open"},                                                           {doorOfTimeDesc});
+  Option ZorasFountain       = Option::U8  ("Zora's Fountain",        {"Normal", "Adult", "Open"},                                                  {fountainNormal, fountainAdult, fountainOpen});
+  Option GerudoFortress      = Option::U8  ("Gerudo Fortress",        {"Normal", "Fast", "Open"},                                                   {gerudoNormal, gerudoFast, gerudoOpen});
+  Option Bridge              = Option::U8  ("Rainbow Bridge",         {"Open", "Vanilla", "Stones", "Medallions", "Rewards", "Dungeons", "Tokens"}, {bridgeOpen, bridgeVanilla, bridgeStones, bridgeMedallions, bridgeRewards, bridgeDungeons, bridgeTokens});
+  Option BridgeStoneCount    = Option::U8  ("  Stone Count",          {"0", "1", "2", "3"},                                                         {bridgeStoneCountDesc});
+  Option BridgeMedallionCount= Option::U8  ("  Medallion Count",      {"0", "1", "2", "3", "4", "5", "6"},                                          {bridgeMedallionCountDesc});
+  Option BridgeRewardCount   = Option::U8  ("  Reward Count",         {"0", "1", "2", "3", "4", "5", "6", "7", "8", "9"},                           {bridgeRewardCountDesc});
+  Option BridgeDungeonCount  = Option::U8  ("  Dungeon Count",        {"0", "1", "2", "3", "4", "5", "6", "7", "8"},                                {bridgeDungeonCountDesc});
+  Option BridgeTokenCount    = Option::U8  ("  Token Count",          {/*Options 0-100 defined in SetDefaultSettings()*/},                          {bridgeTokenCountDesc});
+  Option RandomGanonsTrials  = Option::Bool("Random Ganon's Trials",  {"Off", "On"},                                                                {randomGanonsTrialsDesc});
+  Option GanonsTrialsCount   = Option::U8  ("  Trial Count",          {"0", "1", "2", "3", "4", "5", "6"},                                          {ganonsTrialCountDesc});
   std::vector<Option *> openOptions = {
     &Logic,
     &OpenForest,
@@ -42,6 +43,7 @@ namespace Settings {
     &Bridge,
     &BridgeStoneCount,
     &BridgeMedallionCount,
+    &BridgeRewardCount,
     &BridgeDungeonCount,
     &BridgeTokenCount,
     &RandomGanonsTrials,
@@ -100,12 +102,13 @@ namespace Settings {
                                                                       {gerudoKeysVanilla, gerudoKeysAnyDungeon, gerudoKeysOverworld, gerudoKeysAnywhere});
   Option BossKeysanity       = Option::U8  ("Boss Keys",              {"Start With", "Vanilla", "Own Dungeon", "Any Dungeon", "Overworld", "Anywhere"},
                                                                       {bossKeyStartWith, bossKeyVanilla, bossKeyOwnDungeon, bossKeyAnyDungeon, bossKeyOverworld, bossKeyAnywhere});
-  Option GanonsBossKey       = Option::U8  ("Ganon's Boss Key",       {"Start With", "Vanilla", "Own Dungeon", "Any Dungeon", "Overworld", "Anywhere", "LACS-Vanilla", "LACS-Medallions", "LACS-Stones", "LACS-Dungeons", "LACS-Tokens"},
+  Option GanonsBossKey       = Option::U8  ("Ganon's Boss Key",       {"Start With", "Vanilla", "Own Dungeon", "Any Dungeon", "Overworld", "Anywhere", "LACS-Vanilla", "LACS-Medallions", "LACS-Stones", "LACS-Rewards", "LACS-Dungeons", "LACS-Tokens"},
                                                                       {ganonKeyStartWith, ganonKeyVanilla, ganonKeyOwnDungeon, ganonKeyAnywhere, ganonKeyLACS});
   u8 LACSCondition           = 0;
   Option LACSMedallionCount  = Option::U8  ("  Medallion Count",      {"0", "1", "2", "3", "4", "5", "6"},                                    {lacsMedallionCountDesc});
   Option LACSStoneCount      = Option::U8  ("  Stone Count",          {"0", "1", "2", "3"},                                                   {lacsStoneCountDesc});
-  Option LACSDungeonCount    = Option::U8  ("  Dungeon Count",        {"0", "1", "2", "3", "4", "5", "6", "7", "8", "9"},                     {lacsDungeonCountDesc});
+  Option LACSRewardCount     = Option::U8  ("  Reward Count",         {"0", "1", "2", "3", "4", "5", "6", "7", "8", "9"},                     {lacsRewardCountDesc});
+  Option LACSDungeonCount    = Option::U8  ("  Dungeon Count",        {"0", "1", "2", "3", "4", "5", "6", "7", "8"},                          {lacsDungeonCountDesc});
   Option LACSTokenCount      = Option::U8  ("  Token Count",          {/*Options 0-100 defined in SetDefaultSettings()*/},                    {lacsTokenCountDesc});
   std::vector<Option *> shuffleDungeonItemOptions = {
     &MapsAndCompasses,
@@ -115,6 +118,7 @@ namespace Settings {
     &GanonsBossKey,
     &LACSMedallionCount,
     &LACSStoneCount,
+    &LACSRewardCount,
     &LACSDungeonCount,
     &LACSTokenCount,
   };
@@ -426,6 +430,7 @@ namespace Settings {
     ctx.rainbowBridge        = Bridge.Value<u8>();
     ctx.bridgeStoneCount     = BridgeStoneCount.Value<u8>();
     ctx.bridgeMedallionCount = BridgeMedallionCount.Value<u8>();
+    ctx.bridgeRewardCount    = BridgeRewardCount.Value<u8>();
     ctx.bridgeDungeonCount   = BridgeDungeonCount.Value<u8>();
     ctx.bridgeTokenCount     = BridgeTokenCount.Value<u8>();
     ctx.randomGanonsTrials   = (RandomGanonsTrials) ? 1 : 0;
@@ -460,6 +465,7 @@ namespace Settings {
     ctx.lacsCondition        = LACSCondition;
     ctx.lacsMedallionCount   = LACSMedallionCount.Value<u8>();
     ctx.lacsStoneCount       = LACSStoneCount.Value<u8>();
+    ctx.lacsRewardCount      = LACSRewardCount.Value<u8>();
     ctx.lacsDungeonCount     = LACSDungeonCount.Value<u8>();
     ctx.lacsTokenCount       = LACSTokenCount.Value<u8>();
 
@@ -734,10 +740,10 @@ namespace Settings {
 
     //Only show stone count option if Stones is selected
     if (Bridge.Is(RAINBOWBRIDGE_STONES)) {
+      BridgeStoneCount.SetSelectedIndex(3);
       BridgeStoneCount.Unhide();
     } else {
       BridgeStoneCount.Hide();
-      BridgeStoneCount.SetSelectedIndex(3);
     }
 
     //Only show medallion count option if Medallions is selected
@@ -748,27 +754,35 @@ namespace Settings {
       BridgeMedallionCount.SetSelectedIndex(6);
     }
 
-    //Only show dungeon count option if Dungeons is selected
+    //Only show reward count option if Rewards is selected
+    if (Bridge.Is(RAINBOWBRIDGE_REWARDS)) {
+      BridgeRewardCount.SetSelectedIndex(9);
+      BridgeRewardCount.Unhide();
+    } else {
+      BridgeRewardCount.Hide();
+    }
+
+    //Only show reward count option if Rewards is selected
     if (Bridge.Is(RAINBOWBRIDGE_DUNGEONS)) {
+      BridgeDungeonCount.SetSelectedIndex(8);
       BridgeDungeonCount.Unhide();
     } else {
       BridgeDungeonCount.Hide();
-      BridgeDungeonCount.SetSelectedIndex(9);
     }
 
     //Only show token count option if Tokens is selected
     if (Bridge.Is(RAINBOWBRIDGE_TOKENS)) {
+      BridgeTokenCount.SetSelectedIndex(1);
       BridgeTokenCount.Unhide();
     } else {
       BridgeTokenCount.Hide();
-      BridgeTokenCount.SetSelectedIndex(1);
     }
 
     //Only show Trial Count option if Random Trial Count is off
     if (RandomGanonsTrials) {
       GanonsTrialsCount.Hide();
-      GanonsTrialsCount.SetSelectedIndex(6);
     } else {
+      GanonsTrialsCount.SetSelectedIndex(6);
       GanonsTrialsCount.Unhide();
     }
 
@@ -783,8 +797,8 @@ namespace Settings {
     //Only show MQ Dungeon Count if Random MQ Dungeons is off
     if (RandomMQDungeons) {
       MQDungeonCount.Hide();
-      MQDungeonCount.SetSelectedIndex(0);
     } else {
+      MQDungeonCount.SetSelectedIndex(0);
       MQDungeonCount.Unhide();
     }
 
@@ -812,11 +826,19 @@ namespace Settings {
       LACSStoneCount.Hide();
     }
 
+    //Only show Reward Count if setting Ganons Boss Key to LACS Rewards
+    if (GanonsBossKey.Is(GANONSBOSSKEY_LACS_REWARDS)) {
+      LACSRewardCount.Unhide();
+    } else {
+      LACSRewardCount.SetSelectedIndex(9);
+      LACSRewardCount.Hide();
+    }
+
     //Only show Dungeon Count if setting Ganons Boss Key to LACS Dungeons
     if (GanonsBossKey.Is(GANONSBOSSKEY_LACS_DUNGEONS)) {
       LACSDungeonCount.Unhide();
     } else {
-      LACSDungeonCount.SetSelectedIndex(9);
+      LACSDungeonCount.SetSelectedIndex(8);
       LACSDungeonCount.Hide();
     }
 
@@ -926,6 +948,8 @@ namespace Settings {
       LACSCondition = LACSCONDITION_MEDALLIONS;
     } else if (GanonsBossKey.Is(GANONSBOSSKEY_LACS_STONES)) {
       LACSCondition = LACSCONDITION_STONES;
+    } else if (GanonsBossKey.Is(GANONSBOSSKEY_LACS_REWARDS)) {
+      LACSCondition = LACSCONDITION_REWARDS;
     } else if (GanonsBossKey.Is(GANONSBOSSKEY_LACS_DUNGEONS)) {
       LACSCondition = LACSCONDITION_DUNGEONS;
     } else if (GanonsBossKey.Is(GANONSBOSSKEY_LACS_TOKENS)) {

--- a/source/settings.cpp
+++ b/source/settings.cpp
@@ -740,9 +740,9 @@ namespace Settings {
 
     //Only show stone count option if Stones is selected
     if (Bridge.Is(RAINBOWBRIDGE_STONES)) {
-      BridgeStoneCount.SetSelectedIndex(3);
       BridgeStoneCount.Unhide();
     } else {
+      BridgeStoneCount.SetSelectedIndex(3);
       BridgeStoneCount.Hide();
     }
 
@@ -756,33 +756,33 @@ namespace Settings {
 
     //Only show reward count option if Rewards is selected
     if (Bridge.Is(RAINBOWBRIDGE_REWARDS)) {
-      BridgeRewardCount.SetSelectedIndex(9);
       BridgeRewardCount.Unhide();
     } else {
+      BridgeRewardCount.SetSelectedIndex(9);
       BridgeRewardCount.Hide();
     }
 
     //Only show reward count option if Rewards is selected
     if (Bridge.Is(RAINBOWBRIDGE_DUNGEONS)) {
-      BridgeDungeonCount.SetSelectedIndex(8);
       BridgeDungeonCount.Unhide();
     } else {
+      BridgeDungeonCount.SetSelectedIndex(8);
       BridgeDungeonCount.Hide();
     }
 
     //Only show token count option if Tokens is selected
     if (Bridge.Is(RAINBOWBRIDGE_TOKENS)) {
-      BridgeTokenCount.SetSelectedIndex(1);
       BridgeTokenCount.Unhide();
     } else {
+      BridgeTokenCount.SetSelectedIndex(1);
       BridgeTokenCount.Hide();
     }
 
     //Only show Trial Count option if Random Trial Count is off
     if (RandomGanonsTrials) {
+      GanonsTrialsCount.SetSelectedIndex(6);
       GanonsTrialsCount.Hide();
     } else {
-      GanonsTrialsCount.SetSelectedIndex(6);
       GanonsTrialsCount.Unhide();
     }
 
@@ -796,9 +796,9 @@ namespace Settings {
 
     //Only show MQ Dungeon Count if Random MQ Dungeons is off
     if (RandomMQDungeons) {
+      MQDungeonCount.SetSelectedIndex(0);
       MQDungeonCount.Hide();
     } else {
-      MQDungeonCount.SetSelectedIndex(0);
       MQDungeonCount.Unhide();
     }
 

--- a/source/settings.hpp
+++ b/source/settings.hpp
@@ -244,6 +244,7 @@ namespace Settings {
   extern Option Bridge;
   extern Option BridgeStoneCount;
   extern Option BridgeMedallionCount;
+  extern Option BridgeRewardCount;
   extern Option BridgeDungeonCount;
   extern Option BridgeTokenCount;
   extern Option RandomGanonsTrials;
@@ -277,6 +278,7 @@ namespace Settings {
   extern u8 LACSCondition;
   extern Option LACSMedallionCount;
   extern Option LACSStoneCount;
+  extern Option LACSRewardCount;
   extern Option LACSDungeonCount;
   extern Option LACSTokenCount;
 


### PR DESCRIPTION
Previously, the option of "Dungeons" for LACS and Rainbow Bridge meant collecting a configurable amount of dungeon rewards. This option has been renamed to "Rewards" and the option "Dungeons" now refers to completing a configurable amount of dungeons. Completing a dungeon is a defined as entering its blue warp at the end. 