### PR TITLE
Logic: Allow child to logically buy adult tunics

### DIFF
--- a/source/item_pool.cpp
+++ b/source/item_pool.cpp
@@ -911,20 +911,7 @@ void GenerateItemPool() {
     }
     AddItemsToPool(ItemPool, normalRupees);
   } else {
-    //Make sure tunics are not shuffled into child-only shops
-    bool tunicInChild = true;
-    while(tunicInChild) {
-      Shuffle(ShopItems); //Shuffle shop items amongst themselves
-      tunicInChild = false;
-      //16-23: Bombchu, 24-31: Market Potion, 32-39: Market Bazaar
-      for(int i = 16; i < 40; i++) {
-        //Tunics were placed in a child-only location, run loop again to re-shuffle
-        if (ShopItems[i] == BuyZoraTunic || ShopItems[i] == BuyGoronTunic) {
-          tunicInChild = true;
-          break;
-        }
-      }
-    }
+    Shuffle(ShopItems); //Shuffle shop items amongst themselves
     PlaceShopItems(); //Place now-shuffled shop items
     if (Settings::Shopsanity.Is(SHOPSANITY_ZERO)) { //Shopsanity 0
       AddItemsToPool(ItemPool, normalRupees);

--- a/source/location_access.cpp
+++ b/source/location_access.cpp
@@ -45,18 +45,14 @@ bool ItemLocationPairing::CanBuy() const {
     SufficientWallet = Logic::ProgressiveWallet >= 1;
   }
 
-  //Check for other conditions on buy items
-  bool OtherCondition = true;
-  //Need to be adult to buy tunic
-  const Item& placed = location->GetPlacedItem();
-  if (placed == BuyGoronTunic || placed == BuyZoraTunic) {
-    OtherCondition = Logic::IsAdult;
-  }
   //Need bottle to buy bottle items, only logically relevant bottle items included here
-  else if (placed == BuyBlueFire || placed == BuyBottleBug || placed == BuyFish || placed == BuyFairysSpirit) {
-    OtherCondition = Logic::HasBottle;
+  bool HasOrDoesntNeedBottle = true;
+  const Item& placed = location->GetPlacedItem();
+  if (placed == BuyBlueFire || placed == BuyBottleBug || placed == BuyFish || placed == BuyFairysSpirit) {
+    HasOrDoesntNeedBottle = Logic::HasBottle;
   }
-  return SufficientWallet && OtherCondition;
+
+  return SufficientWallet && HasOrDoesntNeedBottle;
 }
 
 Exit::Exit(std::string regionName_, std::string scene_, std::string hint_,


### PR DESCRIPTION
This removes the retry loop to make sure tunics are not placed in child-only shops, and doesn't check for adult in logic of being able to buy tunics.

This is the result of a discussion in the Discord that we should implement a hack to allow child to buy tunics.