### PR TITLE
Bug fixes

### DIFF
--- a/code/src/chest.c
+++ b/code/src/chest.c
@@ -50,6 +50,10 @@ void EnBox_rInit(Actor* thisx, GlobalContext* globalCtx){
         if((thisx->params & 0xF000) == 0x8000 && globalCtx->sceneNum==13 && thisx->room==9){
             thisx->world.pos.z = -962.0f;
         }
+        //Move MQ Deku Tree SoT chest so it is reachable
+        if(thisx->params==0x5AA0 && globalCtx->sceneNum==0 && thisx->room==5){
+            thisx->world.pos.x = -1380.0f;
+        }
     }
     else{
         //Make chest small

--- a/code/src/savefile.c
+++ b/code/src/savefile.c
@@ -386,6 +386,10 @@ void SaveFile_SetStartingInventory(void) {
         gSaveContext.items[SLOT_OCARINA] = ITEM_OCARINA_FAIRY + (gSettingsContext.startingOcarina - 1);
     }
 
+    if (gSettingsContext.startingKokiriSword) {
+        gSaveContext.childEquips.buttonItems[0] = ITEM_SWORD_KOKIRI;
+    }
+
     if (gSettingsContext.startingBiggoronSword) {
         gSaveContext.bgsFlag = 1;
         gSaveContext.bgsHitsLeft = 1;

--- a/code/src/settings.h
+++ b/code/src/settings.h
@@ -351,6 +351,7 @@ typedef struct {
   u8 startingBottle3;
   u8 startingRutoBottle;
   u8 startingOcarina;
+  u8 startingKokiriSword;
   u8 startingBiggoronSword;
   u8 startingMagicMeter;
   u8 startingDoubleDefense;

--- a/source/settings.cpp
+++ b/source/settings.cpp
@@ -670,6 +670,7 @@ namespace Settings {
     ctx.startingBottle3       = StartingBottle3.Value<u8>();
     ctx.startingRutoBottle    = StartingRutoBottle.Value<u8>();
     ctx.startingOcarina       = StartingOcarina.Value<u8>();
+    ctx.startingKokiriSword   = StartingKokiriSword.Value<u8>();
     ctx.startingBiggoronSword = StartingBiggoronSword.Value<u8>();
     ctx.startingMagicMeter    = StartingMagicMeter.Value<u8>();
     ctx.startingDoubleDefense = StartingDoubleDefense.Value<u8>();


### PR DESCRIPTION
- Starting with Kokiri Sword and going back in time now properly equips the sword.

- One chest in MQ Deku Tree gets repositioned if it's turned into a big chest