### PR TITLE
Some cleanups related to string/string_view, return types and conversions

### DIFF
--- a/source/cosmetics.cpp
+++ b/source/cosmetics.cpp
@@ -24,8 +24,8 @@ namespace Cosmetics {
     return std::string(CUSTOM_COLOR_STR.substr(0, CUSTOM_COLOR_STR.length() - 6)).append(color);
   }
 
-  std::string GetCustomColor(std::string_view str) {
-    return std::string(str.substr(str.length() - 6));
+  std::string GetCustomColor(const std::string& str) {
+    return str.substr(str.length() - 6);
   }
 
   //Generate random hex color

--- a/source/cosmetics.hpp
+++ b/source/cosmetics.hpp
@@ -35,6 +35,6 @@ namespace Cosmetics {
   bool ValidHexString(std::string_view hexStr);
   Color_RGB HexStrToColorRGB(const std::string& hexStr);
   std::string CustomColorOptionText(std::string_view color);
-  std::string GetCustomColor(std::string_view str);
+  std::string GetCustomColor(const std::string& str);
   std::string RandomColor();
 } //namespace Cosmetics

--- a/source/dungeon.hpp
+++ b/source/dungeon.hpp
@@ -18,7 +18,7 @@ public:
                 std::vector<ItemLocation*> sharedLocations_);
     ~DungeonInfo();
 
