### PR TITLE
fill/hints: Elide some copies. Also fix a bug in Max GS count retrieval

### DIFF
--- a/source/custom_messages.cpp
+++ b/source/custom_messages.cpp
@@ -129,22 +129,28 @@ constexpr std::array DungeonColors = {
 
     //textBoxType and textBoxPosition are defined here: https://wiki.cloudmodding.com/oot/Text_Format#Message_Id
     void CreateMessage(u32 textId, u32 unk_04, u32 textBoxType, u32 textBoxPosition,
-        std::string englishText, std::string frenchText, std::string spanishText) {
+                       std::string englishText, std::string frenchText, std::string spanishText) {
             MessageEntry newEntry = { textId, unk_04, textBoxType, textBoxPosition, { 0 } };
 
-            while ((englishText.size() % 4) != 0) englishText += "\0"s;
+            while ((englishText.size() % 4) != 0) {
+              englishText += "\0"s;
+            }
             messageData.seekg(0, messageData.end);
             newEntry.info[ENGLISH_U].offset = (char*)((int)messageData.tellg()) + RCUSTOMMESSAGES_ADDR;
             newEntry.info[ENGLISH_U].length = englishText.size();
             messageData << englishText;
 
-            while ((frenchText.size() % 4) != 0) frenchText += "\0"s;
+            while ((frenchText.size() % 4) != 0) {
+              frenchText += "\0"s;
+            }
             messageData.seekg(0, messageData.end);
             newEntry.info[FRENCH_U].offset = (char*)((int)messageData.tellg()) + RCUSTOMMESSAGES_ADDR;
             newEntry.info[FRENCH_U].length = frenchText.size();
             messageData << frenchText;
 
-            while ((spanishText.size() % 4) != 0) spanishText += "\0"s;
+            while ((spanishText.size() % 4) != 0) {
+              spanishText += "\0"s;
+            }
             messageData.seekg(0, messageData.end);
             newEntry.info[SPANISH_U].offset = (char*)((int)messageData.tellg()) + RCUSTOMMESSAGES_ADDR;
             newEntry.info[SPANISH_U].length = spanishText.size();
@@ -153,7 +159,7 @@ constexpr std::array DungeonColors = {
             messageEntries.insert(newEntry);
     }
 
-    void CreateMessageFromTextObject(u32 textId, u32 unk_04, u32 textBoxType, u32 textBoxPosition, Text text) {
+    void CreateMessageFromTextObject(u32 textId, u32 unk_04, u32 textBoxType, u32 textBoxPosition, const Text& text) {
         CreateMessage(textId, unk_04, textBoxType, textBoxPosition, text.GetEnglish(), text.GetFrench(), text.GetSpanish());
     }
 

--- a/source/custom_messages.hpp
+++ b/source/custom_messages.hpp
@@ -19,7 +19,7 @@
 namespace CustomMessages {
     void CreateMessage(u32 textId, u32 unk_04, u32 textBoxType, u32 textBoxPosition,
                        std::string englishText, std::string frenchText, std::string spanishText);
-    void CreateMessageFromTextObject(u32 textId, u32 unk_04, u32 textBoxType, u32 textBoxPosition, Text text);
+    void CreateMessageFromTextObject(u32 textId, u32 unk_04, u32 textBoxType, u32 textBoxPosition, const Text& text);
 
     u32 NumMessages();
 

--- a/source/fill.cpp
+++ b/source/fill.cpp
@@ -101,7 +101,7 @@ static int GetMaxGSCount() {
 //where items have been placed so far within the world. The allowedLocations argument
 //specifies the pool of locations that we're trying to search for an accessible location in
 std::vector<ItemLocation*> GetAccessibleLocations(const std::vector<ItemLocation*>& allowedLocations,
-                                                  SearchMode mode /*= REACHABILITY_SEARCH*/) {
+                                                  SearchMode mode) {
   std::vector<ItemLocation*> accessibleLocations = {};
 
   //Reset all access to begin a new search
@@ -113,7 +113,7 @@ std::vector<ItemLocation*> GetAccessibleLocations(const std::vector<ItemLocation
 
   //Variables for playthrough
   int gsCount = 0;
-  const int maxGsCount = GENERATE_PLAYTHROUGH ? GetMaxGSCount() : 0; //If generating playthrough want the max that's possibly useful, else doesn't matter
+  const int maxGsCount = mode == SearchMode::GeneratePlaythrough ? GetMaxGSCount() : 0; //If generating playthrough want the max that's possibly useful, else doesn't matter
   bool bombchusFound = false;
   std::vector<std::string> buyIgnores;
   //Variables for search
@@ -193,7 +193,7 @@ std::vector<ItemLocation*> GetAccessibleLocations(const std::vector<ItemLocation
 
             //Playthrough stuff
             //Generate the playthrough, so we want to add advancement items, unless we know to ignore them
-            if (mode == GENERATE_PLAYTHROUGH) {
+            if (mode == SearchMode::GeneratePlaythrough) {
               //Item is an advancement item, figure out if it should be added to this sphere
               if (!playthroughBeatable && location->GetPlacedItem().IsAdvancement()) {
                 ItemType type = location->GetPlacedItem().GetItemType();
@@ -248,7 +248,7 @@ std::vector<ItemLocation*> GetAccessibleLocations(const std::vector<ItemLocation
               }
             }
             //All we care about is if the game is beatable, used to pare down playthrough
-            else if (mode == CHECK_BEATABLE && location->GetPlacedItem() == I_Triforce) {
+            else if (mode == SearchMode::CheckBeatable && location->GetPlacedItem() == I_Triforce) {
               playthroughBeatable = true;
               return {}; //Return early for efficiency
             }
@@ -259,7 +259,7 @@ std::vector<ItemLocation*> GetAccessibleLocations(const std::vector<ItemLocation
 
     erase_if(exitPool, [](Exit* e){ return e->AllAccountedFor();});
 
-    if (mode == GENERATE_PLAYTHROUGH && sphere.size() > 0) {
+    if (mode == SearchMode::GeneratePlaythrough && sphere.size() > 0) {
       playthroughLocations.push_back(sphere);
     }
 
@@ -277,7 +277,7 @@ std::vector<ItemLocation*> GetAccessibleLocations(const std::vector<ItemLocation
 }
 
 static void GeneratePlaythrough() {
-  GetAccessibleLocations(allLocations, GENERATE_PLAYTHROUGH);
+  GetAccessibleLocations(allLocations, SearchMode::GeneratePlaythrough);
 }
 
 //Remove unnecessary items from playthrough by removing their location, and checking if game is still beatable
@@ -295,7 +295,7 @@ static void PareDownPlaythrough() {
       location->SetPlacedItem(NoItem); //Write in empty item
       playthroughBeatable = false;
       LogicReset();
-      GetAccessibleLocations(allLocations, CHECK_BEATABLE); //Check if game is still beatable
+      GetAccessibleLocations(allLocations, SearchMode::CheckBeatable); //Check if game is still beatable
       //Playthrough is still beatable without this item, therefore it can be removed from playthrough section.
       if (playthroughBeatable) {
         //Uncomment to print playthrough deletion log in citra

--- a/source/fill.cpp
+++ b/source/fill.cpp
@@ -100,8 +100,8 @@ static int GetMaxGSCount() {
 //This function will return a vector of ItemLocations that are accessible with
 //where items have been placed so far within the world. The allowedLocations argument
 //specifies the pool of locations that we're trying to search for an accessible location in
-std::vector<ItemLocation*> GetAccessibleLocations(std::vector<ItemLocation*> allowedLocations, SearchMode mode /*= REACHABILITY_SEARCH*/) {
-
+std::vector<ItemLocation*> GetAccessibleLocations(const std::vector<ItemLocation*>& allowedLocations,
+                                                  SearchMode mode /*= REACHABILITY_SEARCH*/) {
   std::vector<ItemLocation*> accessibleLocations = {};
 
   //Reset all access to begin a new search
@@ -264,7 +264,7 @@ std::vector<ItemLocation*> GetAccessibleLocations(std::vector<ItemLocation*> all
     }
 
   }
-  erase_if(accessibleLocations, [allowedLocations](ItemLocation* loc){
+  erase_if(accessibleLocations, [&allowedLocations](ItemLocation* loc){
     for (ItemLocation* allowedLocation : allowedLocations) {
       if (loc == allowedLocation) {
         return false;
@@ -350,8 +350,7 @@ static void FastFill(std::vector<Item> items, std::vector<ItemLocation*> locatio
 | This method helps distribution of items locked behind many requirements.
 | - OoT Randomizer
 */
-static void AssumedFill(std::vector<Item> items, std::vector<ItemLocation*> allowedLocations, bool setLocationsAsHintable = false) {
-
+static void AssumedFill(const std::vector<Item>& items, const std::vector<ItemLocation*>& allowedLocations, bool setLocationsAsHintable = false) {
   if (items.size() > allowedLocations.size()) {
     printf("\x1b[H1;1ERROR: MORE ITEMS THAN LOCATIONS");
   }
@@ -384,7 +383,7 @@ static void AssumedFill(std::vector<Item> items, std::vector<ItemLocation*> allo
       }
 
       //get all accessible locations that are allowed
-      std::vector<ItemLocation*> accessibleLocations = GetAccessibleLocations(allowedLocations);
+      const std::vector<ItemLocation*> accessibleLocations = GetAccessibleLocations(allowedLocations);
 
       //retry if there are no more locations to place items
       if (accessibleLocations.empty()) {
@@ -409,7 +408,7 @@ static void AssumedFill(std::vector<Item> items, std::vector<ItemLocation*> allo
       }
 
       //place the item within one of the allowed locations
-      ItemLocation* selectedLocation = RandomElement(accessibleLocations, false);
+      ItemLocation* selectedLocation = RandomElement(accessibleLocations);
       PlaceItemInLocation(selectedLocation, item);
       attemptedLocations.push_back(selectedLocation);
 

--- a/source/fill.hpp
+++ b/source/fill.hpp
@@ -2,15 +2,15 @@
 
 #include <vector>
 
-extern int Fill();
-
 class ItemLocation;
 
-enum SearchMode {
-    REACHABILITY_SEARCH,
-    GENERATE_PLAYTHROUGH,
-    CHECK_BEATABLE
+enum class SearchMode {
+    ReachabilitySearch,
+    GeneratePlaythrough,
+    CheckBeatable,
 };
 
+int Fill();
+
 std::vector<ItemLocation*> GetAccessibleLocations(const std::vector<ItemLocation*>& allowedLocations,
-                                                  SearchMode mode = REACHABILITY_SEARCH);
+                                                  SearchMode mode = SearchMode::ReachabilitySearch);

--- a/source/fill.hpp
+++ b/source/fill.hpp
@@ -5,5 +5,12 @@
 extern int Fill();
 
 class ItemLocation;
-enum SearchMode {REACHABILITY_SEARCH, GENERATE_PLAYTHROUGH, CHECK_BEATABLE};
-extern std::vector<ItemLocation*> GetAccessibleLocations(std::vector<ItemLocation*> allowedLocations, SearchMode mode = REACHABILITY_SEARCH);
+
+enum SearchMode {
+    REACHABILITY_SEARCH,
+    GENERATE_PLAYTHROUGH,
+    CHECK_BEATABLE
+};
+
+std::vector<ItemLocation*> GetAccessibleLocations(const std::vector<ItemLocation*>& allowedLocations,
+                                                  SearchMode mode = REACHABILITY_SEARCH);

--- a/source/hints.cpp
+++ b/source/hints.cpp
@@ -150,13 +150,11 @@ static std::vector<ItemLocation*> GetAccessibleGossipStones(ItemLocation* hinted
   hintedLocation->SetPlacedItem(NoItem);
 
   LogicReset();
-  std::vector<ItemLocation*> accessibleGossipStones = GetAccessibleLocations(gossipStoneLocations);
-  hintedLocation->SetPlacedItem(originalItem);
 
-  return accessibleGossipStones;
+  return GetAccessibleLocations(gossipStoneLocations);
 }
 
-static void AddHint(Text hint, ItemLocation* gossipStone, const std::vector<u8>& colors = {}) {
+static void AddHint(const Text& hint, ItemLocation* gossipStone, const std::vector<u8>& colors = {}) {
   //save hints as dummy items to gossip stone locations for writing to the spoiler log
   gossipStone->SetPlacedItem(Item{hint.GetEnglish(), ITEMTYPE_EVENT, GI_RUPEE_BLUE_LOSE, false, &noVariable, &Hints::NoHintText});
 
@@ -165,15 +163,15 @@ static void AddHint(Text hint, ItemLocation* gossipStone, const std::vector<u8>&
   CreateMessageFromTextObject(messageId, 0, 2, 3, AddColorsAndFormat(hint, colors));
 }
 
-static void CreateLocationHint(std::vector<ItemLocation*> possibleHintLocations) {
+static void CreateLocationHint(const std::vector<ItemLocation*>& possibleHintLocations) {
   //return if there aren't any hintable locations or gossip stones available
   if (possibleHintLocations.empty()) {
     PlacementLog_Msg("\tNO LOCATIONS TO HINT\n\n");
     return;
   }
 
-  ItemLocation* hintedLocation = RandomElement(possibleHintLocations, false);
-  std::vector<ItemLocation*> accessibleGossipStones = GetAccessibleGossipStones(hintedLocation);
+  ItemLocation* hintedLocation = RandomElement(possibleHintLocations);
+  const std::vector<ItemLocation*> accessibleGossipStones = GetAccessibleGossipStones(hintedLocation);
 
   PlacementLog_Msg("\tLocation: ");
   PlacementLog_Msg(hintedLocation->GetName());
@@ -188,13 +186,13 @@ static void CreateLocationHint(std::vector<ItemLocation*> possibleHintLocations)
     return;
   }
 
-  ItemLocation* gossipStone = RandomElement(accessibleGossipStones, false);
+  ItemLocation* gossipStone = RandomElement(accessibleGossipStones);
   hintedLocation->SetAsHinted();
 
   //make hint text
-  Text locationHintText = hintedLocation->GetHintText().GetText();
-  Text itemHintText = hintedLocation->GetPlacedItem().GetHintText().GetText();
-  Text prefix = Hints::Prefix.GetText();
+  const Text& locationHintText = hintedLocation->GetHintText().GetText();
+  const Text& itemHintText = hintedLocation->GetPlacedItem().GetHintText().GetText();
+  const Text& prefix = Hints::Prefix.GetText();
 
   Text finalHint = prefix + locationHintText + " #"+itemHintText+"#.";
   PlacementLog_Msg("\tMessage: ");
@@ -221,7 +219,7 @@ static void CreateWothHint(u8* remainingDungeonWothHints) {
     PlacementLog_Msg("\tNO LOCATIONS TO HINT\n\n");
     return;
   }
-  ItemLocation* hintedLocation = RandomElement(possibleHintLocations, false);
+  ItemLocation* hintedLocation = RandomElement(possibleHintLocations);
 
   PlacementLog_Msg("\tLocation: ");
   PlacementLog_Msg(hintedLocation->GetName());
@@ -232,17 +230,17 @@ static void CreateWothHint(u8* remainingDungeonWothHints) {
   PlacementLog_Msg("\n");
 
   //get an accessible gossip stone
-  std::vector<ItemLocation*> gossipStoneLocations = GetAccessibleGossipStones(hintedLocation);
+  const std::vector<ItemLocation*> gossipStoneLocations = GetAccessibleGossipStones(hintedLocation);
 
   if (gossipStoneLocations.empty()) {
     PlacementLog_Msg("\tNO GOSSIP STONES TO PLACE HINT\n\n");
     return;
   }
   hintedLocation->SetAsHinted();
-  ItemLocation* gossipStone = RandomElement(gossipStoneLocations, false);
+  ItemLocation* gossipStone = RandomElement(gossipStoneLocations);
 
   //form hint text
-  Text locationText = Text{"","",""};
+  Text locationText;
   if (hintedLocation->IsDungeon()) {
     *remainingDungeonWothHints -= 1;
     locationText = hintedLocation->GetParentRegion()->hintText->GetText();
@@ -277,17 +275,16 @@ static void CreateBarrenHint(u8* remainingDungeonBarrenHints, std::vector<ItemLo
   PlacementLog_Msg("\n");
 
   //get an accessible gossip stone
-  std::vector<ItemLocation*> gossipStoneLocations = GetAccessibleGossipStones(hintedLocation);
-
+  const std::vector<ItemLocation*> gossipStoneLocations = GetAccessibleGossipStones(hintedLocation);
   if (gossipStoneLocations.empty()) {
     PlacementLog_Msg("\tNO GOSSIP STONES TO PLACE HINT\n\n");
     return;
   }
   hintedLocation->SetAsHinted();
-  ItemLocation* gossipStone = RandomElement(gossipStoneLocations, false);
+  ItemLocation* gossipStone = RandomElement(gossipStoneLocations);
 
   //form hint text
-  Text locationText = Text{"","",""};
+  Text locationText;
   if (hintedLocation->IsDungeon()) {
     *remainingDungeonBarrenHints -= 1;
     locationText = hintedLocation->GetParentRegion()->hintText->GetText();
@@ -307,14 +304,16 @@ static void CreateBarrenHint(u8* remainingDungeonBarrenHints, std::vector<ItemLo
 
 }
 
-static void CreateRandomLocationHint(bool goodItem = false){
-  std::vector<ItemLocation*> possibleHintLocations = FilterFromPool(allLocations, [goodItem](ItemLocation* loc){return loc->IsHintable() && !loc->IsHintedAt() && (!goodItem || loc->GetPlacedItem().IsMajorItem());});
+static void CreateRandomLocationHint(bool goodItem = false) {
+  const std::vector<ItemLocation*> possibleHintLocations = FilterFromPool(allLocations, [goodItem](const ItemLocation* loc) {
+    return loc->IsHintable() && !loc->IsHintedAt() && (!goodItem || loc->GetPlacedItem().IsMajorItem());
+  });
   //If no more locations can be hinted at, then just try to get another hint
   if (possibleHintLocations.empty()) {
     PlacementLog_Msg("\tNO LOCATIONS TO HINT\n\n");
     return;
   }
-  ItemLocation* hintedLocation = RandomElement(possibleHintLocations, false);
+  ItemLocation* hintedLocation = RandomElement(possibleHintLocations);
 
   PlacementLog_Msg("\tLocation: ");
   PlacementLog_Msg(hintedLocation->GetName());
@@ -325,27 +324,25 @@ static void CreateRandomLocationHint(bool goodItem = false){
   PlacementLog_Msg("\n");
 
   //get an acessible gossip stone
-  std::vector<ItemLocation*> gossipStoneLocations = GetAccessibleGossipStones(hintedLocation);
-
+  const std::vector<ItemLocation*> gossipStoneLocations = GetAccessibleGossipStones(hintedLocation);
   if (gossipStoneLocations.empty()) {
     PlacementLog_Msg("\tNO GOSSIP STONES TO PLACE HINT\n\n");
     return;
   }
   hintedLocation->SetAsHinted();
-  ItemLocation* gossipStone = RandomElement(gossipStoneLocations, false);
-
+  ItemLocation* gossipStone = RandomElement(gossipStoneLocations);
 
   //form hint text
-  Text itemText = hintedLocation->GetPlacedItem().GetHintText().GetText();
+  const Text& itemText = hintedLocation->GetPlacedItem().GetHintText().GetText();
   if (hintedLocation->IsDungeon()) {
-    Text locationText = hintedLocation->GetParentRegion()->hintText->GetText();
+    const Text& locationText = hintedLocation->GetParentRegion()->hintText->GetText();
     Text finalHint = Hints::Prefix.GetText()+"#"+locationText+"# hoards #"+itemText+"#.";
     PlacementLog_Msg("\tMessage: ");
     PlacementLog_Msg(finalHint.english);
     PlacementLog_Msg("\n\n");
     AddHint(finalHint, gossipStone, {QM_GREEN, QM_RED});
   } else {
-    Text locationText = GetHintRegion(hintedLocation->GetParentRegion())->hintText->GetText();
+    const Text& locationText = GetHintRegion(hintedLocation->GetParentRegion())->hintText->GetText();
     Text finalHint = Hints::Prefix.GetText()+"#"+itemText+"# can be found at #"+locationText+"#.";
     PlacementLog_Msg("\tMessage: ");
     PlacementLog_Msg(finalHint.english);
@@ -360,15 +357,15 @@ static void CreateGoodItemHint() {
 
 static void CreateJunkHint() {
   //duplicate junk hints are possible for now
-  HintText* junkHint = RandomElement(Hints::junkHints);
+  const HintText* junkHint = RandomElement(Hints::junkHints);
   LogicReset();
-  std::vector<ItemLocation*> gossipStones = GetAccessibleLocations(gossipStoneLocations);
+  const std::vector<ItemLocation*> gossipStones = GetAccessibleLocations(gossipStoneLocations);
   if (gossipStones.empty()) {
     PlacementLog_Msg("\tNO GOSSIP STONES TO PLACE HINT\n\n");
     return;
   }
-  ItemLocation* gossipStone = RandomElement(gossipStones, false);
-  Text hintText = junkHint->GetText();
+  ItemLocation* gossipStone = RandomElement(gossipStones);
+  const Text& hintText = junkHint->GetText();
 
   PlacementLog_Msg("\tMessage: ");
   PlacementLog_Msg(hintText.english);
@@ -383,19 +380,19 @@ static std::vector<ItemLocation*> CalculateBarrenRegions() {
 
   for (ItemLocation* location : allLocations) {
     if (location->GetPlacedItem().IsMajorItem()) {
-      AddElementsToPool(potentiallyUsefulLocations, std::vector<ItemLocation*>{location});
+      AddElementsToPool(potentiallyUsefulLocations, std::vector{location});
     } else {
       if (location != &LinksPocket) { //Nobody cares to know if Link's Pocket is barren
-        AddElementsToPool(barrenLocations, std::vector<ItemLocation*>{location});
+        AddElementsToPool(barrenLocations, std::vector{location});
       }
     }
   }
 
   //leave only locations at barren regions in the list
-  auto finalBarrenLocations = FilterFromPool(barrenLocations, [potentiallyUsefulLocations](ItemLocation* loc){
+  auto finalBarrenLocations = FilterFromPool(barrenLocations, [&potentiallyUsefulLocations](ItemLocation* loc){
     for (ItemLocation* usefulLoc : potentiallyUsefulLocations) {
-      HintText* barren = GetHintRegion(loc->GetParentRegion())->hintText;
-      HintText* useful = GetHintRegion(usefulLoc->GetParentRegion())->hintText;
+      const HintText* barren = GetHintRegion(loc->GetParentRegion())->hintText;
+      const HintText* useful = GetHintRegion(usefulLoc->GetParentRegion())->hintText;
       if (barren == useful) {
         return false;
       }
@@ -469,17 +466,18 @@ static void CreateTrialHints() {
 
 void CreateAllHints() {
   PlacementLog_Msg("\nNOW CREATING HINTS\n");
-  HintSetting hintSetting = hintSettingTable[Settings::HintDistribution.Value<u8>()];
+  const HintSetting& hintSetting = hintSettingTable[Settings::HintDistribution.Value<u8>()];
 
   u8 remainingDungeonWothHints = hintSetting.dungeonsWothLimit;
   u8 remainingDungeonBarrenHints = hintSetting.dungeonsBarrenLimit;
 
-  //Add 'always' location hints
+  // Add 'always' location hints
   if (hintSetting.distTable[static_cast<int>(HintType::Always)].copies > 0) {
-
-    //only filter locations that had a random item placed at them (e.g. don't get cow locations if shuffle cows is off)
-    std::vector<ItemLocation*> alwaysHintLocations = FilterFromPool(allLocations, [](ItemLocation* loc){return loc->GetHintCategory() == HintCategory::Always &&
-                                                                                                               loc->IsHintable()      && !loc->IsHintedAt();});
+    // Only filter locations that had a random item placed at them (e.g. don't get cow locations if shuffle cows is off)
+    const auto alwaysHintLocations = FilterFromPool(allLocations, [](const ItemLocation* loc){
+        return loc->GetHintCategory() == HintCategory::Always &&
+               loc->IsHintable()      && !loc->IsHintedAt();
+    });
     for (ItemLocation* location : alwaysHintLocations) {
       CreateLocationHint({location});
     }

--- a/source/hints.hpp
+++ b/source/hints.hpp
@@ -165,16 +165,11 @@ public:
     }
 
     bool operator==(const HintText& right) const {
-        if (obscureText.size() != right.obscureText.size()) {
-          return false;
-        }
-        for (size_t i = 0; i < obscureText.size(); i++) {
-          if (obscureText[i] != right.obscureText[i]) {
-            return false;
-          }
-        }
-
-        return clearText == right.clearText;
+        return obscureText == right.obscureText &&
+               clearText == right.clearText;
+    }
+    bool operator!=(const HintText& right) const {
+        return !operator==(right);
     }
 
 private:

--- a/source/hints.hpp
+++ b/source/hints.hpp
@@ -138,18 +138,22 @@ public:
         return HintText{std::move(obscureText), std::move(clearText), HintCategory::GanonLine};
     }
 
-    Text GetObscure() {
-        return RandomElement(obscureText, false);
+    Text& GetObscure() {
+        return RandomElement(obscureText);
     }
 
-    Text GetClear() {
+    const Text& GetObscure() const {
+        return RandomElement(obscureText);
+    }
+
+    const Text& GetClear() const {
         if (clearText.GetEnglish() == NONE) {
             return GetObscure();
         }
         return clearText;
     }
 
-    Text GetText() {
+    const Text& GetText() const {
         if (Settings::ClearerHints) {
             return GetClear();
         }

--- a/source/random.hpp
+++ b/source/random.hpp
@@ -19,9 +19,13 @@ T RandomElement(std::vector<T>& vector, bool erase) {
     }
     return selected;
 }
-template <typename T, std::size_t size>
-T RandomElement(const std::array<T, size>& arr) {
-    return arr[Random(0, arr.size())];
+template <typename Container>
+auto& RandomElement(Container& container) {
+    return container[Random(0, std::size(container))];
+}
+template <typename Container>
+const auto& RandomElement(const Container& container) {
+    return container[Random(0, std::size(container))];
 }
 
 //Shuffle items within a vector or array

--- a/source/text.hpp
+++ b/source/text.hpp
@@ -4,23 +4,24 @@
 
 class Text {
 public:
+    Text() = default;
     Text(std::string english_, std::string french_, std::string spanish_)
       : english(std::move(english_)),
         french(std::move(french_)),
         spanish(std::move(spanish_)) {}
 
-    std::string GetEnglish() const {
+    const std::string& GetEnglish() const {
         return english;
     }
 
-    std::string GetFrench() const {
+    const std::string& GetFrench() const {
         if (french.length() > 0) {
             return french;
         }
         return english;
     }
 
-    std::string GetSpanish() const {
+    const std::string& GetSpanish() const {
         if (spanish.length() > 0) {
             return spanish;
         }


### PR DESCRIPTION
Gets rid of some object churn and makes it much more evident through reading whether or not an object is being changed.
We can also generalize RandomElement to operate on more than just arrays.

Turning the SearchMode enum into an enum class also uncovered a bug when determining the max GS count in `GetAccessibleLocations` in that the ternary expression would always evaluate to true, since regular enum values aren't strongly typed and implicitly convert to bool, meaning the true path would always be taken.