### PR TITLE
Improve preset file structure

### DIFF
--- a/source/preset.cpp
+++ b/source/preset.cpp
@@ -79,7 +79,13 @@ bool SavePreset(std::string_view presetName, OptionCategory category) {
   using namespace tinyxml2;
 
   XMLDocument preset = XMLDocument();
-  preset.NewDeclaration();
+
+  // Create and insert the XML declaration
+  preset.InsertEndChild(preset.NewDeclaration());
+
+  // Create the root node
+  XMLElement* rootNode = preset.NewElement("settings");
+  preset.InsertEndChild(rootNode);
 
   for (MenuItem* menu : Settings::mainMenu) {
     if (menu->mode != OPTION_SUB_MENU) {
@@ -90,24 +96,13 @@ bool SavePreset(std::string_view presetName, OptionCategory category) {
         continue;
       }
 
-      //Create all necessary elements
+      // Create the <setting> element
       XMLElement* newSetting = preset.NewElement("setting");
-      XMLElement* settingName = preset.NewElement("settingName");
-      XMLElement* valueName = preset.NewElement("valueName");
-      XMLText* settingText = preset.NewText(std::string(setting->GetName()).c_str());
-      XMLText* valueText = preset.NewText(setting->GetSelectedOptionText().c_str());
+      newSetting->SetAttribute("name", std::string(setting->GetName()).c_str());
+      newSetting->SetText(setting->GetSelectedOptionText().c_str());
 
-      //Some setting names have punctuation in them. Set all values as CDATA so
-      //there are no conflicts with XML
-      settingText->SetCData(true);
-      valueText->SetCData(true);
-
-      //add elements to the document
-      settingName->InsertEndChild(settingText);
-      valueName->InsertEndChild(valueText);
-      newSetting->InsertEndChild(settingName);
-      newSetting->InsertEndChild(valueName);
-      preset.InsertEndChild(newSetting);
+      // Append it to the root node
+      rootNode->InsertEndChild(newSetting);
     }
   }
 

--- a/source/preset.cpp
+++ b/source/preset.cpp
@@ -146,10 +146,8 @@ bool LoadPreset(std::string_view presetName, OptionCategory category) {
       // we loop through the settings to find most of the matching elements.
       std::string settingToFind = std::string{setting->GetName()};
       std::string curSettingName = curNode->Attribute("name");
-      std::string curSettingValue = curNode->GetText();
-
       if (curSettingName == settingToFind) {
-        setting->SetSelectedIndexByString(curSettingValue);
+        setting->SetSelectedIndexByString(curNode->GetText());
         curNode = curNode->NextSiblingElement();
       } else {
         // If the current setting and element don't match, then search
@@ -159,10 +157,8 @@ bool LoadPreset(std::string_view presetName, OptionCategory category) {
         bool settingFound = false;
         while (curNode != nullptr) {
           curSettingName = curNode->Attribute("name");
-          curSettingValue = curNode->GetText();
-
           if (curSettingName == settingToFind) {
-            setting->SetSelectedIndexByString(curSettingValue);
+            setting->SetSelectedIndexByString(curNode->GetText());
             curNode = curNode->NextSiblingElement();
             settingFound = true;
             break;

--- a/source/preset.cpp
+++ b/source/preset.cpp
@@ -130,7 +130,7 @@ bool LoadPreset(std::string_view presetName, OptionCategory category) {
       return false;
   }
 
-  XMLElement* curNode = rootNode->FirstChildElement("setting");
+  XMLElement* curNode = rootNode->FirstChildElement();
 
   for (MenuItem* menu : Settings::mainMenu) {
     if (menu->mode != OPTION_SUB_MENU) {
@@ -150,7 +150,7 @@ bool LoadPreset(std::string_view presetName, OptionCategory category) {
 
       if (curSettingName == settingToFind) {
         setting->SetSelectedIndexByString(curSettingValue);
-        curNode = curNode->NextSiblingElement("setting");
+        curNode = curNode->NextSiblingElement();
       } else {
         // If the current setting and element don't match, then search
         // linearly from the beginning. This will get us back on track if the
@@ -167,11 +167,11 @@ bool LoadPreset(std::string_view presetName, OptionCategory category) {
             settingFound = true;
             break;
           }
-          curNode = curNode->NextSiblingElement("setting");
+          curNode = curNode->NextSiblingElement();
         }
         //reset to the beginning if the setting wasn't found
         if (!settingFound) {
-          curNode = rootNode->FirstChildElement("setting");
+          curNode = rootNode->FirstChildElement();
         }
       }
     }


### PR DESCRIPTION
The structure of the preset files has been optimized, cutting their size in half. More details to the changes can be found in #148.
This closes #148.

Please check the changes carefully, I am not a C++ developer and might made obvious mistakes. Changes were tested on a 3DS system (saving and loading of custom presets, and the CACHED_SETTINGS.xml variant and its cosmetic counterpart).