-    std::string_view GetName() const {
+    const std::string& GetName() const {
         return name;
     }
 

--- a/source/item.hpp
+++ b/source/item.hpp
@@ -36,7 +36,7 @@ public:
 
     ItemOverride_Value Value() const;
 
-    std::string_view GetName() const {
+    const std::string& GetName() const {
         return name;
     }
 

--- a/source/item_location.hpp
+++ b/source/item_location.hpp
@@ -73,11 +73,11 @@ public:
       addedToPool = false;
     }
 
-    std::string_view GetName() const {
+    const std::string& GetName() const {
       return name;
     }
 
-    std::string_view GetPlacedItemName() const {
+    const std::string& GetPlacedItemName() const {
       return placedItem.GetName();
     }
 

--- a/source/menu.cpp
+++ b/source/menu.cpp
@@ -235,7 +235,7 @@ void UpdateMainMenu(u32 kDown) {
 
 void UpdateCustomCosmeticColors(u32 kDown) {
   if (kDown & KEY_A) {
-    if (currentSetting->GetSelectedOptionText().substr(0, 8) == Cosmetics::CUSTOM_COLOR_PREFIX) {
+    if (currentSetting->GetSelectedOptionText().compare(0, 8, Cosmetics::CUSTOM_COLOR_PREFIX) == 0) {
       std::string newColor = GetInput("Enter a 6 digit hex color").substr(0, 6);
       if (Cosmetics::ValidHexString(newColor)) {
         currentSetting->SetSelectedOptionText(Cosmetics::CustomColorOptionText(newColor));

--- a/source/preset.cpp
+++ b/source/preset.cpp
@@ -98,7 +98,7 @@ bool SavePreset(std::string_view presetName, OptionCategory category) {
 
       // Create the <setting> element
       XMLElement* newSetting = preset.NewElement("setting");
-      newSetting->SetAttribute("name", std::string(setting->GetName()).c_str());
+      newSetting->SetAttribute("name", setting->GetName().c_str());
       newSetting->SetText(setting->GetSelectedOptionText().c_str());
 
       // Append it to the root node
@@ -144,7 +144,7 @@ bool LoadPreset(std::string_view presetName, OptionCategory category) {
 
       // Since presets are saved linearly, we can simply loop through the nodes as
       // we loop through the settings to find most of the matching elements.
-      std::string settingToFind = std::string{setting->GetName()};
+      const std::string& settingToFind = setting->GetName();
       std::string curSettingName = curNode->Attribute("name");
       if (curSettingName == settingToFind) {
         setting->SetSelectedIndexByString(curNode->GetText());

--- a/source/preset.cpp
+++ b/source/preset.cpp
@@ -145,8 +145,7 @@ bool LoadPreset(std::string_view presetName, OptionCategory category) {
       // Since presets are saved linearly, we can simply loop through the nodes as
       // we loop through the settings to find most of the matching elements.
       const std::string& settingToFind = setting->GetName();
-      std::string curSettingName = curNode->Attribute("name");
-      if (curSettingName == settingToFind) {
+      if (settingToFind == curNode->Attribute("name")) {
         setting->SetSelectedIndexByString(curNode->GetText());
         curNode = curNode->NextSiblingElement();
       } else {
@@ -156,8 +155,7 @@ bool LoadPreset(std::string_view presetName, OptionCategory category) {
         curNode = rootNode->FirstChildElement();
         bool settingFound = false;
         while (curNode != nullptr) {
-          curSettingName = curNode->Attribute("name");
-          if (curSettingName == settingToFind) {
+          if (settingToFind == curNode->Attribute("name")) {
             setting->SetSelectedIndexByString(curNode->GetText());
             curNode = curNode->NextSiblingElement();
             settingFound = true;

--- a/source/settings.hpp
+++ b/source/settings.hpp
@@ -69,7 +69,7 @@ public:
         return name;
     }
 
-    std::string GetSelectedOptionText() const {
+    const std::string& GetSelectedOptionText() const {
         return options[selectedOption];
     }
 

--- a/source/settings.hpp
+++ b/source/settings.hpp
@@ -128,7 +128,7 @@ public:
 
       //Special case for custom cosmetic settings
       if (options.size() > CUSTOM_COLOR) {
-        if (newSetting.substr(0, 8) == CUSTOM_COLOR_PREFIX && options[CUSTOM_COLOR].substr(0, 8) == CUSTOM_COLOR_PREFIX) {
+        if (newSetting.compare(0, 8, CUSTOM_COLOR_PREFIX) == 0 && options[CUSTOM_COLOR].compare(0, 8, CUSTOM_COLOR_PREFIX) == 0) {
           SetSelectedIndex(CUSTOM_COLOR);
           SetSelectedOptionText(newSetting);
           return;

--- a/source/settings.hpp
+++ b/source/settings.hpp
@@ -65,7 +65,7 @@ public:
         return options.size();
     }
 
-    std::string_view GetName() const {
+    const std::string& GetName() const {
         return name;
     }
 

--- a/source/shops.cpp
+++ b/source/shops.cpp
@@ -154,12 +154,12 @@ std::string GetIceTrapName(u8 id) {
 }
 
 //Get shop index based on a given location
-std::map<std::string, int> ShopNameToNum = {{"KF Shop", 0},{"Kak Potion Shop", 1},{"MK Bombchu Shop", 2},{"MK Potion Shop", 3},{"MK Bazaar", 4},{"Kak Bazaar", 5},{"ZD Shop", 6},{"GC Shop", 7}}; 
+static std::map<std::string_view, int> ShopNameToNum = {{"KF Shop", 0},{"Kak Potion Shop", 1},{"MK Bombchu Shop", 2},{"MK Potion Shop", 3},{"MK Bazaar", 4},{"Kak Bazaar", 5},{"ZD Shop", 6},{"GC Shop", 7}};
 int GetShopIndex(ItemLocation* loc) {
   //Kind of hacky, but extract the shop and item position from the name
   const std::string& name(loc->GetName());
   int split = name.find(" Item ");
-  std::string shop = name.substr(0, split);
+  std::string_view shop(name.c_str(), split);
   int pos = std::stoi(name.substr(split+6, 1)) - 1;
   int shopnum = ShopNameToNum[shop];
   return shopnum*8 + pos;

--- a/source/shops.cpp
+++ b/source/shops.cpp
@@ -157,7 +157,7 @@ std::string GetIceTrapName(u8 id) {
 std::map<std::string, int> ShopNameToNum = {{"KF Shop", 0},{"Kak Potion Shop", 1},{"MK Bombchu Shop", 2},{"MK Potion Shop", 3},{"MK Bazaar", 4},{"Kak Bazaar", 5},{"ZD Shop", 6},{"GC Shop", 7}}; 
 int GetShopIndex(ItemLocation* loc) {
   //Kind of hacky, but extract the shop and item position from the name
-  std::string name = std::basic_string(loc->GetName());
+  const std::string& name(loc->GetName());
   int split = name.find(" Item ");
   std::string shop = name.substr(0, split);
   int pos = std::stoi(name.substr(split+6, 1)) - 1;

--- a/source/spoiler_log.cpp
+++ b/source/spoiler_log.cpp
@@ -143,7 +143,7 @@ static void WriteSettings() {
   logtxt += "\nExcluded Locations:\n";
   for (auto& l : Settings::excludeLocationsOptions) {
     if (l->GetSelectedOptionIndex() == EXCLUDE) {
-      std::string name = l->GetName().data();
+      std::string name = l->GetName();
 
       //get rid of newline characters if necessary
       if (name.find('\n') != std::string::npos)
@@ -173,7 +173,7 @@ static void WriteSettings() {
   logtxt += "\nEnabled Tricks:\n";
   for (auto& l : Settings::detailedLogicOptions) {
     if (l->GetSelectedOptionIndex() == TRICK_ENABLED && l->IsCategory(OptionCategory::Setting)) {
-      std::string name = l->GetName().data();
+      std::string name = l->GetName();
 
       //get rid of newline characters if necessary
       if (name.find('\n') != std::string::npos)

--- a/source/spoiler_log.cpp
+++ b/source/spoiler_log.cpp
@@ -161,10 +161,8 @@ static void WriteSettings() {
   for (size_t i = 3; i < Settings::startingInventoryOptions.size(); i++) {
     auto setting = Settings::startingInventoryOptions[i];
     if (setting->GetSelectedOptionIndex() != STARTINGINVENTORY_NONE) {
-      std::string item = setting->GetSelectedOptionText();
-
       logtxt += "\t";
-      logtxt += item;
+      logtxt += setting->GetSelectedOptionText();
       logtxt += "\n";
     }
   }


### PR DESCRIPTION
This kind of started with my short review of #150, where an explicit construction of a `std::string`, just to copy it's raw data, looked very much out of place.

The central theme of this change is somewhere between code simplification and reducing the number of object copies made. This is done with the following changes:
* Change the return type `std::string_view` to `const std::string&` where applicable
* Prefer using `const std::string&` to save the return values of these calls, instead of making copies that aren't going to be mutated
* Prefer `std::string::compare` over substrings when there is no need to create a partial copy of the original string.