### PR TITLE
Cutscene skips

### DIFF
--- a/code/oot.ld
+++ b/code/oot.ld
@@ -112,6 +112,10 @@ SECTIONS
 		*(.patch_AnjuCheckCuccoAmount)
 	}
 
+	.patch_FastOwlCutscenes 0x188584 : {
+		*(.patch_FastOwlCutscenes)
+	}
+
 	.patch_BombchuShopInfinitePurchases 0x188D4C : {
 		*(.patch_BombchuShopInfinitePurchases)
 	}

--- a/code/src/actor.c
+++ b/code/src/actor.c
@@ -21,6 +21,7 @@
 #include "gossip_stone.h"
 #include "drawbridge.h"
 #include "king_zora.h"
+#include "collapsing_castle.h"
 
 
 #define OBJECT_GI_HEARTS 189
@@ -72,6 +73,8 @@ void Actor_Init() {
 
     gActorOverlayTable[0x168].initInfo->init = EnExItem_rInit;
     gActorOverlayTable[0x168].initInfo->destroy = EnExItem_rDestroy;
+
+    gActorOverlayTable[0x174].initInfo->update = DemoGt_rUpdate;
 
     gActorOverlayTable[0x185].initInfo->update = EnWonderTalk2_rUpdate;
 

--- a/code/src/actor.c
+++ b/code/src/actor.c
@@ -19,6 +19,8 @@
 #include "gerudo_archery_manager.h"
 #include "chest.h"
 #include "gossip_stone.h"
+#include "drawbridge.h"
+
 
 #define OBJECT_GI_HEARTS 189
 #define OBJECT_GI_OCARINA 222
@@ -30,6 +32,8 @@ void Actor_Init() {
     gActorOverlayTable[0x15].initInfo->init = EnItem00_rInit;
     gActorOverlayTable[0x15].initInfo->destroy = EnItem00_rDestroy;
     gActorOverlayTable[0x15].initInfo->draw = EnItem00_rDraw;
+
+    gActorOverlayTable[0x4A].initInfo->update = BgSpot00Hanebasi_rUpdate;
 
     gActorOverlayTable[0x5F].initInfo->init = ItemBHeart_rInit;
     gActorOverlayTable[0x5F].initInfo->destroy = ItemBHeart_rDestroy;

--- a/code/src/actor.c
+++ b/code/src/actor.c
@@ -25,8 +25,6 @@
 #define OBJECT_GI_OCARINA_0 270
 
 void Actor_Init() {
-    gActorOverlayTable[0x14D].initInfo->init = EnOwl_DespawnInit; //Despawns unnecessary owls
-
     gActorOverlayTable[0xA].initInfo->init = EnBox_rInit;
 
     gActorOverlayTable[0x15].initInfo->init = EnItem00_rInit;
@@ -59,6 +57,9 @@ void Actor_Init() {
     gActorOverlayTable[0x12A].initInfo->init = ObjSwitch_rInit;
 
     gActorOverlayTable[0x138].initInfo->update = EnGe1_rUpdate;
+
+    gActorOverlayTable[0x14D].initInfo->init = EnOwl_DespawnInit; //Despawns unnecessary owls
+    gActorOverlayTable[0x14D].initInfo->update = EnOwl_rUpdate;
 
     gActorOverlayTable[0x15E].initInfo->init = EnGanonOrgan_rInit;
 

--- a/code/src/actor.c
+++ b/code/src/actor.c
@@ -20,6 +20,7 @@
 #include "chest.h"
 #include "gossip_stone.h"
 #include "drawbridge.h"
+#include "king_zora.h"
 
 
 #define OBJECT_GI_HEARTS 189
@@ -66,6 +67,8 @@ void Actor_Init() {
     gActorOverlayTable[0x14D].initInfo->update = EnOwl_rUpdate;
 
     gActorOverlayTable[0x15E].initInfo->init = EnGanonOrgan_rInit;
+
+    gActorOverlayTable[0x164].initInfo->update = EnKz_rUpdate;
 
     gActorOverlayTable[0x168].initInfo->init = EnExItem_rInit;
     gActorOverlayTable[0x168].initInfo->destroy = EnExItem_rDestroy;

--- a/code/src/actor.c
+++ b/code/src/actor.c
@@ -22,6 +22,7 @@
 #include "drawbridge.h"
 #include "king_zora.h"
 #include "collapsing_castle.h"
+#include "demo_kankyo.h"
 
 
 #define OBJECT_GI_HEARTS 189
@@ -43,6 +44,8 @@ void Actor_Init() {
 
     gActorOverlayTable[0x8B].initInfo->init = DemoEffect_rInit;
     gActorOverlayTable[0x8B].initInfo->destroy = DemoEffect_rDestroy;
+
+    gActorOverlayTable[0x8C].initInfo->update = DemoKankyo_rUpdate;
 
     gActorOverlayTable[0xC3].initInfo->draw = EnNb_rDraw;
 

--- a/code/src/collapsing_castle.c
+++ b/code/src/collapsing_castle.c
@@ -1,0 +1,13 @@
+#include "z3D/z3D.h"
+#include "collapsing_castle.h"
+
+#define DemoGt_Update_addr 0x12E1C4
+#define DemoGt_Update ((ActorFunc)DemoGt_Update_addr)
+
+void DemoGt_rUpdate(Actor* thisx, GlobalContext* globalCtx){
+    DemoGt_Update(thisx, globalCtx);
+    //set cutscene timer to near the end of the cutscene
+    if(globalCtx->csCtx.frames > 10 && globalCtx->csCtx.frames < 100){
+        globalCtx->csCtx.frames = 1670;
+    }
+}

--- a/code/src/collapsing_castle.h
+++ b/code/src/collapsing_castle.h
@@ -1,0 +1,8 @@
+#ifndef _COLLAPSING_CASTLE_H_
+#define _COLLAPSING_CASTLE_H_
+
+#include "z3D/z3D.h"
+
+void DemoGt_rUpdate(Actor* thisx, GlobalContext* globalCtx);
+
+#endif //_COLLAPSING_CASTLE_H_

--- a/code/src/cutscenes.c
+++ b/code/src/cutscenes.c
@@ -189,28 +189,47 @@ void Cutscene_OverrideFairyReward(BgDyYoseizo* fairy) {
 
 //skip dungeon exit cutscenes
 void Cutscene_OverrideDekuTree(void) {
+    ItemOverride_PushDungeonReward(DUNGEON_DEKU_TREE);
+    gSaveContext.eventChkInf[0x1] |= 0x1000; //spoke to Mido after Deku Tree's death
+
+    //If warping with FW, let the wrong warp work
+    if (gSaveContext.respawnFlag == 3) {
+        gSaveContext.nextCutsceneIndex = 0xFFF1;
+        return;
+    }
     gGlobalContext->nextEntranceIndex = 0x457;
     gGlobalContext->sceneLoadFlag = 0x14;
     gGlobalContext->fadeOutTransition = 0xA;
     gSaveContext.nextCutsceneIndex = 0x0;
-    ItemOverride_PushDungeonReward(DUNGEON_DEKU_TREE);
-    gSaveContext.eventChkInf[0x1] |= 0x1000; //spoke to Mido after Deku Tree's death
 }
 
 void Custcene_OverrideDodongosCavern(void) {
+    ItemOverride_PushDungeonReward(DUNGEON_DODONGOS_CAVERN);
+
+    //If warping with FW, let the wrong warp work
+    if (gSaveContext.respawnFlag == 3) {
+        gSaveContext.nextCutsceneIndex = 0xFFF1;
+        return;
+    }
     gGlobalContext->nextEntranceIndex = 0x47A;
     gGlobalContext->sceneLoadFlag = 0x14;
     gGlobalContext->fadeOutTransition = 0xA;
     gSaveContext.nextCutsceneIndex = 0x0;
-    ItemOverride_PushDungeonReward(DUNGEON_DODONGOS_CAVERN);
 }
 
 void Custcene_OverrideJabuJabusBelly(void) {
+    ItemOverride_PushDungeonReward(DUNGEON_JABUJABUS_BELLY);
+
+    //If warping with FW, let the wrong warp work
+    //(this code will never be executed lol)
+    if (gSaveContext.respawnFlag == 3) {
+        gSaveContext.nextCutsceneIndex = 0xFFF0;
+        return;
+    }
     gGlobalContext->nextEntranceIndex = 0x221;
     gGlobalContext->sceneLoadFlag = 0x14;
     gGlobalContext->fadeOutTransition = 0xA;
     gSaveContext.nextCutsceneIndex = 0x0;
-    ItemOverride_PushDungeonReward(DUNGEON_JABUJABUS_BELLY);
 }
 
 void Custcene_OverrideForestTemple(void) {
@@ -222,11 +241,17 @@ void Custcene_OverrideForestTemple(void) {
 }
 
 void Cutscene_OverrideFireTemple(void) {
+    ItemOverride_PushDungeonReward(DUNGEON_FIRE_TEMPLE);
+
+    //If warping with FW, let the wrong warp work
+    if (gSaveContext.respawnFlag == 3) {
+        gSaveContext.nextCutsceneIndex = 0xFFF3;
+        return;
+    }
     gGlobalContext->nextEntranceIndex = 0x564;
     gGlobalContext->sceneLoadFlag = 0x14;
     gGlobalContext->fadeOutTransition = 0x3;
     gSaveContext.nextCutsceneIndex = 0x0;
-    ItemOverride_PushDungeonReward(DUNGEON_FIRE_TEMPLE);
 }
 
 void Custcene_OverrideWaterTemple(void) {

--- a/code/src/demo_kankyo.c
+++ b/code/src/demo_kankyo.c
@@ -1,0 +1,41 @@
+#include "z3D/z3D.h"
+#include "demo_kankyo.h"
+
+#define DemoKankyo_Update_addr 0x262EA4
+#define DemoKankyo_Update ((ActorFunc)DemoKankyo_Update_addr)
+
+#define DoT_Opening_Cutscene_Pointer ((void*)0x0893AD30)
+#define CsTimer (globalCtx->csCtx.frames)
+
+void DemoKankyo_rUpdate(Actor* thisx, GlobalContext* globalCtx){
+    DemoKankyo_Update(thisx, globalCtx);
+
+/*  //Warp Song particles. This is meant to skip the warping animations, but it works only in ToT for now, because the
+    //animations use different cutscene data in that scene specifically. To avoid confusion, this is commented out for now
+    if(thisx->params == 0x000F){
+        u8* warpTimer = (((u8*)thisx)+0x01A6);
+        //Make camera-panning cutscene start immediately
+        if(*warpTimer > 2){
+            *warpTimer = 2;
+        }
+        //Make camera-panning cutscene end immediately
+        if(CsTimer < 37){
+            CsTimer = 37;
+        }
+        //Unset Zoneout Type -3 to avoid cutscene at destination
+        gSaveContext.respawnFlag = 0;
+    }
+*/
+
+    //Door of Time, the opening cutscene is playing (only regular one, not beta CS #03)
+    if(thisx->params == 0x000D && globalCtx->csCtx.segment == DoT_Opening_Cutscene_Pointer){
+        //skip the Spiritual Stones part of the cutscene
+        if(CsTimer < 800){
+            CsTimer = 800;
+        }
+        //Make cutscene end when the door is fully open
+        else if(CsTimer > 1090 && CsTimer < 1180){
+            CsTimer = 1180;
+        }
+    }
+}

--- a/code/src/demo_kankyo.h
+++ b/code/src/demo_kankyo.h
@@ -1,0 +1,8 @@
+#ifndef _DOOR_OF_TIME_H_
+#define _DOOR_OF_TIME_H_
+
+#include "z3D/z3D.h"
+
+void DemoKankyo_rUpdate(Actor* thisx, GlobalContext* globalCtx);
+
+#endif //_DOOR_OF_TIME_H_

--- a/code/src/drawbridge.c
+++ b/code/src/drawbridge.c
@@ -1,0 +1,14 @@
+#include "z3D/z3D.h"
+#include "drawbridge.h"
+
+#define BgSpot00Hanebasi_Update_addr 0x38B390
+#define BgSpot00Hanebasi_Update ((ActorFunc)BgSpot00Hanebasi_Update_addr)
+
+void BgSpot00Hanebasi_rUpdate(Actor* thisx, GlobalContext* globalCtx){
+    
+    //if about to start Zelda Escape cutscene, don't
+    if(gSaveContext.nextCutsceneIndex==0xFFF1 && globalCtx->nextEntranceIndex==0x00CD){
+        gSaveContext.nextCutsceneIndex=0;
+    }
+    BgSpot00Hanebasi_Update(thisx, globalCtx);
+}

--- a/code/src/drawbridge.h
+++ b/code/src/drawbridge.h
@@ -1,0 +1,8 @@
+#ifndef _DRAWBRIDGE_H_
+#define _DRAWBRIDGE_H_
+
+#include "z3D/z3D.h"
+
+void BgSpot00Hanebasi_rUpdate(Actor* thisx, GlobalContext* globalCtx);
+
+#endif //_DRAWBRIDGE_H_

--- a/code/src/entrance.c
+++ b/code/src/entrance.c
@@ -111,6 +111,11 @@ void Entrance_Init(void) {
     for (index = 0x594; index < 0x598; ++index) {
         gEntranceTable[index].field = 0x0102;
     }
+
+    // Delete the title card and add a fade in for Hyrule Field from Ocarina of Time cutscene
+    for (index = 0x50F; index < 0x513; ++index) {
+        gEntranceTable[index].field = 0x010B;
+    }
 }
 
 void Entrance_DeathInGanonBattle(void) {

--- a/code/src/hooks.s
+++ b/code/src/hooks.s
@@ -508,6 +508,14 @@ hook_DecoratedChest:
     pop {r0-r12, lr}
     bx lr
 
+.global hook_FastOwlCutscenes
+hook_FastOwlCutscenes:
+    push {r0-r12, lr}
+    bl EnOwl_FastCutscene
+    pop {r0-r12, lr}
+    mov r1,#0xa
+    bx lr
+
 .section .loader
 .global hook_into_loader
 hook_into_loader:

--- a/code/src/king_zora.c
+++ b/code/src/king_zora.c
@@ -1,10 +1,23 @@
 #include "z3D/z3D.h"
 #include "settings.h"
+#include "king_zora.h"
+
+#define EnKz_Update_addr 0x1B66F8
+#define EnKz_Update ((ActorFunc)EnKz_Update_addr)
 
 u32 EnKz_CheckMovedFlag(void) {
     if ((gSaveContext.eventChkInf[3] & 0x8) || ((gSaveContext.linkAge == AGE_ADULT) && (gSettingsContext.zorasFountain == ZORASFOUNTAIN_ADULT))) {
         return 1;
     } else {
         return 0;
+    }
+}
+
+void EnKz_rUpdate(Actor* thisx, GlobalContext* globalCtx){
+    EnKz_Update(thisx, globalCtx);
+    // Zora's Domain scene, the position check is just to add a 1 frame delay
+    if(globalCtx->sceneNum == 88 && thisx->speedXZ != 0 && thisx->world.pos.x < 628.0f){
+        thisx->speedXZ = 6.4f; //at this speed it takes him one mweep to move out of the way
+        thisx->world.pos.z = -1783.0f; //lock Z position so the increased speed doesn't mess it up
     }
 }

--- a/code/src/king_zora.h
+++ b/code/src/king_zora.h
@@ -1,0 +1,8 @@
+#ifndef _KING_ZORA_H_
+#define _KING_ZORA_H_
+
+#include "z3D/z3D.h"
+
+void EnKz_rUpdate(Actor* thisx, GlobalContext* globalCtx);
+
+#endif //_KING_ZORA_H_

--- a/code/src/owl.c
+++ b/code/src/owl.c
@@ -3,6 +3,11 @@
 #define EnOwl_Init_Addr 0x18DB28
 #define EnOwl_Init ((ActorFunc)EnOwl_Init_Addr)
 
+#define EnOwl_Update_Addr 0x1DCB60
+#define EnOwl_Update ((ActorFunc)EnOwl_Update_Addr)
+
+static u8 shortcutActivated = 0xFF;
+
 void EnOwl_DespawnInit(Actor* owl, GlobalContext* globalCtx) {
     switch ((owl->params & 0x3C0) >> 6) {
         case 7:
@@ -13,4 +18,24 @@ void EnOwl_DespawnInit(Actor* owl, GlobalContext* globalCtx) {
         default:
             Actor_Kill(owl);
     }
+}
+
+void EnOwl_rUpdate(Actor* owl, GlobalContext* globalCtx) {
+    EnOwl_Update(owl, globalCtx);
+    //repeat this for some frames to be sure the cutscene timer
+    //isn't reset to 0 by the cutscene
+    if(shortcutActivated < 5){
+        if(globalCtx->sceneNum==96){//DMT
+            globalCtx->csCtx.frames = 600;
+            shortcutActivated++;
+        }
+        else if(globalCtx->sceneNum==87){//Lake Hylia
+            globalCtx->csCtx.frames = 500;
+            shortcutActivated++;
+        }
+    }
+}
+
+void EnOwl_FastCutscene() {
+    shortcutActivated = 0;
 }

--- a/code/src/owl.h
+++ b/code/src/owl.h
@@ -4,5 +4,7 @@
 #include "z3D/z3D.h"
 
 void EnOwl_DespawnInit(Actor* owl, GlobalContext* globalCtx);
+void EnOwl_rUpdate(Actor* owl, GlobalContext* globalCtx);
+void EnOwl_FastCutscene(GlobalContext* globalCtx);
 
 #endif //_OWL_H_

--- a/code/src/patches.s
+++ b/code/src/patches.s
@@ -1161,6 +1161,11 @@ ReadGossipStoneHints_patch:
 DecoratedChest_patch:
     bl hook_DecoratedChest
 
+.section .patch_FastOwlCutscenes
+.global FastOwlCutscenes_patch
+FastOwlCutscenes_patch:
+    bl hook_FastOwlCutscenes
+
 .section .patch_loader
 .global loader_patch
 

--- a/code/src/savefile.c
+++ b/code/src/savefile.c
@@ -40,7 +40,7 @@ void SaveFile_Init() {
     gSaveContext.eventChkInf[0x3] |= 0x0800; //began Nabooru Battle
     gSaveContext.eventChkInf[0x7] |= 0x01FF; //began boss battles
     gSaveContext.eventChkInf[0x9] |= 0x0010; //Spoke to Nabooru as child
-    gSaveContext.eventChkInf[0xA] |= 0x027B; //entrance cutscenes (minus temple of time)
+    gSaveContext.eventChkInf[0xA] |= 0x037B; //entrance cutscenes (minus temple of time)
     gSaveContext.eventChkInf[0xB] |= 0x07FF; //more entrance cutscenes
     gSaveContext.eventChkInf[0xC] |= 0x0001; //Nabooru ordered to fight by Twinrova
     gSaveContext.eventChkInf[0xC] |= 0x8000; //Forest Temple entrance cutscene (3ds only)

--- a/code/src/savefile.c
+++ b/code/src/savefile.c
@@ -40,7 +40,7 @@ void SaveFile_Init() {
     gSaveContext.eventChkInf[0x3] |= 0x0800; //began Nabooru Battle
     gSaveContext.eventChkInf[0x7] |= 0x01FF; //began boss battles
     gSaveContext.eventChkInf[0x9] |= 0x0010; //Spoke to Nabooru as child
-    gSaveContext.eventChkInf[0xA] |= 0x017B; //entrance cutscenes (minus temple of time)
+    gSaveContext.eventChkInf[0xA] |= 0x027B; //entrance cutscenes (minus temple of time)
     gSaveContext.eventChkInf[0xB] |= 0x07FF; //more entrance cutscenes
     gSaveContext.eventChkInf[0xC] |= 0x0001; //Nabooru ordered to fight by Twinrova
     gSaveContext.eventChkInf[0xC] |= 0x8000; //Forest Temple entrance cutscene (3ds only)


### PR DESCRIPTION
The following cutscenes are now skipped or shortened to a couple of seconds at most:

- Kaepora Gaebora's shortcuts
- Zelda escaping the castle after 3 spiritual stones have been obtained
- Entrance cutscene to Hyrule Field after getting the Ocarina of Time
- King Zora ~~mweeping~~ moving out of the way
- Ganon's Castle collapsing

The Door of Time cutscene, while not skipped entirely for various reasons, is also shortened

Additionally, Wrong Warping from dungeon blue warps using FW is possible again.