### PR TITLE
Add switch for Lake Hylia water level. Fix CSMC bugs

### DIFF
--- a/code/include/z3D/z3D.h
+++ b/code/include/z3D/z3D.h
@@ -550,4 +550,8 @@ typedef void (*PlaySound_proc)(u32);
 #define PlaySound_addr 0x35C528
 #define PlaySound ((PlaySound_proc)PlaySound_addr) //this function plays sound effects and music tracks, overlaid on top of the current BGM
 
+typedef Actor* (*Actor_Spawn_proc)(ActorContext *actorCtx,GlobalContext *globalCtx,s16 actorId,float posX,float posY,float posZ,s16 rotX,s16 rotY,s16 rotZ,s16 params);
+#define Actor_Spawn_addr 0x3738D0
+#define Actor_Spawn ((Actor_Spawn_proc)Actor_Spawn_addr)
+
 #endif //_Z3D_H_

--- a/code/src/actor.c
+++ b/code/src/actor.c
@@ -19,6 +19,7 @@
 #include "gerudo_archery_manager.h"
 #include "chest.h"
 #include "gossip_stone.h"
+#include "lake_hylia_objects.h"
 
 #define OBJECT_GI_HEARTS 189
 #define OBJECT_GI_OCARINA 222
@@ -41,6 +42,9 @@ void Actor_Init() {
     gActorOverlayTable[0x8B].initInfo->destroy = DemoEffect_rDestroy;
 
     gActorOverlayTable[0xC3].initInfo->draw = EnNb_rDraw;
+
+    gActorOverlayTable[0xD5].initInfo->update = BgSpot06Objects_rUpdate;
+    gActorOverlayTable[0xD5].initInfo->destroy = BgSpot06Objects_rDestroy;
 
     gActorOverlayTable[0xDC].initInfo->init = Boss_Tw_rInit;
     gActorOverlayTable[0xDC].initInfo->update = Boss_Tw_rUpdate;

--- a/code/src/chest.c
+++ b/code/src/chest.c
@@ -15,7 +15,8 @@ static u8 type = 0;
 static u8 checkedForBombchus = 0;
 
 void EnBox_rInit(Actor* thisx, GlobalContext* globalCtx){
-
+    u8 vanilla = 0;
+    
     if(!checkedForBombchus && gSettingsContext.bombchusInLogic && gSaveContext.items[8] == 0xFF){
         ItemTable_SetBombchusChestType(0);
         checkedForBombchus = 1;
@@ -24,22 +25,26 @@ void EnBox_rInit(Actor* thisx, GlobalContext* globalCtx){
         ItemTable_SetBombchusChestType(1);
         checkedForBombchus = 0;
     }
+                                                                   // treasure box shop chests
+    if ((gSettingsContext.chestSize == VANILLA_SIZE) || (globalCtx->sceneNum == 16 && thisx->room != 6)){
+        vanilla = 1;
+    } 
     
     ItemOverride thisOverride = ItemOverride_Lookup(thisx, globalCtx->sceneNum, 0);
     ItemRow* thisItemRow;
-    if (thisOverride.key.all == 0){
-        thisItemRow = ItemTable_GetItemRowFromIndex((thisx->params & 0x0FE0) >> 5); //for unused chests that aren't randomized
+    if(vanilla || thisOverride.key.all == 0){
+        thisItemRow = ItemTable_GetItemRowFromIndex((thisx->params & 0x0FE0) >> 5); //get type from vanilla item table
     }       
     else{
         thisItemRow = ItemTable_GetItemRow(ItemTable_ResolveUpgrades(thisOverride.value.itemId));
     }
     type = thisItemRow->chestType;
-                                                                   // treasure box shop chests
-    if((gSettingsContext.chestSize == VANILLA_SIZE) || (globalCtx->sceneNum == 16 && thisx->room != 6)){
-        return EnBox_Init(thisx, globalCtx);
-    }
     
     EnBox_Init(thisx, globalCtx);
+    
+    if(vanilla){
+        return;
+    } 
     
     if(type == WOODEN_BIG || type == DECORATED_BIG){
         //Make chest BIG

--- a/code/src/chest.c
+++ b/code/src/chest.c
@@ -15,7 +15,8 @@ static u8 type = 0;
 static u8 checkedForBombchus = 0;
 
 void EnBox_rInit(Actor* thisx, GlobalContext* globalCtx){
-    u8 vanilla = 0;
+                                                                 // treasure box shop chests
+    u8 vanilla = (gSettingsContext.chestSize == VANILLA_SIZE) || (globalCtx->sceneNum == 16 && thisx->room != 6);
     
     if(!checkedForBombchus && gSettingsContext.bombchusInLogic && gSaveContext.items[8] == 0xFF){
         ItemTable_SetBombchusChestType(0);
@@ -25,10 +26,6 @@ void EnBox_rInit(Actor* thisx, GlobalContext* globalCtx){
         ItemTable_SetBombchusChestType(1);
         checkedForBombchus = 0;
     }
-                                                                   // treasure box shop chests
-    if ((gSettingsContext.chestSize == VANILLA_SIZE) || (globalCtx->sceneNum == 16 && thisx->room != 6)){
-        vanilla = 1;
-    } 
     
     ItemOverride thisOverride = ItemOverride_Lookup(thisx, globalCtx->sceneNum, 0);
     ItemRow* thisItemRow;
@@ -43,6 +40,7 @@ void EnBox_rInit(Actor* thisx, GlobalContext* globalCtx){
     EnBox_Init(thisx, globalCtx);
     
     if(vanilla){
+        type = 0;
         return;
     } 
     

--- a/code/src/chest.c
+++ b/code/src/chest.c
@@ -24,10 +24,6 @@ void EnBox_rInit(Actor* thisx, GlobalContext* globalCtx){
         ItemTable_SetBombchusChestType(1);
         checkedForBombchus = 0;
     }
-                                                                   // treasure box shop chests
-    if((gSettingsContext.chestSize == VANILLA_SIZE) || (globalCtx->sceneNum == 16 && thisx->room != 6)){
-        return EnBox_Init(thisx, globalCtx);
-    }
     
     ItemOverride thisOverride = ItemOverride_Lookup(thisx, globalCtx->sceneNum, 0);
     ItemRow* thisItemRow;
@@ -38,6 +34,10 @@ void EnBox_rInit(Actor* thisx, GlobalContext* globalCtx){
         thisItemRow = ItemTable_GetItemRow(ItemTable_ResolveUpgrades(thisOverride.value.itemId));
     }
     type = thisItemRow->chestType;
+                                                                   // treasure box shop chests
+    if((gSettingsContext.chestSize == VANILLA_SIZE) || (globalCtx->sceneNum == 16 && thisx->room != 6)){
+        return EnBox_Init(thisx, globalCtx);
+    }
     
     EnBox_Init(thisx, globalCtx);
     
@@ -70,6 +70,7 @@ void EnBox_rInit(Actor* thisx, GlobalContext* globalCtx){
             thisx->world.pos.x = 400.0f;
         }
     }
+    type = 0;
 }
 
 u8 Chest_OverrideAnimation(){

--- a/code/src/lake_hylia_objects.c
+++ b/code/src/lake_hylia_objects.c
@@ -1,0 +1,109 @@
+#include "z3D/z3D.h"
+#include "lake_hylia_objects.h"
+#include "objects.h"
+
+#define BgSpot06Objects_Update_addr 0x3833F8
+#define BgSpot06Objects_Update ((ActorFunc)BgSpot06Objects_Update_addr)
+
+#define BgSpot06Objects_Destroy_addr 0x2AD1E4
+#define BgSpot06Objects_Destroy ((ActorFunc)BgSpot06Objects_Destroy_addr)
+
+static u8 actionCounter = 0; //used to perform some actions on subsequent frames
+static s8 waterMovement = 0; //to be used when implementing moving water plane
+static Actor* floorSwitch;
+
+void BgSpot06Objects_rUpdate(Actor* thisx, GlobalContext* globalCtx){
+    BgSpot06Objects_Update(thisx, globalCtx);
+    if(gSaveContext.linkAge==1) return; //don't do anything for child Link
+
+    if(actionCounter==0){
+        Object_Spawn((&(globalCtx->objectCtx)), 0x3); //object containing floor switch data (and ice block data)
+
+        //Spawn a floor switch
+        floorSwitch = Actor_Spawn((&(globalCtx->actorCtx)), globalCtx, 0x12A, 0.0f, 0.0f, 0.0f, 0, 0, 0, 0);
+        if(gSaveContext.eventChkInf[4] & 0x0400){//Water Temple blue warp cleared
+            floorSwitch->params = 0x3E10; //Toggle-able floor switch, linked to temp_switch 0x1E (room temporary, cleared when room unloads)
+        }
+        else{
+            floorSwitch->params = 0x3E81; //Frozen rusty switch, same flag as above. It's glitched and can't be pressed, which is perfect
+        }
+        //Setting some data before the switch is initialized on the next frame
+        floorSwitch->world.pos.x = -896.0f; //the focus point of the switch cutscene is copied from here, then the world.pos is reset by the Init function(?)
+        floorSwitch->world.pos.y = -1243.0f;
+        floorSwitch->world.pos.z =  6953.0f;
+        floorSwitch->home.pos.x = -896.0f; //the ice spawns at the home position
+        floorSwitch->home.pos.y = -1243.0f;
+        floorSwitch->home.pos.z =  6953.0f;
+        //if Lake Hylia's water is lowered, set the temp_switch flag
+        if(!(gSaveContext.eventChkInf[6] & 0x0200)){
+            globalCtx->actorCtx.flags.tempSwch |= (0x40 << 24);
+        }
+
+        //Spawn a sign
+        Actor* sign = Actor_Spawn((&(globalCtx->actorCtx)), globalCtx, 0x141, 0.0f, 0.0f, 0.0f, 0, 0, 0, 0);
+        sign->params = 0x0046;
+        sign->world.pos.x = -970.0f;
+        sign->world.pos.y = -1242.0f;
+        sign->world.pos.z =  6954.0f;
+
+        //Spawn a Navi check spot
+        if(!(gSaveContext.eventChkInf[4] & 0x0400)){//Water Temple blue warp not cleared
+            Actor* naviMsg = Actor_Spawn((&(globalCtx->actorCtx)), globalCtx, 0x173, 0.0f, 0.0f, 0.0f, 0, 0, 0, 0);
+            naviMsg->params = 0x3DB2;
+            naviMsg->world.pos.x = -896.0f;
+            naviMsg->world.pos.y = -1243.0f;
+            naviMsg->world.pos.z =  6953.0f;
+            naviMsg->focus.pos.x = -896.0f;
+            naviMsg->focus.pos.y = -1243.0f;
+            naviMsg->focus.pos.z =  6953.0f;
+        }
+
+        actionCounter++;
+        return;
+    }
+    else if(actionCounter==1){
+        //put the switch in the right place after it's been initialized
+        floorSwitch->world.pos.x = -896.0f;
+        floorSwitch->world.pos.y = -1242.0f;
+        floorSwitch->world.pos.z =  6953.0f;
+        if(!(gSaveContext.eventChkInf[4] & 0x0400)){//Water Temple blue warp not cleared
+            //remove link to ice block so melting that doesn't set the flag
+            floorSwitch->params = 0x3E01;
+        }
+        actionCounter++;
+        return;
+    }
+
+    if(globalCtx->actorCtx.flags.tempSwch & (0x40 << 24)){//switch pressed
+        if(thisx->params==0x0002 && gSaveContext.eventChkInf[6] & 0x0200){//if water is raised, lower it
+            waterMovement = -1;
+            PlaySound(0x100025B);
+            gSaveContext.eventChkInf[6] &= ~0x0200;
+            //TODO: remove this warp when the water will properly move
+            globalCtx->nextEntranceIndex = 0x0604;
+            globalCtx->sceneLoadFlag = 0x14;
+        }
+    }
+    else{
+        if(thisx->params==0x0002 && !(gSaveContext.eventChkInf[6] & 0x0200)){
+            waterMovement = 1;
+            PlaySound(0x100025B);
+            gSaveContext.eventChkInf[6] |= 0x0200;
+            //TODO: remove this warp when the water will properly move
+            globalCtx->nextEntranceIndex = 0x0604;
+            globalCtx->sceneLoadFlag = 0x14;
+        }
+    }
+/*  //TODO: change shape of the water texture to cover the entire lake, then change collision context stuff to make the water plane move
+    //this only moves the texture
+    if(thisx->params==0x0002 && thisx->world.pos.y <= -1313 && thisx->world.pos.y >= -1994){
+        thisx->world.pos.y += waterMovement;
+    }
+*/
+}
+
+void BgSpot06Objects_rDestroy(Actor* thisx, GlobalContext* globalCtx){
+    BgSpot06Objects_Destroy(thisx, globalCtx);
+    actionCounter = 0;
+    waterMovement = 0;
+}

--- a/code/src/lake_hylia_objects.h
+++ b/code/src/lake_hylia_objects.h
@@ -1,0 +1,9 @@
+#ifndef _LAKE_HYLIA_OBJECTS_H_
+#define _LAKE_HYLIA_OBJECTS_H_
+
+#include "z3D/z3D.h"
+
+void BgSpot06Objects_rUpdate(Actor* thisx, GlobalContext* globalCtx);
+void BgSpot06Objects_rDestroy(Actor* thisx, GlobalContext* globalCtx);
+
+#endif //_LAKE_HYLIA_OBJECTS_H_

--- a/source/custom_messages.cpp
+++ b/source/custom_messages.cpp
@@ -196,12 +196,12 @@ constexpr std::array DungeonColors = {
             u32 dungeon = DUNGEON_FOREST_TEMPLE + bossKey;
             CreateMessage(0x9D4 + bossKey, 0, 2, 3,
                 UNSKIPPABLE()+ITEM_OBTAINED(ITEM_KEY_BOSS)+INSTANT_TEXT_ON()+"You got the "+COLOR(DungeonColors[dungeon])+EnglishDungeonNames[dungeon]+NEWLINE()+"Boss Key"+COLOR(QM_WHITE)+"!"+INSTANT_TEXT_OFF()+MESSAGE_END(),
-                UNSKIPPABLE()+ITEM_OBTAINED(ITEM_KEY_BOSS)+INSTANT_TEXT_ON()+"Vous trouvez la "+COLOR(DungeonColors[dungeon])+"grande clé du boss "+NEWLINE()+FrenchDungeonArticles[dungeon]+FrenchDungeonNames[dungeon]+COLOR(QM_WHITE)+"!"+INSTANT_TEXT_OFF()+MESSAGE_END(),
+                UNSKIPPABLE()+ITEM_OBTAINED(ITEM_KEY_BOSS)+INSTANT_TEXT_ON()+"Vous trouvez la "+COLOR(DungeonColors[dungeon])+"grande clé du boss "+NEWLINE()+FrenchDungeonArticles[dungeon]+" "+FrenchDungeonNames[dungeon]+COLOR(QM_WHITE)+"!"+INSTANT_TEXT_OFF()+MESSAGE_END(),
                 UNSKIPPABLE()+ITEM_OBTAINED(ITEM_KEY_BOSS)+INSTANT_TEXT_ON()+"¡Tienes la "+COLOR(DungeonColors[dungeon])+"gran llave "+SpanishDungeonArticles[dungeon]+NEWLINE()+SpanishDungeonNames[dungeon]+COLOR(QM_WHITE)+"!"+INSTANT_TEXT_OFF()+MESSAGE_END());
         }
         CreateMessage(0x9D9, 0, 2, 3,
             UNSKIPPABLE()+ITEM_OBTAINED(ITEM_KEY_BOSS)+INSTANT_TEXT_ON()+"You got the "+COLOR(DungeonColors[DUNGEON_GANONS_CASTLE_FIRST_PART])+EnglishDungeonNames[DUNGEON_GANONS_CASTLE_FIRST_PART]+NEWLINE()+"Boss Key"+COLOR(QM_WHITE)+"!"+INSTANT_TEXT_OFF()+MESSAGE_END(),
-            UNSKIPPABLE()+ITEM_OBTAINED(ITEM_KEY_BOSS)+INSTANT_TEXT_ON()+"Vous trouvez la "+COLOR(DungeonColors[DUNGEON_GANONS_CASTLE_FIRST_PART])+"grande clé du boss "+NEWLINE()+FrenchDungeonArticles[DUNGEON_GANONS_CASTLE_FIRST_PART]+FrenchDungeonNames[DUNGEON_GANONS_CASTLE_FIRST_PART]+COLOR(QM_WHITE)+"!"+INSTANT_TEXT_OFF()+MESSAGE_END(),
+            UNSKIPPABLE()+ITEM_OBTAINED(ITEM_KEY_BOSS)+INSTANT_TEXT_ON()+"Vous trouvez la "+COLOR(DungeonColors[DUNGEON_GANONS_CASTLE_FIRST_PART])+"grande clé du boss "+NEWLINE()+FrenchDungeonArticles[DUNGEON_GANONS_CASTLE_FIRST_PART]+" "+FrenchDungeonNames[DUNGEON_GANONS_CASTLE_FIRST_PART]+COLOR(QM_WHITE)+"!"+INSTANT_TEXT_OFF()+MESSAGE_END(),
             UNSKIPPABLE()+ITEM_OBTAINED(ITEM_KEY_BOSS)+INSTANT_TEXT_ON()+"¡Tienes la "+COLOR(DungeonColors[DUNGEON_GANONS_CASTLE_FIRST_PART])+"gran llave "+SpanishDungeonArticles[DUNGEON_GANONS_CASTLE_FIRST_PART]+NEWLINE()+SpanishDungeonNames[DUNGEON_GANONS_CASTLE_FIRST_PART]+COLOR(QM_WHITE)+"!"+INSTANT_TEXT_OFF()+MESSAGE_END());
         //Compasses
         for (u32 dungeon = DUNGEON_DEKU_TREE; dungeon <= DUNGEON_ICE_CAVERN; dungeon++) {
@@ -298,15 +298,15 @@ constexpr std::array DungeonColors = {
             UNSKIPPABLE()+INSTANT_TEXT_ON()+CENTER_TEXT()+"Vous pouvez désormais jouer à"+NEWLINE()+CENTER_TEXT()+"The Legend of Zelda Ocarina of Time 3D"+NEWLINE()+CENTER_TEXT()+"Master Quest!"+INSTANT_TEXT_OFF()+MESSAGE_END(),
             UNSKIPPABLE()+INSTANT_TEXT_ON()+CENTER_TEXT()+"¡Ya puedes jugar The Legend of Zelda"+NEWLINE()+CENTER_TEXT()+"Ocarina of Time 3D Master Quest!"+INSTANT_TEXT_OFF()+MESSAGE_END());
         
-        //messages for the new Lake Hylia switch
+        //Messages for the new Lake Hylia switch
         CreateMessage(0x346, 0, 1, 3,
             UNSKIPPABLE()+INSTANT_TEXT_ON()+CENTER_TEXT()+"Water level control system."+NEWLINE()+CENTER_TEXT()+"Keep away!"+INSTANT_TEXT_OFF()+MESSAGE_END(),
-            UNSKIPPABLE()+INSTANT_TEXT_ON()+CENTER_TEXT()+"Water level control system."+NEWLINE()+CENTER_TEXT()+"Keep away!"+INSTANT_TEXT_OFF()+MESSAGE_END(),
-            UNSKIPPABLE()+INSTANT_TEXT_ON()+CENTER_TEXT()+"Water level control system."+NEWLINE()+CENTER_TEXT()+"Keep away!"+INSTANT_TEXT_OFF()+MESSAGE_END());
+            UNSKIPPABLE()+INSTANT_TEXT_ON()+CENTER_TEXT()+"Contrôle du niveau d'eau."+NEWLINE()+CENTER_TEXT()+"Ne pas toucher!"+INSTANT_TEXT_OFF()+MESSAGE_END(),
+            UNSKIPPABLE()+INSTANT_TEXT_ON()+CENTER_TEXT()+"Control del nivel del agua."+NEWLINE()+CENTER_TEXT()+"¡No te acerques!"+INSTANT_TEXT_OFF()+MESSAGE_END());
         CreateMessage(0x1B2, 0, 0, 3,
-            UNSKIPPABLE()+INSTANT_TEXT_ON()+"This switch is rustier than you think."+WAIT_FOR_INPUT()+"Something must be wrong with the pipe"+NEWLINE()+"system in the Water Temple."+INSTANT_TEXT_OFF()+MESSAGE_END(),
-            UNSKIPPABLE()+INSTANT_TEXT_ON()+"This switch is rustier than you think."+WAIT_FOR_INPUT()+"Something must be wrong with the pipe"+NEWLINE()+"system in the Water Temple."+INSTANT_TEXT_OFF()+MESSAGE_END(),
-            UNSKIPPABLE()+INSTANT_TEXT_ON()+"This switch is rustier than you think."+WAIT_FOR_INPUT()+"Something must be wrong with the pipe"+NEWLINE()+"system in the Water Temple."+INSTANT_TEXT_OFF()+MESSAGE_END());
+            UNSKIPPABLE()+"This switch is rustier than you think."+WAIT_FOR_INPUT()+"Something must be wrong with the pipe"+NEWLINE()+"system in the Water Temple."+MESSAGE_END(),
+            UNSKIPPABLE()+"Cet interrupteur est très rouillé."+WAIT_FOR_INPUT()+"Quelque chose ne va pas avec"+NEWLINE()+"la tuyauterie du Temple de l'Eau."+MESSAGE_END(),
+            UNSKIPPABLE()+"El interruptor está más oxidado de lo que"+NEWLINE()+"aparenta."+WAIT_FOR_INPUT()+"Algo debe andar mal en el sistema de"+NEWLINE()+"cañerías del Templo del Agua."+MESSAGE_END());
     }
 
     Text AddColorsAndFormat(Text text, const std::vector<u8>& colors /*= {}*/) {

--- a/source/custom_messages.cpp
+++ b/source/custom_messages.cpp
@@ -297,6 +297,16 @@ constexpr std::array DungeonColors = {
             UNSKIPPABLE()+INSTANT_TEXT_ON()+CENTER_TEXT()+"Master Quest doesn't affect the Randomizer,"+NEWLINE()+CENTER_TEXT()+"so you can use 3 more save slots now."+NEWLINE()+NEWLINE()+CENTER_TEXT()+"Thanks for playing!"+INSTANT_TEXT_OFF()+MESSAGE_END(),
             UNSKIPPABLE()+INSTANT_TEXT_ON()+CENTER_TEXT()+"Vous pouvez désormais jouer à"+NEWLINE()+CENTER_TEXT()+"The Legend of Zelda Ocarina of Time 3D"+NEWLINE()+CENTER_TEXT()+"Master Quest!"+INSTANT_TEXT_OFF()+MESSAGE_END(),
             UNSKIPPABLE()+INSTANT_TEXT_ON()+CENTER_TEXT()+"¡Ya puedes jugar The Legend of Zelda"+NEWLINE()+CENTER_TEXT()+"Ocarina of Time 3D Master Quest!"+INSTANT_TEXT_OFF()+MESSAGE_END());
+        
+        //messages for the new Lake Hylia switch
+        CreateMessage(0x346, 0, 1, 3,
+            UNSKIPPABLE()+INSTANT_TEXT_ON()+CENTER_TEXT()+"Water level control system."+NEWLINE()+CENTER_TEXT()+"Keep away!"+INSTANT_TEXT_OFF()+MESSAGE_END(),
+            UNSKIPPABLE()+INSTANT_TEXT_ON()+CENTER_TEXT()+"Water level control system."+NEWLINE()+CENTER_TEXT()+"Keep away!"+INSTANT_TEXT_OFF()+MESSAGE_END(),
+            UNSKIPPABLE()+INSTANT_TEXT_ON()+CENTER_TEXT()+"Water level control system."+NEWLINE()+CENTER_TEXT()+"Keep away!"+INSTANT_TEXT_OFF()+MESSAGE_END());
+        CreateMessage(0x1B2, 0, 0, 3,
+            UNSKIPPABLE()+INSTANT_TEXT_ON()+"This switch is rustier than you think."+WAIT_FOR_INPUT()+"Something must be wrong with the pipe"+NEWLINE()+"system in the Water Temple."+INSTANT_TEXT_OFF()+MESSAGE_END(),
+            UNSKIPPABLE()+INSTANT_TEXT_ON()+"This switch is rustier than you think."+WAIT_FOR_INPUT()+"Something must be wrong with the pipe"+NEWLINE()+"system in the Water Temple."+INSTANT_TEXT_OFF()+MESSAGE_END(),
+            UNSKIPPABLE()+INSTANT_TEXT_ON()+"This switch is rustier than you think."+WAIT_FOR_INPUT()+"Something must be wrong with the pipe"+NEWLINE()+"system in the Water Temple."+INSTANT_TEXT_OFF()+MESSAGE_END());
     }
 
     Text AddColorsAndFormat(Text text, const std::vector<u8>& colors /*= {}*/) {


### PR DESCRIPTION
A switch has been added to Lake Hylia to control the water level, so that beating Water Temple after entering the dungeon with gold scale can't lock the player out of some WT checks. The switch is rusty and can't be pressed until after the dungeon's blue warp has been cleared. Afterwards it turns into the underused red type.

Some bugs related to CSMC have been fixed:
- Treasure Box shop chests being decorated (caused by them using a stale value for the type variable)
- Boss Key chests being normal wooden ones when CSMC is set to Vanilla (because the type was never set for the Vanilla setting)