### PR TITLE
Workaround for endless "Placing items.."

### DIFF
--- a/source/item_location.hpp
+++ b/source/item_location.hpp
@@ -82,6 +82,9 @@ public:
     }
 
     const Item& GetPlacedItem() const {
+      // @fixme Working around faulty initialization of placedItem. Should already be NoItem, but isn't.
+      if (placedItem.GetName() == "") { return NoItem; }
+
       return placedItem;
     }
 


### PR DESCRIPTION
Working around faulty initialization of placedItem, leading to an endless "Placing items..", because the generator thinks that there is already an item placed at the location.

This change only fixes the effect, not the actual cause that placedItem is not correctly initialized to NoItem. If anybody has a fix for the actual cause, this workaround can be removed.