### PR TITLE
Enabled menu during DHWW, removed some cutscenes/downtime

### DIFF
--- a/code/src/actor.c
+++ b/code/src/actor.c
@@ -12,6 +12,7 @@
 #include "string.h"
 #include "ganondorf_organ.h"
 #include "checkable_spot.h"
+#include "twinrova.h"
 
 #define OBJECT_CUSTOM_DOUBLE_DEFENSE 4
 #define OBJECT_CUSTOM_ZELDAS_LULLABY 5
@@ -44,6 +45,9 @@ void Actor_Init() {
 
     gActorOverlayTable[0x8B].initInfo->init = DemoEffect_rInit;
     gActorOverlayTable[0x8B].initInfo->destroy = DemoEffect_rDestroy;
+    
+    gActorOverlayTable[0xDC].initInfo->update = Boss_Tw_rUpdate;
+    gActorOverlayTable[0xDC].initInfo->draw = Boss_Tw_rDraw;
 
     gActorOverlayTable[0xF1].initInfo->init = ItemOcarina_rInit;
     gActorOverlayTable[0xF1].initInfo->destroy = ItemOcarina_rDestroy;

--- a/code/src/actor.c
+++ b/code/src/actor.c
@@ -33,7 +33,7 @@
 #define OBJECT_GI_OCARINA_0 270
 
 void Actor_Init() {
-    gActorOverlayTable[0x14D].initInfo->init = EnOwl_DespawnInit; //Despawns unneccesary owls
+    gActorOverlayTable[0x14D].initInfo->init = EnOwl_DespawnInit; //Despawns unnecessary owls
 
     gActorOverlayTable[0x15].initInfo->init = EnItem00_rInit;
     gActorOverlayTable[0x15].initInfo->destroy = EnItem00_rDestroy;
@@ -45,9 +45,10 @@ void Actor_Init() {
 
     gActorOverlayTable[0x8B].initInfo->init = DemoEffect_rInit;
     gActorOverlayTable[0x8B].initInfo->destroy = DemoEffect_rDestroy;
-    
+
     gActorOverlayTable[0xDC].initInfo->update = Boss_Tw_rUpdate;
     gActorOverlayTable[0xDC].initInfo->draw = Boss_Tw_rDraw;
+    gActorOverlayTable[0xDC].initInfo->destroy = Boss_Tw_rDestroy;
 
     gActorOverlayTable[0xF1].initInfo->init = ItemOcarina_rInit;
     gActorOverlayTable[0xF1].initInfo->destroy = ItemOcarina_rDestroy;

--- a/code/src/actor.c
+++ b/code/src/actor.c
@@ -11,6 +11,7 @@
 #include "cow.h"
 #include "string.h"
 #include "ganondorf_organ.h"
+#include "checkable_spot.h"
 
 #define OBJECT_CUSTOM_DOUBLE_DEFENSE 4
 #define OBJECT_CUSTOM_ZELDAS_LULLABY 5
@@ -57,6 +58,8 @@ void Actor_Init() {
 
     gActorOverlayTable[0x168].initInfo->init = EnExItem_rInit;
     gActorOverlayTable[0x168].initInfo->destroy = EnExItem_rDestroy;
+
+    gActorOverlayTable[0x185].initInfo->update = EnWonderTalk2_rUpdate;
 
     gActorOverlayTable[0x195].initInfo->init = EnShopnuts_rInit;
 

--- a/code/src/actor.c
+++ b/code/src/actor.c
@@ -13,6 +13,7 @@
 #include "ganondorf_organ.h"
 #include "checkable_spot.h"
 #include "twinrova.h"
+#include "nabooru.h"
 
 #define OBJECT_CUSTOM_DOUBLE_DEFENSE 4
 #define OBJECT_CUSTOM_ZELDAS_LULLABY 5
@@ -45,6 +46,8 @@ void Actor_Init() {
 
     gActorOverlayTable[0x8B].initInfo->init = DemoEffect_rInit;
     gActorOverlayTable[0x8B].initInfo->destroy = DemoEffect_rDestroy;
+
+    gActorOverlayTable[0xC3].initInfo->draw = EnNb_rDraw;
 
     gActorOverlayTable[0xDC].initInfo->update = Boss_Tw_rUpdate;
     gActorOverlayTable[0xDC].initInfo->draw = Boss_Tw_rDraw;

--- a/code/src/checkable_spot.c
+++ b/code/src/checkable_spot.c
@@ -1,0 +1,10 @@
+#include "z3D/z3D.h"
+#include "checkable_spot.h"
+
+#define EnWonderTalk2_Update_addr 0x3794EC
+#define EnWonderTalk2_Update ((ActorFunc)EnWonderTalk2_Update_addr)
+
+void EnWonderTalk2_rUpdate(Actor* thisx, GlobalContext* globalCtx){
+        if((thisx->params & 0xC000) != 0x4000) //automatic text boxes (GtG, Shadow Temple) never update so they don't appear
+            EnWonderTalk2_Update(thisx, globalCtx);
+}

--- a/code/src/checkable_spot.c
+++ b/code/src/checkable_spot.c
@@ -5,6 +5,6 @@
 #define EnWonderTalk2_Update ((ActorFunc)EnWonderTalk2_Update_addr)
 
 void EnWonderTalk2_rUpdate(Actor* thisx, GlobalContext* globalCtx){
-        if((thisx->params & 0xC000) != 0x4000) //automatic text boxes (GtG, Shadow Temple) never update so they don't appear
-            EnWonderTalk2_Update(thisx, globalCtx);
+    if((thisx->params & 0xC000) != 0x4000) //automatic text boxes (GtG, Shadow Temple) never update so they don't appear
+        EnWonderTalk2_Update(thisx, globalCtx);
 }

--- a/code/src/checkable_spot.h
+++ b/code/src/checkable_spot.h
@@ -1,0 +1,3 @@
+#include "z3D/z3D.h"
+
+void EnWonderTalk2_rUpdate(Actor* thisx, GlobalContext* globalCtx);

--- a/code/src/gfx.c
+++ b/code/src/gfx.c
@@ -125,7 +125,13 @@ void Gfx_Update(void) {
         Gfx_Init();
     }
 
-    if(gSaveContext.gameMode == 0 && openingButton()) {
+    s32 entr = gSaveContext.entranceIndex;
+    s32 mode = gSaveContext.gameMode;
+    if(openingButton() && 
+        (mode == 0 || 
+        (mode == 1 && entr != 0x0629 && entr != 0x0147 && entr != 0x00A0 && entr != 0x008D)
+        )
+      ){
         Gfx_ShowMenu();
         svcSleepThread(1000 * 1000 * 300LL);
     }

--- a/code/src/nabooru.c
+++ b/code/src/nabooru.c
@@ -1,0 +1,17 @@
+#include "z3D/z3D.h"
+#include "nabooru.h"
+
+#define EnNb_Draw_addr 0x1B7FBC
+#define EnNb_Draw ((ActorFunc)EnNb_Draw_addr)
+
+void EnNb_rDraw(Actor* thisx, GlobalContext* globalCtx){
+
+    //if the scene is Spirit Boss, Nabooru Knuckle is defeated and Nabooru is on the ground, reload scene
+    //(Nabooru is teleported to ground level when the cutscene starts, her actor is initially loaded elsewhere)
+    if(globalCtx->sceneNum == 23 && (globalCtx->actorCtx.flags.swch & 0x00000020) && thisx->prevPos.y==0){
+        globalCtx->nextEntranceIndex = 0x008D;
+        globalCtx->sceneLoadFlag = 0x14;
+    }
+    
+    EnNb_Draw(thisx, globalCtx);
+}

--- a/code/src/nabooru.h
+++ b/code/src/nabooru.h
@@ -1,0 +1,3 @@
+#include "z3D/z3D.h"
+
+void EnNb_rDraw(Actor* thisx, GlobalContext* globalCtx);

--- a/code/src/savefile.c
+++ b/code/src/savefile.c
@@ -36,7 +36,7 @@ void SaveFile_Init() {
     gSaveContext.infTable  [0x11] |= 0x0400; //Met Darunia in Fire Temple
     gSaveContext.infTable  [0x14] |= 0x000E; //Ruto in Jabu can be escorted immediately
     gSaveContext.eventChkInf[0x3] |= 0x0800; //began Nabooru Battle
-    gSaveContext.eventChkInf[0x7] |= 0x01DF; //began boss battles (except Twinrova and Ganondorf)
+    gSaveContext.eventChkInf[0x7] |= 0x01FF; //began boss battles (except Ganondorf)
     gSaveContext.eventChkInf[0x9] |= 0x0010; //Spoke to Nabooru as child
     gSaveContext.eventChkInf[0xA] |= 0x017B; //entrance cutscenes (minus temple of time)
     gSaveContext.eventChkInf[0xB] |= 0x07FF; //more entrance cutscenes

--- a/code/src/savefile.c
+++ b/code/src/savefile.c
@@ -44,6 +44,8 @@ void SaveFile_Init() {
     gSaveContext.eventChkInf[0xC] |= 0x8000; //Forest Temple entrance cutscene (3ds only)
 
     gSaveContext.sceneFlags[5].swch |= 0x00010000; //remove Ruto cutscene in Water Temple
+    
+    gSaveContext.unk_13D0[4] |= 0x01; //Club Moblin cutscene
 
     //open lowest Vanilla Fire Temple locked door (to prevent key logic lockouts)
     if (gSettingsContext.fireTempleDungeonMode == DUNGEONMODE_VANILLA) {

--- a/code/src/twinrova.c
+++ b/code/src/twinrova.c
@@ -1,0 +1,26 @@
+#include "z3D/z3D.h"
+#include "twinrova.h"
+
+#define Boss_Tw_Update_addr 0x1ef880
+#define Boss_Tw_Update ((ActorFunc)Boss_Tw_Update_addr)
+
+#define Boss_Tw_Draw_addr 0x1eedf0
+#define Boss_Tw_Draw ((ActorFunc)Boss_Tw_Draw_addr)
+
+static u8 fightStarted = 0;
+
+void Boss_Tw_rUpdate(Actor* thisx, GlobalContext* globalCtx){
+        
+        Vec3f pos = PLAYER->actor.prevPos;
+        
+        if(pos.x > -100 && pos.x < 100 && pos.y > 200 && pos.z > -100 && pos.z < 100)
+            fightStarted = 1;
+        
+        if(fightStarted)
+            Boss_Tw_Update(thisx, globalCtx);
+}
+
+void Boss_Tw_rDraw(Actor* thisx, GlobalContext* globalCtx){
+        if(fightStarted)
+            Boss_Tw_Draw(thisx, globalCtx);
+}

--- a/code/src/twinrova.c
+++ b/code/src/twinrova.c
@@ -29,6 +29,8 @@ void Boss_Tw_rDraw(Actor* thisx, GlobalContext* globalCtx){
 }
 
 void Boss_Tw_rDestroy(Actor* thisx, GlobalContext* globalCtx){
-    fightStarted = 0;
+    if(thisx->params == 0x0001)    //Koume. This check is needed because the elemental
+        fightStarted = 0;          //attacks are different instances of the actor
+    
     Boss_Tw_Destroy(thisx, globalCtx);
 }

--- a/code/src/twinrova.c
+++ b/code/src/twinrova.c
@@ -1,26 +1,34 @@
 #include "z3D/z3D.h"
 #include "twinrova.h"
 
-#define Boss_Tw_Update_addr 0x1ef880
+#define Boss_Tw_Update_addr 0x1EF880
 #define Boss_Tw_Update ((ActorFunc)Boss_Tw_Update_addr)
 
-#define Boss_Tw_Draw_addr 0x1eedf0
+#define Boss_Tw_Draw_addr 0x1EEDF0
 #define Boss_Tw_Draw ((ActorFunc)Boss_Tw_Draw_addr)
+
+#define Boss_Tw_Destroy_addr 0x1A88E8
+#define Boss_Tw_Destroy ((ActorFunc)Boss_Tw_Destroy_addr)
 
 static u8 fightStarted = 0;
 
 void Boss_Tw_rUpdate(Actor* thisx, GlobalContext* globalCtx){
-        
-        Vec3f pos = PLAYER->actor.prevPos;
-        
-        if(pos.x > -100 && pos.x < 100 && pos.y > 200 && pos.z > -100 && pos.z < 100)
-            fightStarted = 1;
-        
-        if(fightStarted)
-            Boss_Tw_Update(thisx, globalCtx);
+
+    Vec3f pos = PLAYER->actor.prevPos;
+    
+    if(pos.x > -100 && pos.x < 100 && pos.y > 200 && pos.z > -100 && pos.z < 100)
+        fightStarted = 1;
+    
+    if(fightStarted)
+        Boss_Tw_Update(thisx, globalCtx);
 }
 
 void Boss_Tw_rDraw(Actor* thisx, GlobalContext* globalCtx){
-        if(fightStarted)
-            Boss_Tw_Draw(thisx, globalCtx);
+    if(fightStarted)
+        Boss_Tw_Draw(thisx, globalCtx);
+}
+
+void Boss_Tw_rDestroy(Actor* thisx, GlobalContext* globalCtx){
+    fightStarted = 0;
+    Boss_Tw_Destroy(thisx, globalCtx);
 }

--- a/code/src/twinrova.h
+++ b/code/src/twinrova.h
@@ -1,0 +1,4 @@
+#include "z3D/z3D.h"
+
+void Boss_Tw_rUpdate(Actor* thisx, GlobalContext* globalCtx);
+void Boss_Tw_rDraw(Actor* thisx, GlobalContext* globalCtx);

--- a/code/src/twinrova.h
+++ b/code/src/twinrova.h
@@ -2,3 +2,4 @@
 
 void Boss_Tw_rUpdate(Actor* thisx, GlobalContext* globalCtx);
 void Boss_Tw_rDraw(Actor* thisx, GlobalContext* globalCtx);
+void Boss_Tw_rDestroy(Actor* thisx, GlobalContext* globalCtx);


### PR DESCRIPTION
The info menu can now be used to buffer tricks during DHWW.

The cutscenes for Twinrova's battle introduction, Nabooru Knuckle's defeat and the softlock-loving Club Moblin are removed. The first 2 may feel a bit hacky for now, but it's still better than having to watch the cutscenes imo.

The text boxes that pop up in Shadow Temple, Gerudo Training Grounds, Thieves' Hideout and ouside Kokiri Shop are also removed.

Read the commits descriptions for more information.