### PR TITLE
hints: Make hint settings table constexpr

### DIFF
--- a/source/hints.cpp
+++ b/source/hints.cpp
@@ -17,96 +17,95 @@ using namespace Logic;
 using namespace Settings;
 using namespace Trial;
 
-const HintSetting uselessHints =  {
-  .dungeonsWothLimit = 2,
-  .dungeonsBarrenLimit = 1,
-  .namedItemsRequired = false,
-  .distTable = {
-    {.type = HintType::Trial,     .order =  1, .weight =  0, .fixed = 0, .copies = 0},
-    {.type = HintType::Always,    .order =  2, .weight =  0, .fixed = 0, .copies = 0},
-    {.type = HintType::Woth,      .order =  3, .weight =  0, .fixed = 0, .copies = 0},
-    {.type = HintType::Barren,    .order =  4, .weight =  0, .fixed = 0, .copies = 0},
-    {.type = HintType::Entrance,  .order =  5, .weight =  0, .fixed = 0, .copies = 0},
-    {.type = HintType::Sometimes, .order =  6, .weight =  0, .fixed = 0, .copies = 0},
-    {.type = HintType::Random,    .order =  7, .weight =  0, .fixed = 0, .copies = 0},
-    {.type = HintType::Item,      .order =  8, .weight =  0, .fixed = 0, .copies = 0},
-    {.type = HintType::Song,      .order =  9, .weight =  0, .fixed = 0, .copies = 0},
-    {.type = HintType::Overworld, .order = 10, .weight =  0, .fixed = 0, .copies = 0},
-    {.type = HintType::Dungeon,   .order = 11, .weight =  0, .fixed = 0, .copies = 0},
-    {.type = HintType::Junk,      .order = 12, .weight = 99, .fixed = 0, .copies = 0},
-    {.type = HintType::NamedItem, .order = 13, .weight =  0, .fixed = 0, .copies = 0},
+constexpr std::array<HintSetting, 4> hintSettingTable{{
+  // Useless hints
+  {
+    .dungeonsWothLimit = 2,
+    .dungeonsBarrenLimit = 1,
+    .namedItemsRequired = false,
+    .distTable = {{
+      {.type = HintType::Trial,     .order =  1, .weight =  0, .fixed = 0, .copies = 0},
+      {.type = HintType::Always,    .order =  2, .weight =  0, .fixed = 0, .copies = 0},
+      {.type = HintType::Woth,      .order =  3, .weight =  0, .fixed = 0, .copies = 0},
+      {.type = HintType::Barren,    .order =  4, .weight =  0, .fixed = 0, .copies = 0},
+      {.type = HintType::Entrance,  .order =  5, .weight =  0, .fixed = 0, .copies = 0},
+      {.type = HintType::Sometimes, .order =  6, .weight =  0, .fixed = 0, .copies = 0},
+      {.type = HintType::Random,    .order =  7, .weight =  0, .fixed = 0, .copies = 0},
+      {.type = HintType::Item,      .order =  8, .weight =  0, .fixed = 0, .copies = 0},
+      {.type = HintType::Song,      .order =  9, .weight =  0, .fixed = 0, .copies = 0},
+      {.type = HintType::Overworld, .order = 10, .weight =  0, .fixed = 0, .copies = 0},
+      {.type = HintType::Dungeon,   .order = 11, .weight =  0, .fixed = 0, .copies = 0},
+      {.type = HintType::Junk,      .order = 12, .weight = 99, .fixed = 0, .copies = 0},
+      {.type = HintType::NamedItem, .order = 13, .weight =  0, .fixed = 0, .copies = 0},
+    }},
   },
-};
 
-const HintSetting balancedHints = {
-  .dungeonsWothLimit = 2,
-  .dungeonsBarrenLimit = 1,
-  .namedItemsRequired = true,
-  .distTable = {
-    {.type = HintType::Trial,     .order =  1, .weight =  0, .fixed = 0, .copies = 1},
-    {.type = HintType::Always,    .order =  2, .weight =  0, .fixed = 0, .copies = 1},
-    {.type = HintType::Woth,      .order =  3, .weight =  7, .fixed = 0, .copies = 1},
-    {.type = HintType::Barren,    .order =  4, .weight =  4, .fixed = 0, .copies = 1},
-    {.type = HintType::Entrance,  .order =  5, .weight =  6, .fixed = 0, .copies = 1},
-    {.type = HintType::Sometimes, .order =  6, .weight =  0, .fixed = 0, .copies = 1},
-    {.type = HintType::Random,    .order =  7, .weight = 12, .fixed = 0, .copies = 1},
-    {.type = HintType::Item,      .order =  8, .weight = 10, .fixed = 0, .copies = 1},
-    {.type = HintType::Song,      .order =  9, .weight =  2, .fixed = 0, .copies = 1},
-    {.type = HintType::Overworld, .order = 10, .weight =  4, .fixed = 0, .copies = 1},
-    {.type = HintType::Dungeon,   .order = 11, .weight =  3, .fixed = 0, .copies = 1},
-    {.type = HintType::Junk,      .order = 12, .weight =  6, .fixed = 0, .copies = 1},
-    {.type = HintType::NamedItem, .order = 13, .weight =  0, .fixed = 0, .copies = 1},
+  // Balanced hints
+  {
+    .dungeonsWothLimit = 2,
+    .dungeonsBarrenLimit = 1,
+    .namedItemsRequired = true,
+    .distTable = {{
+      {.type = HintType::Trial,     .order =  1, .weight =  0, .fixed = 0, .copies = 1},
+      {.type = HintType::Always,    .order =  2, .weight =  0, .fixed = 0, .copies = 1},
+      {.type = HintType::Woth,      .order =  3, .weight =  7, .fixed = 0, .copies = 1},
+      {.type = HintType::Barren,    .order =  4, .weight =  4, .fixed = 0, .copies = 1},
+      {.type = HintType::Entrance,  .order =  5, .weight =  6, .fixed = 0, .copies = 1},
+      {.type = HintType::Sometimes, .order =  6, .weight =  0, .fixed = 0, .copies = 1},
+      {.type = HintType::Random,    .order =  7, .weight = 12, .fixed = 0, .copies = 1},
+      {.type = HintType::Item,      .order =  8, .weight = 10, .fixed = 0, .copies = 1},
+      {.type = HintType::Song,      .order =  9, .weight =  2, .fixed = 0, .copies = 1},
+      {.type = HintType::Overworld, .order = 10, .weight =  4, .fixed = 0, .copies = 1},
+      {.type = HintType::Dungeon,   .order = 11, .weight =  3, .fixed = 0, .copies = 1},
+      {.type = HintType::Junk,      .order = 12, .weight =  6, .fixed = 0, .copies = 1},
+      {.type = HintType::NamedItem, .order = 13, .weight =  0, .fixed = 0, .copies = 1},
+    }},
   },
-};
 
-const HintSetting strongHints = {
-  .dungeonsWothLimit = 2,
-  .dungeonsBarrenLimit = 1,
-  .namedItemsRequired = true,
-  .distTable = {
-    {.type = HintType::Trial,     .order =  1, .weight =  0, .fixed = 0, .copies = 1},
-    {.type = HintType::Always,    .order =  2, .weight =  0, .fixed = 0, .copies = 2},
-    {.type = HintType::Woth,      .order =  3, .weight = 12, .fixed = 0, .copies = 2},
-    {.type = HintType::Barren,    .order =  4, .weight = 12, .fixed = 0, .copies = 1},
-    {.type = HintType::Entrance,  .order =  5, .weight =  4, .fixed = 0, .copies = 1},
-    {.type = HintType::Sometimes, .order =  6, .weight =  0, .fixed = 0, .copies = 1},
-    {.type = HintType::Random,    .order =  7, .weight =  8, .fixed = 0, .copies = 1},
-    {.type = HintType::Item,      .order =  8, .weight =  8, .fixed = 0, .copies = 1},
-    {.type = HintType::Song,      .order =  9, .weight =  4, .fixed = 0, .copies = 1},
-    {.type = HintType::Overworld, .order = 10, .weight =  6, .fixed = 0, .copies = 1},
-    {.type = HintType::Dungeon,   .order = 11, .weight =  6, .fixed = 0, .copies = 1},
-    {.type = HintType::Junk,      .order = 12, .weight =  0, .fixed = 0, .copies = 1},
-    {.type = HintType::NamedItem, .order = 13, .weight =  0, .fixed = 0, .copies = 1},
+  // Strong hints
+  {
+    .dungeonsWothLimit = 2,
+    .dungeonsBarrenLimit = 1,
+    .namedItemsRequired = true,
+    .distTable = {{
+      {.type = HintType::Trial,     .order =  1, .weight =  0, .fixed = 0, .copies = 1},
+      {.type = HintType::Always,    .order =  2, .weight =  0, .fixed = 0, .copies = 2},
+      {.type = HintType::Woth,      .order =  3, .weight = 12, .fixed = 0, .copies = 2},
+      {.type = HintType::Barren,    .order =  4, .weight = 12, .fixed = 0, .copies = 1},
+      {.type = HintType::Entrance,  .order =  5, .weight =  4, .fixed = 0, .copies = 1},
+      {.type = HintType::Sometimes, .order =  6, .weight =  0, .fixed = 0, .copies = 1},
+      {.type = HintType::Random,    .order =  7, .weight =  8, .fixed = 0, .copies = 1},
+      {.type = HintType::Item,      .order =  8, .weight =  8, .fixed = 0, .copies = 1},
+      {.type = HintType::Song,      .order =  9, .weight =  4, .fixed = 0, .copies = 1},
+      {.type = HintType::Overworld, .order = 10, .weight =  6, .fixed = 0, .copies = 1},
+      {.type = HintType::Dungeon,   .order = 11, .weight =  6, .fixed = 0, .copies = 1},
+      {.type = HintType::Junk,      .order = 12, .weight =  0, .fixed = 0, .copies = 1},
+      {.type = HintType::NamedItem, .order = 13, .weight =  0, .fixed = 0, .copies = 1},
+    }},
   },
-};
 
-const HintSetting veryStrongHints = {
-  .dungeonsWothLimit = 40,
-  .dungeonsBarrenLimit = 40,
-  .namedItemsRequired = true,
-  .distTable = {
-    {.type = HintType::Trial,     .order =  1, .weight =  0, .fixed = 0, .copies = 1},
-    {.type = HintType::Always,    .order =  2, .weight =  0, .fixed = 0, .copies = 2},
-    {.type = HintType::Woth,      .order =  3, .weight = 15, .fixed = 0, .copies = 2},
-    {.type = HintType::Barren,    .order =  4, .weight = 15, .fixed = 0, .copies = 1},
-    {.type = HintType::Entrance,  .order =  5, .weight = 10, .fixed = 0, .copies = 1},
-    {.type = HintType::Sometimes, .order =  6, .weight =  0, .fixed = 0, .copies = 1},
-    {.type = HintType::Random,    .order =  7, .weight =  0, .fixed = 0, .copies = 1},
-    {.type = HintType::Item,      .order =  8, .weight =  5, .fixed = 0, .copies = 1},
-    {.type = HintType::Song,      .order =  9, .weight =  2, .fixed = 0, .copies = 1},
-    {.type = HintType::Overworld, .order = 10, .weight =  7, .fixed = 0, .copies = 1},
-    {.type = HintType::Dungeon,   .order = 11, .weight =  7, .fixed = 0, .copies = 1},
-    {.type = HintType::Junk,      .order = 12, .weight =  0, .fixed = 0, .copies = 1},
-    {.type = HintType::NamedItem, .order = 13, .weight =  0, .fixed = 0, .copies = 1},
+  // Very strong hints
+  {
+    .dungeonsWothLimit = 40,
+    .dungeonsBarrenLimit = 40,
+    .namedItemsRequired = true,
+    .distTable = {{
+      {.type = HintType::Trial,     .order =  1, .weight =  0, .fixed = 0, .copies = 1},
+      {.type = HintType::Always,    .order =  2, .weight =  0, .fixed = 0, .copies = 2},
+      {.type = HintType::Woth,      .order =  3, .weight = 15, .fixed = 0, .copies = 2},
+      {.type = HintType::Barren,    .order =  4, .weight = 15, .fixed = 0, .copies = 1},
+      {.type = HintType::Entrance,  .order =  5, .weight = 10, .fixed = 0, .copies = 1},
+      {.type = HintType::Sometimes, .order =  6, .weight =  0, .fixed = 0, .copies = 1},
+      {.type = HintType::Random,    .order =  7, .weight =  0, .fixed = 0, .copies = 1},
+      {.type = HintType::Item,      .order =  8, .weight =  5, .fixed = 0, .copies = 1},
+      {.type = HintType::Song,      .order =  9, .weight =  2, .fixed = 0, .copies = 1},
+      {.type = HintType::Overworld, .order = 10, .weight =  7, .fixed = 0, .copies = 1},
+      {.type = HintType::Dungeon,   .order = 11, .weight =  7, .fixed = 0, .copies = 1},
+      {.type = HintType::Junk,      .order = 12, .weight =  0, .fixed = 0, .copies = 1},
+      {.type = HintType::NamedItem, .order = 13, .weight =  0, .fixed = 0, .copies = 1},
+    }},
   },
-};
-
-std::array<HintSetting, 4> hintSettingTable = {
- uselessHints,
- balancedHints,
- strongHints,
- veryStrongHints,
-};
+}};
 
 static Exit* GetHintRegion(Exit* exit) {
 

--- a/source/hints.hpp
+++ b/source/hints.hpp
@@ -9,8 +9,6 @@
 #include "random.hpp"
 #include "settings.hpp"
 
-const std::string NONE = "";
-
 enum class HintType {
   Trial,
   Always,
@@ -71,67 +69,67 @@ public:
       clearText(std::move(clearText_)),
       type(type_) {}
 
-    static auto Item(std::vector<Text>&& obscureText, Text&& clearText = Text{NONE, NONE, NONE}) {
+    static auto Item(std::vector<Text>&& obscureText, Text&& clearText = {}) {
         return HintText{std::move(obscureText), std::move(clearText), HintCategory::Item};
     }
 
-    static auto Always(std::vector<Text>&& obscureText, Text&& clearText = Text{NONE, NONE, NONE}) {
+    static auto Always(std::vector<Text>&& obscureText, Text&& clearText = {}) {
         return HintText{std::move(obscureText), std::move(clearText), HintCategory::Always};
     }
 
-    static auto Sometimes(std::vector<Text>&& obscureText, Text&& clearText = Text{NONE, NONE, NONE}) {
+    static auto Sometimes(std::vector<Text>&& obscureText, Text&& clearText = {}) {
         return HintText{std::move(obscureText), std::move(clearText), HintCategory::Sometimes};
     }
 
-    static auto Exclude(std::vector<Text>&& obscureText, Text&& clearText = Text{NONE, NONE, NONE}) {
+    static auto Exclude(std::vector<Text>&& obscureText, Text&& clearText = {}) {
         return HintText{std::move(obscureText), std::move(clearText), HintCategory::Exclude};
     }
 
-    static auto Entrance(std::vector<Text>&& obscureText, Text&& clearText = Text{NONE, NONE, NONE}) {
+    static auto Entrance(std::vector<Text>&& obscureText, Text&& clearText = {}) {
         return HintText{std::move(obscureText), std::move(clearText), HintCategory::Entrance};
     }
 
-    static auto Region(std::vector<Text>&& obscureText, Text&& clearText = Text{NONE, NONE, NONE}) {
+    static auto Region(std::vector<Text>&& obscureText, Text&& clearText = {}) {
         return HintText{std::move(obscureText), std::move(clearText), HintCategory::Region};
     }
 
-    static auto Junk(std::vector<Text>&& obscureText, Text&& clearText = Text{NONE, NONE, NONE}) {
+    static auto Junk(std::vector<Text>&& obscureText, Text&& clearText = {}) {
         return HintText{std::move(obscureText), std::move(clearText), HintCategory::Junk};
     }
 
-    static auto DungeonName(std::vector<Text>&& obscureText, Text&& clearText = Text{NONE, NONE, NONE}) {
+    static auto DungeonName(std::vector<Text>&& obscureText, Text&& clearText = {}) {
         return HintText{std::move(obscureText), std::move(clearText), HintCategory::DungeonName};
     }
 
-    static auto Boss(std::vector<Text>&& obscureText, Text&& clearText = Text{NONE, NONE, NONE}) {
+    static auto Boss(std::vector<Text>&& obscureText, Text&& clearText = {}) {
         return HintText{std::move(obscureText), std::move(clearText), HintCategory::Boss};
     }
 
-    static auto Bridge(std::vector<Text>&& obscureText, Text&& clearText = Text{NONE, NONE, NONE}) {
+    static auto Bridge(std::vector<Text>&& obscureText, Text&& clearText = {}) {
         return HintText{std::move(obscureText), std::move(clearText), HintCategory::Bridge};
     }
 
-    static auto GanonsBossKey(std::vector<Text>&& obscureText, Text&& clearText = Text{NONE, NONE, NONE}) {
+    static auto GanonsBossKey(std::vector<Text>&& obscureText, Text&& clearText = {}) {
         return HintText{std::move(obscureText), std::move(clearText), HintCategory::GanonsBossKey};
     }
 
-    static auto LACS(std::vector<Text>&& obscureText, Text&& clearText = Text{NONE, NONE, NONE}) {
+    static auto LACS(std::vector<Text>&& obscureText, Text&& clearText = {}) {
         return HintText{std::move(obscureText), std::move(clearText), HintCategory::LACS};
     }
 
-    static auto Altar(std::vector<Text>&& obscureText, Text&& clearText = Text{NONE, NONE, NONE}) {
+    static auto Altar(std::vector<Text>&& obscureText, Text&& clearText = {}) {
         return HintText{std::move(obscureText), std::move(clearText), HintCategory::Altar};
     }
 
-    static auto Validation(std::vector<Text>&& obscureText, Text&& clearText = Text{NONE, NONE, NONE}) {
+    static auto Validation(std::vector<Text>&& obscureText, Text&& clearText = {}) {
         return HintText{std::move(obscureText), std::move(clearText), HintCategory::Validation};
     }
 
-    static auto LightArrow(std::vector<Text>&& obscureText, Text&& clearText = Text{NONE, NONE, NONE}) {
+    static auto LightArrow(std::vector<Text>&& obscureText, Text&& clearText = {}) {
         return HintText{std::move(obscureText), std::move(clearText), HintCategory::LightArrow};
     }
 
-    static auto GanonLine(std::vector<Text>&& obscureText, Text&& clearText = Text{NONE, NONE, NONE}) {
+    static auto GanonLine(std::vector<Text>&& obscureText, Text&& clearText = {}) {
         return HintText{std::move(obscureText), std::move(clearText), HintCategory::GanonLine};
     }
 
@@ -144,7 +142,7 @@ public:
     }
 
     const Text& GetClear() const {
-        if (clearText.GetEnglish() == NONE) {
+        if (clearText.GetEnglish().empty()) {
             return GetObscure();
         }
         return clearText;

--- a/source/hints.hpp
+++ b/source/hints.hpp
@@ -1,6 +1,7 @@
 #pragma once
 
 #include <3ds.h>
+#include <array>
 #include <string>
 #include <vector>
 
@@ -36,17 +37,13 @@ struct HintDistributionSetting {
 };
 
 struct HintSetting {
+  using DistributionTable = std::array<HintDistributionSetting, static_cast<int>(HintType::MaxCount)>;
+
   u8 dungeonsWothLimit;
   u8 dungeonsBarrenLimit;
   bool namedItemsRequired;
-  HintDistributionSetting distTable[static_cast<int>(HintType::MaxCount)];
+  DistributionTable distTable;
 };
-
-extern const HintSetting uselessHints;
-extern const HintSetting balancedHints;
-extern const HintSetting strongHints;
-extern const HintSetting veryStrongHints;
-extern std::array<HintSetting, 4> hintSettingTable;
 
 enum class HintCategory {
   Item,


### PR DESCRIPTION
Ensures that the information is always available at compile-time and placed in the read-only section

While we're in the same area, we can remove a file-scope empty string.