### PR TITLE
Feature: Randomize all settings for Open, World, Shuffle, and Dungeon settings

### DIFF
--- a/source/menu.cpp
+++ b/source/menu.cpp
@@ -85,6 +85,9 @@ void MenuInit() {
   //If cached presets exist, load them
   LoadCachedSettings();
   LoadCachedCosmetics();
+  //If Randomize all settings in a category is selected
+  //Re-randomize them
+  Settings::RandomizeAllSettings();
 
   PrintTopScreen();
 

--- a/source/setting_descriptions.cpp
+++ b/source/setting_descriptions.cpp
@@ -3,6 +3,11 @@
 //Setting descriptions are mostly copied from OoT Randomizer tooltips with minor edits
 
 /*------------------------------
+|      RANDOMIZE SETTINGS      |
+------------------------------*/
+string_view openRandomize             = "Randomize all Open Settings.";
+
+/*------------------------------
 |            LOGIC             |                           *SCREEN WIDTH*
 ------------------------------*/       /*--------------------------------------------------*/
 string_view logicGlitchless           = "No glitches are required, but may require some\n" //

--- a/source/setting_descriptions.cpp
+++ b/source/setting_descriptions.cpp
@@ -5,7 +5,10 @@
 /*------------------------------
 |      RANDOMIZE SETTINGS      |
 ------------------------------*/
-string_view openRandomize             = "Randomize all Open Settings.";
+string_view openRandomize             = "Randomize all Open Settings except for Logic rules.";
+string_view worldRandomize            = "Randomize all World Settings except for MQ dungeons";
+string_view shuffleRandomize          = "Randomize all Shuffle Settings";
+string_view dungeonRandomize          = "Randomize all Dungeon Shuffle Settings";
 
 /*------------------------------
 |            LOGIC             |                           *SCREEN WIDTH*

--- a/source/setting_descriptions.hpp
+++ b/source/setting_descriptions.hpp
@@ -4,6 +4,9 @@
 using string_view = std::string_view;
 
 extern string_view openRandomize;
+extern string_view worldRandomize;
+extern string_view shuffleRandomize;
+extern string_view dungeonRandomize;
 
 extern string_view logicGlitchless;
 extern string_view logicNoLogic;

--- a/source/setting_descriptions.hpp
+++ b/source/setting_descriptions.hpp
@@ -3,6 +3,8 @@
 
 using string_view = std::string_view;
 
+extern string_view openRandomize;
+
 extern string_view logicGlitchless;
 extern string_view logicNoLogic;
 

--- a/source/settings.cpp
+++ b/source/settings.cpp
@@ -1128,7 +1128,7 @@ namespace Settings {
       RandomGanonsTrials.SetSelectedIndex(ON);
     }
     else {
-      for (u8 i=2; i < openOptions.size(); i++) {
+      for (size_t i = 2; i < openOptions.size(); i++) {
         openOptions[i]->Unhide();
       }
     }

--- a/source/settings.cpp
+++ b/source/settings.cpp
@@ -1114,6 +1114,9 @@ namespace Settings {
   // Randomizes all settings in a category if chosen
   // Hides all relevant options
   void RandomizeAllSettings() {
+    //Init Random_ interface for consistency in racing
+    Random_Init(seed);
+
     // Open Settings
     if (RandomizeOpen) {
       // Skip Logic and RandomizeOpen Options to ensure proper logic
@@ -1122,7 +1125,7 @@ namespace Settings {
         openOptions[i]->Hide();
 
         //randomize options
-        openOptions[i]->SetSelectedIndex(rand() % openOptions[i]->GetOptionCount());
+        openOptions[i]->SetSelectedIndex(Random(0,openOptions[i]->GetOptionCount()));
       }
       // Randomize Ganon Trials
       RandomGanonsTrials.SetSelectedIndex(ON);
@@ -1143,7 +1146,7 @@ namespace Settings {
         }
         worldOptions[i]->Hide();
         //randomize options
-        worldOptions[i]->SetSelectedIndex(rand() % worldOptions[i]->GetOptionCount());
+        worldOptions[i]->SetSelectedIndex(Random(0,worldOptions[i]->GetOptionCount()));
       }
     }
     else {
@@ -1163,7 +1166,7 @@ namespace Settings {
       for (u8 i=1; i < shuffleOptions.size(); i++) {
         shuffleOptions[i]->Hide();
         //randomize options
-        shuffleOptions[i]->SetSelectedIndex(rand() % shuffleOptions[i]->GetOptionCount());
+        shuffleOptions[i]->SetSelectedIndex(Random(0,shuffleOptions[i]->GetOptionCount()));
       }
       // Double check that this is the case in case of randomization on init
       if (ShuffleRewards.Is(REWARDSHUFFLE_END_OF_DUNGEON)) {
@@ -1182,7 +1185,7 @@ namespace Settings {
       for (size_t i=1; i < shuffleDungeonItemOptions.size(); i++) {
         shuffleDungeonItemOptions[i]->Hide();
         //randomize options
-        shuffleDungeonItemOptions[i]->SetSelectedIndex(rand() % shuffleDungeonItemOptions[i]->GetOptionCount());
+        shuffleDungeonItemOptions[i]->SetSelectedIndex(Random(0,shuffleDungeonItemOptions[i]->GetOptionCount()));
       }
     }
     else {

--- a/source/settings.cpp
+++ b/source/settings.cpp
@@ -1136,7 +1136,7 @@ namespace Settings {
     // World Settings
     if (RandomizeWorld) {
       // Skip RandomizeWorld Option
-      for (u8 i=1; i < worldOptions.size(); i++) {
+      for (size_t i=1; i < worldOptions.size(); i++) {
         // skip MQ options
         if (i == 4 || i == 5) {
           continue;
@@ -1147,7 +1147,7 @@ namespace Settings {
       }
     }
     else {
-      for (u8 i=1; i < worldOptions.size(); i++) {
+      for (size_t i=1; i < worldOptions.size(); i++) {
         if ((i == 4) || (i==5)) {
           continue;
         }
@@ -1171,7 +1171,7 @@ namespace Settings {
       }
     }
     else {
-      for (u8 i=1; i < shuffleOptions.size(); i++) {
+      for (size_t i=1; i < shuffleOptions.size(); i++) {
         shuffleOptions[i]->Unhide();
       }
     }
@@ -1179,14 +1179,14 @@ namespace Settings {
     // Dungeon Shuffle Settings
     if (RandomizeDungeon) {
       // Skip RandomizeDungeon Option
-      for (u8 i=1; i < shuffleDungeonItemOptions.size(); i++) {
+      for (size_t i=1; i < shuffleDungeonItemOptions.size(); i++) {
         shuffleDungeonItemOptions[i]->Hide();
         //randomize options
         shuffleDungeonItemOptions[i]->SetSelectedIndex(rand() % shuffleDungeonItemOptions[i]->GetOptionCount());
       }
     }
     else {
-      for (u8 i=1; i < shuffleDungeonItemOptions.size(); i++) {
+      for (size_t i=1; i < shuffleDungeonItemOptions.size(); i++) {
         shuffleDungeonItemOptions[i]->Unhide();
       }
     }

--- a/source/settings.cpp
+++ b/source/settings.cpp
@@ -22,7 +22,7 @@ namespace Settings {
 
   //                                        Setting name,              Options,                                                                     Setting Descriptions (assigned in setting_descriptions.cpp)
   //Open Settings                                                                                                                                   Any option index past the last description will use the last description
-  Option RandomizeOpen       = Option::Bool("Randomize Settings",     {"Yes","No"},                                                                 {openRandomize});
+  Option RandomizeOpen       = Option::Bool("Randomize Settings",     {"No","Yes"},                                                                 {openRandomize});
   Option Logic               = Option::U8  ("Logic",                  {"Glitchless", "No Logic"},                                                   {logicGlitchless, logicNoLogic});
   Option OpenForest          = Option::U8  ("Forest",                 {"Closed", "Open"},                                                           {forestClosed, forestOpen});
   Option OpenKakariko        = Option::U8  ("Kakariko Gate",          {"Closed", "Open"},                                                           {kakGateClosed, kakGateOpen});
@@ -56,6 +56,7 @@ namespace Settings {
   };
 
   //World Settings
+  Option RandomizeWorld      = Option::Bool("Randomize Settings",     {"No","Yes"},                                                      {worldRandomize});
   Option StartingAge         = Option::U8  ("Starting Age",           {"Adult", "Child", "Random"},                                      {ageDesc});
   u8 ResolvedStartingAge;
   Option BombchusInLogic     = Option::Bool("Bombchus in Logic",      {"Off", "On"},                                                     {bombchuLogicDesc});
@@ -63,6 +64,7 @@ namespace Settings {
   Option RandomMQDungeons    = Option::Bool("Random MQ Dungeons",     {"Off", "On"},                                                     {randomMQDungeonsDesc});
   Option MQDungeonCount      = Option::U8  ("  MQ Dungeon Count",     {"0","1","2","3","4","5","6","7","8","9","10","11","12"},          {mqDungeonCountDesc});
   std::vector<Option *> worldOptions = {
+    &RandomizeWorld,
     &StartingAge,
     &BombchusInLogic,
     &BombchuDrops,
@@ -71,6 +73,7 @@ namespace Settings {
   };
 
   //Shuffle Settings
+  Option RandomizeShuffle    = Option::Bool("Randomize Settings",     {"No","Yes"},                                                      {shuffleRandomize});
   Option ShuffleRewards      = Option::U8  ("Shuffle Dungeon Rewards",{"End of Dungeons", "Any Dungeon", "Overworld", "Anywhere"},       {shuffleRewardsEndOfDungeon, shuffleRewardsAnyDungeon, shuffleRewardsOverworld, shuffleRewardsAnywhere});
   Option LinksPocketItem     = Option::U8  ("Link's Pocket",          {"Dungeon Reward", "Advancement", "Anything", "Nothing"},          {linksPocketDungeonReward, linksPocketAdvancement, linksPocketAnything, linksPocketNothing});
   Option ShuffleSongs        = Option::U8  ("Shuffle Songs",          {"Song Locations", "Dungeon Rewards", "Anywhere"},                 {songsSongLocations, songsDungeonRewards, songsAllLocations});
@@ -85,6 +88,7 @@ namespace Settings {
   Option ShuffleMagicBeans   = Option::Bool("Shuffle Magic Beans",    {"Off", "On"},                                                     {magicBeansDesc});
   //TODO: Medigoron and Carpet Salesman
   std::vector<Option *> shuffleOptions = {
+    &RandomizeShuffle,
     &ShuffleRewards,
     &LinksPocketItem,
     &ShuffleSongs,
@@ -101,6 +105,7 @@ namespace Settings {
   };
 
   //Shuffle Dungeon Items
+  Option RandomizeDungeon    = Option::Bool("Randomize Settings",     {"No","Yes"},                                                      {dungeonRandomize});
   Option MapsAndCompasses    = Option::U8  ("Maps/Compasses",         {"Start With", "Vanilla", "Own Dungeon", "Any Dungeon", "Overworld", "Anywhere"},
                                                                       {mapCompassStartWith, mapCompassVanilla, mapCompassOwnDungeon, mapCompassAnyDungeon, mapCompassOverworld, mapCompassAnywhere});
   Option Keysanity           = Option::U8  ("Small Keys",             {"Start With", "Vanilla", "Own Dungeon", "Any Dungeon", "Overworld", "Anywhere"},
@@ -118,6 +123,7 @@ namespace Settings {
   Option LACSDungeonCount    = Option::U8  ("  Dungeon Count",        {"0", "1", "2", "3", "4", "5", "6", "7", "8"},                          {lacsDungeonCountDesc});
   Option LACSTokenCount      = Option::U8  ("  Token Count",          {/*Options 0-100 defined in SetDefaultSettings()*/},                    {lacsTokenCountDesc});
   std::vector<Option *> shuffleDungeonItemOptions = {
+    &RandomizeDungeon,
     &MapsAndCompasses,
     &Keysanity,
     &GerudoKeys,
@@ -944,68 +950,76 @@ namespace Settings {
   //will force Starting Age to Child).
   void ForceChange(u32 kDown, Option* currentSetting) {
 
-    //Adult is not compatible with Closed Forest
-    if (OpenForest.Is(OPENFOREST_CLOSED)) {
-      StartingAge.SetSelectedIndex(AGE_CHILD);
-      StartingAge.Lock();
-    } else {
-      StartingAge.Unlock();
+    RandomizeAllSettings();
+
+    //Only go through options if all settings are not randomized
+    if (!RandomizeOpen) {
+      //Adult is not compatible with Closed Forest
+      if (OpenForest.Is(OPENFOREST_CLOSED)) {
+        StartingAge.SetSelectedIndex(AGE_CHILD);
+        StartingAge.Lock();
+      } else {
+        StartingAge.Unlock();
+      }
+
+      //Only show stone count option if Stones is selected
+      if (Bridge.Is(RAINBOWBRIDGE_STONES)) {
+        BridgeStoneCount.Unhide();
+      } else {
+        BridgeStoneCount.SetSelectedIndex(3);
+        BridgeStoneCount.Hide();
+      }
+
+      //Only show medallion count option if Medallions is selected
+      if (Bridge.Is(RAINBOWBRIDGE_MEDALLIONS)) {
+        BridgeMedallionCount.Unhide();
+      } else {
+        BridgeMedallionCount.Hide();
+        BridgeMedallionCount.SetSelectedIndex(6);
+      }
+
+      //Only show reward count option if Rewards is selected
+      if (Bridge.Is(RAINBOWBRIDGE_REWARDS)) {
+        BridgeRewardCount.Unhide();
+      } else {
+        BridgeRewardCount.SetSelectedIndex(9);
+        BridgeRewardCount.Hide();
+      }
+
+      //Only show reward count option if Rewards is selected
+      if (Bridge.Is(RAINBOWBRIDGE_DUNGEONS)) {
+        BridgeDungeonCount.Unhide();
+      } else {
+        BridgeDungeonCount.SetSelectedIndex(8);
+        BridgeDungeonCount.Hide();
+      }
+
+      //Only show token count option if Tokens is selected
+      if (Bridge.Is(RAINBOWBRIDGE_TOKENS)) {
+        BridgeTokenCount.Unhide();
+      } else {
+        BridgeTokenCount.SetSelectedIndex(1);
+        BridgeTokenCount.Hide();
+      }
+
+      //Only show Trial Count option if Random Trial Count is off
+      if (RandomGanonsTrials) {
+        GanonsTrialsCount.SetSelectedIndex(6);
+        GanonsTrialsCount.Hide();
+      } else {
+        GanonsTrialsCount.Unhide();
+      }
     }
 
-    //Only show stone count option if Stones is selected
-    if (Bridge.Is(RAINBOWBRIDGE_STONES)) {
-      BridgeStoneCount.Unhide();
-    } else {
-      BridgeStoneCount.SetSelectedIndex(3);
-      BridgeStoneCount.Hide();
-    }
-
-    //Only show medallion count option if Medallions is selected
-    if (Bridge.Is(RAINBOWBRIDGE_MEDALLIONS)) {
-      BridgeMedallionCount.Unhide();
-    } else {
-      BridgeMedallionCount.Hide();
-      BridgeMedallionCount.SetSelectedIndex(6);
-    }
-
-    //Only show reward count option if Rewards is selected
-    if (Bridge.Is(RAINBOWBRIDGE_REWARDS)) {
-      BridgeRewardCount.Unhide();
-    } else {
-      BridgeRewardCount.SetSelectedIndex(9);
-      BridgeRewardCount.Hide();
-    }
-
-    //Only show reward count option if Rewards is selected
-    if (Bridge.Is(RAINBOWBRIDGE_DUNGEONS)) {
-      BridgeDungeonCount.Unhide();
-    } else {
-      BridgeDungeonCount.SetSelectedIndex(8);
-      BridgeDungeonCount.Hide();
-    }
-
-    //Only show token count option if Tokens is selected
-    if (Bridge.Is(RAINBOWBRIDGE_TOKENS)) {
-      BridgeTokenCount.Unhide();
-    } else {
-      BridgeTokenCount.SetSelectedIndex(1);
-      BridgeTokenCount.Hide();
-    }
-
-    //Only show Trial Count option if Random Trial Count is off
-    if (RandomGanonsTrials) {
-      GanonsTrialsCount.SetSelectedIndex(6);
-      GanonsTrialsCount.Hide();
-    } else {
-      GanonsTrialsCount.Unhide();
-    }
-
-    //Bombchus in Logic forces Bombchu Drops
-    if (BombchusInLogic) {
-      BombchuDrops.SetSelectedIndex(ON);
-      BombchuDrops.Lock();
-    } else {
-      BombchuDrops.Unlock();
+    //Only go through options if all settings are not randomized
+    if (!RandomizeWorld) {
+      //Bombchus in Logic forces Bombchu Drops
+      if (BombchusInLogic) {
+        BombchuDrops.SetSelectedIndex(ON);
+        BombchuDrops.Lock();
+      } else {
+        BombchuDrops.Unlock();
+      }
     }
 
     //Only show MQ Dungeon Count if Random MQ Dungeons is off
@@ -1020,48 +1034,55 @@ namespace Settings {
     if (ShuffleRewards.Is(REWARDSHUFFLE_END_OF_DUNGEON)) {
       LinksPocketItem.Lock();
       LinksPocketItem.SetSelectedIndex(LINKSPOCKETITEM_DUNGEON_REWARD);
+      if (RandomizeShuffle) {
+        //Even if it is supposed to be locked, still hide it to keep the surprise
+        LinksPocketItem.Unlock();
+        LinksPocketItem.Hide();
+      }
     } else {
       LinksPocketItem.Unlock();
     }
 
-    //Only show Medallion Count if setting Ganons Boss Key to LACS Medallions
-    if (GanonsBossKey.Is(GANONSBOSSKEY_LACS_MEDALLIONS)) {
-      LACSMedallionCount.Unhide();
-    } else {
-      LACSMedallionCount.SetSelectedIndex(6);
-      LACSMedallionCount.Hide();
-    }
+    if (!RandomizeDungeon) {
+      //Only show Medallion Count if setting Ganons Boss Key to LACS Medallions
+      if (GanonsBossKey.Is(GANONSBOSSKEY_LACS_MEDALLIONS)) {
+        LACSMedallionCount.Unhide();
+      } else {
+        LACSMedallionCount.SetSelectedIndex(6);
+        LACSMedallionCount.Hide();
+      }
 
-    //Only show Stone Count if setting Ganons Boss Key to LACS Stones
-    if (GanonsBossKey.Is(GANONSBOSSKEY_LACS_STONES)) {
-      LACSStoneCount.Unhide();
-    } else {
-      LACSStoneCount.SetSelectedIndex(3);
-      LACSStoneCount.Hide();
-    }
+      //Only show Stone Count if setting Ganons Boss Key to LACS Stones
+      if (GanonsBossKey.Is(GANONSBOSSKEY_LACS_STONES)) {
+        LACSStoneCount.Unhide();
+      } else {
+        LACSStoneCount.SetSelectedIndex(3);
+        LACSStoneCount.Hide();
+      }
 
-    //Only show Reward Count if setting Ganons Boss Key to LACS Rewards
-    if (GanonsBossKey.Is(GANONSBOSSKEY_LACS_REWARDS)) {
-      LACSRewardCount.Unhide();
-    } else {
-      LACSRewardCount.SetSelectedIndex(9);
-      LACSRewardCount.Hide();
-    }
+      //Only show Reward Count if setting Ganons Boss Key to LACS Rewards
+      if (GanonsBossKey.Is(GANONSBOSSKEY_LACS_REWARDS)) {
+        LACSRewardCount.Unhide();
+      } else {
+        LACSRewardCount.SetSelectedIndex(9);
+        LACSRewardCount.Hide();
+      }
 
-    //Only show Dungeon Count if setting Ganons Boss Key to LACS Dungeons
-    if (GanonsBossKey.Is(GANONSBOSSKEY_LACS_DUNGEONS)) {
-      LACSDungeonCount.Unhide();
-    } else {
-      LACSDungeonCount.SetSelectedIndex(8);
-      LACSDungeonCount.Hide();
-    }
+      //Only show Dungeon Count if setting Ganons Boss Key to LACS Dungeons
+      if (GanonsBossKey.Is(GANONSBOSSKEY_LACS_DUNGEONS)) {
+        LACSDungeonCount.Unhide();
+      } else {
+        LACSDungeonCount.SetSelectedIndex(8);
+        LACSDungeonCount.Hide();
+      }
 
-    //Only show Token Count if setting Ganons Boss Key to LACS Tokens
-    if (GanonsBossKey.Is(GANONSBOSSKEY_LACS_TOKENS)) {
-      LACSTokenCount.Unhide();
-    } else {
-      LACSTokenCount.SetSelectedIndex(100);
-      LACSTokenCount.Hide();
+      //Only show Token Count if setting Ganons Boss Key to LACS Tokens
+      if (GanonsBossKey.Is(GANONSBOSSKEY_LACS_TOKENS)) {
+        LACSTokenCount.Unhide();
+      } else {
+        LACSTokenCount.SetSelectedIndex(100);
+        LACSTokenCount.Hide();
+      }
     }
 
     //Only show hint options if hints are enabled
@@ -1088,6 +1109,78 @@ namespace Settings {
     }
 
     ResolveExcludedLocationConflicts();
+  }
+
+  // Randomizes all settings in a category if chosen
+  // Hides all relevant options
+  void RandomizeAllSettings() {
+    // Open Settings
+    if (RandomizeOpen) {
+      // Skip Logic and RandomizeOpen Options to ensure proper logic
+      for (u8 i=2; i < openOptions.size(); i++) {
+        openOptions[i]->Hide();
+        // Randomize the option
+        openOptions[i]->SetSelectedIndex(Random(0, openOptions[i]->GetOptionCount()));
+      }
+      // Randomize Ganon Trials
+      RandomGanonsTrials.SetSelectedIndex(ON);
+    }
+    else {
+      for (u8 i=2; i < openOptions.size(); i++) {
+        openOptions[i]->Unhide();
+      }
+    }
+
+    // World Settings
+    if (RandomizeWorld) {
+      // Skip RandomizeWorld Option
+      for (u8 i=1; i < worldOptions.size(); i++) {
+        // skip MQ options
+        if ((i == 4) || (i==5)) {
+          continue;
+        }
+        worldOptions[i]->Hide();
+        worldOptions[i]->SetSelectedIndex(Random(0, worldOptions[i]->GetOptionCount()));
+      }
+    }
+    else {
+      for (u8 i=1; i < worldOptions.size(); i++) {
+        if ((i == 4) || (i==5)) {
+          continue;
+        }
+        worldOptions[i]->Unhide();
+      }
+    }
+
+    // Shuffle Settings
+    if (RandomizeShuffle) {
+      // Still displays if previously locked
+      LinksPocketItem.Unlock();
+      // Skip RandomizeShuffle Option
+      for (u8 i=1; i < shuffleOptions.size(); i++) {
+        shuffleOptions[i]->Hide();
+        shuffleOptions[i]->SetSelectedIndex(Random(0, shuffleOptions[i]->GetOptionCount()));
+      }
+    }
+    else {
+      for (u8 i=1; i < shuffleOptions.size(); i++) {
+        shuffleOptions[i]->Unhide();
+      }
+    }
+
+    // Dungeon Shuffle Settings
+    if (RandomizeDungeon) {
+      // Skip RandomizeDungeon Option
+      for (u8 i=1; i < shuffleDungeonItemOptions.size(); i++) {
+        shuffleDungeonItemOptions[i]->Hide();
+        shuffleDungeonItemOptions[i]->SetSelectedIndex(Random(0, shuffleDungeonItemOptions[i]->GetOptionCount()));
+      }
+    }
+    else {
+      for (u8 i=1; i < shuffleDungeonItemOptions.size(); i++) {
+        shuffleDungeonItemOptions[i]->Unhide();
+      }
+    }
   }
 
   //eventual settings

--- a/source/settings.cpp
+++ b/source/settings.cpp
@@ -22,6 +22,7 @@ namespace Settings {
 
   //                                        Setting name,              Options,                                                                     Setting Descriptions (assigned in setting_descriptions.cpp)
   //Open Settings                                                                                                                                   Any option index past the last description will use the last description
+  Option RandomizeOpen       = Option::Bool("Randomize Settings",     {"Yes","No"},                                                                 {openRandomize});
   Option Logic               = Option::U8  ("Logic",                  {"Glitchless", "No Logic"},                                                   {logicGlitchless, logicNoLogic});
   Option OpenForest          = Option::U8  ("Forest",                 {"Closed", "Open"},                                                           {forestClosed, forestOpen});
   Option OpenKakariko        = Option::U8  ("Kakariko Gate",          {"Closed", "Open"},                                                           {kakGateClosed, kakGateOpen});
@@ -37,6 +38,7 @@ namespace Settings {
   Option RandomGanonsTrials  = Option::Bool("Random Ganon's Trials",  {"Off", "On"},                                                                {randomGanonsTrialsDesc});
   Option GanonsTrialsCount   = Option::U8  ("  Trial Count",          {"0", "1", "2", "3", "4", "5", "6"},                                          {ganonsTrialCountDesc});
   std::vector<Option *> openOptions = {
+    &RandomizeOpen,
     &Logic,
     &OpenForest,
     //&OpenKakariko,

--- a/source/settings.cpp
+++ b/source/settings.cpp
@@ -1161,6 +1161,10 @@ namespace Settings {
         shuffleOptions[i]->Hide();
         shuffleOptions[i]->SetSelectedIndex(Random(0, shuffleOptions[i]->GetOptionCount()));
       }
+      // Double check that this is the case in case of randomization on init
+      if (ShuffleRewards.Is(REWARDSHUFFLE_END_OF_DUNGEON)) {
+        LinksPocketItem.SetSelectedIndex(LINKSPOCKETITEM_DUNGEON_REWARD);
+      }
     }
     else {
       for (u8 i=1; i < shuffleOptions.size(); i++) {

--- a/source/settings.cpp
+++ b/source/settings.cpp
@@ -1138,7 +1138,7 @@ namespace Settings {
       // Skip RandomizeWorld Option
       for (u8 i=1; i < worldOptions.size(); i++) {
         // skip MQ options
-        if ((i == 4) || (i==5)) {
+        if (i == 4 || i == 5) {
           continue;
         }
         worldOptions[i]->Hide();

--- a/source/settings.cpp
+++ b/source/settings.cpp
@@ -1117,7 +1117,7 @@ namespace Settings {
     // Open Settings
     if (RandomizeOpen) {
       // Skip Logic and RandomizeOpen Options to ensure proper logic
-      for (u8 i=2; i < openOptions.size(); i++) {
+      for (size_t i = 2; i < openOptions.size(); i++) {
         //hide options
         openOptions[i]->Hide();
 

--- a/source/settings.cpp
+++ b/source/settings.cpp
@@ -1118,9 +1118,11 @@ namespace Settings {
     if (RandomizeOpen) {
       // Skip Logic and RandomizeOpen Options to ensure proper logic
       for (u8 i=2; i < openOptions.size(); i++) {
+        //hide options
         openOptions[i]->Hide();
-        // Randomize the option
-        openOptions[i]->SetSelectedIndex(Random(0, openOptions[i]->GetOptionCount()));
+
+        //randomize options
+        openOptions[i]->SetSelectedIndex(rand() % openOptions[i]->GetOptionCount());
       }
       // Randomize Ganon Trials
       RandomGanonsTrials.SetSelectedIndex(ON);
@@ -1140,7 +1142,8 @@ namespace Settings {
           continue;
         }
         worldOptions[i]->Hide();
-        worldOptions[i]->SetSelectedIndex(Random(0, worldOptions[i]->GetOptionCount()));
+        //randomize options
+        worldOptions[i]->SetSelectedIndex(rand() % worldOptions[i]->GetOptionCount());
       }
     }
     else {
@@ -1159,7 +1162,8 @@ namespace Settings {
       // Skip RandomizeShuffle Option
       for (u8 i=1; i < shuffleOptions.size(); i++) {
         shuffleOptions[i]->Hide();
-        shuffleOptions[i]->SetSelectedIndex(Random(0, shuffleOptions[i]->GetOptionCount()));
+        //randomize options
+        shuffleOptions[i]->SetSelectedIndex(rand() % shuffleOptions[i]->GetOptionCount());
       }
       // Double check that this is the case in case of randomization on init
       if (ShuffleRewards.Is(REWARDSHUFFLE_END_OF_DUNGEON)) {
@@ -1177,7 +1181,8 @@ namespace Settings {
       // Skip RandomizeDungeon Option
       for (u8 i=1; i < shuffleDungeonItemOptions.size(); i++) {
         shuffleDungeonItemOptions[i]->Hide();
-        shuffleDungeonItemOptions[i]->SetSelectedIndex(Random(0, shuffleDungeonItemOptions[i]->GetOptionCount()));
+        //randomize options
+        shuffleDungeonItemOptions[i]->SetSelectedIndex(rand() % shuffleDungeonItemOptions[i]->GetOptionCount());
       }
     }
     else {

--- a/source/settings.hpp
+++ b/source/settings.hpp
@@ -234,6 +234,7 @@ namespace Settings {
   void UpdateSettings();
   SettingsContext FillContext();
   void SetDefaultSettings();
+  void RandomizeAllSettings();
   void ForceChange(u32 kDown, Option* currentSetting);
 
   extern std::string seed;


### PR DESCRIPTION
This randomizes all settings in the Open, World, Shuffle, and Shuffle Dungeon Items settings. If "randomize all settings" is cached, it will also re-randomize the settings on init. World ignores MQ dungeons following the 64 randomizer, and Open ignores Logic rules to avoid unwanted unbeatable seeds.