### PR TITLE
Re-catchable bugs, more cutscene skips

### DIFF
--- a/code/oot.ld
+++ b/code/oot.ld
@@ -12,6 +12,10 @@ SECTIONS
 		*(.patch_MidoCheckDekuTreeClearTwo)
 	}
 
+	.patch_ShortenRainbowBridgeCS 0x10b904 : {
+		*(.patch_ShortenRainbowBridgeCS)
+	}
+
 	.patch_BombchuPurchaseableCheck 0x112ED0 : {
 		*(.patch_BombchuPurchaseableCheck)
 	}

--- a/code/oot.ld
+++ b/code/oot.ld
@@ -340,6 +340,10 @@ SECTIONS
 		*(.patch_CourtyardCheckForVisitedZeldaTwo)
 	}
 
+	.patch_BugsRecatchable 0x212090 : {
+		*(.patch_BugsRecatchable)
+	}
+
 	.patch_DekuSproutCheckForest 0x2153A4 : {
 		*(.patch_DekuSproutCheckForest)
 	}

--- a/code/oot.ld
+++ b/code/oot.ld
@@ -172,6 +172,14 @@ SECTIONS
 		*(.patch_PlayerGetCustomTunicCMAB)
 	}
 
+	.patch_SkipDaruniaDanceOne 0x19493C : {
+		*(.patch_SkipDaruniaDanceOne)
+	}
+
+	.patch_SkipDaruniaDanceTwo 0x194944 : {
+		*(.patch_SkipDaruniaDanceTwo)
+	}
+
 	.patch_ChildRollingGoron 0x194B18 : {
 		*(.patch_ChildRollingGoron)
 	}
@@ -374,6 +382,10 @@ SECTIONS
 
 	.patch_SpiritTempleItemGiveTwo 0x24CF4C : {
 		*(.patch_SpiritTempleItemGiveTwo)
+	}
+
+	.patch_SkipDaruniaDanceThree 0x257f00 : {
+		*(.patch_SkipDaruniaDanceThree)
 	}
 
 	.patch_LostWoodsShootingGame 0x259E4C : {

--- a/code/src/cutscenes.c
+++ b/code/src/cutscenes.c
@@ -242,6 +242,7 @@ void Custcene_OverrideForestTemple(void) {
 
 void Cutscene_OverrideFireTemple(void) {
     ItemOverride_PushDungeonReward(DUNGEON_FIRE_TEMPLE);
+    gSaveContext.eventChkInf[2] |= 0x8000; //Death Mountain cloud is normal again
 
     //If warping with FW, let the wrong warp work
     if (gSaveContext.respawnFlag == 3) {

--- a/code/src/demo_kankyo.c
+++ b/code/src/demo_kankyo.c
@@ -10,22 +10,36 @@
 void DemoKankyo_rUpdate(Actor* thisx, GlobalContext* globalCtx){
     DemoKankyo_Update(thisx, globalCtx);
 
-/*  //Warp Song particles. This is meant to skip the warping animations, but it works only in ToT for now, because the
-    //animations use different cutscene data in that scene specifically. To avoid confusion, this is commented out for now
+    //Warp Song particles
     if(thisx->params == 0x000F){
-        u8* warpTimer = (((u8*)thisx)+0x01A6);
-        //Make camera-panning cutscene start immediately
-        if(*warpTimer > 2){
-            *warpTimer = 2;
+        globalCtx->sceneLoadFlag = 0x14;
+        switch (globalCtx->unk_2304[0x0878]){ //text related variable
+            case 0:
+                globalCtx->nextEntranceIndex = 0x0600; //Minuet
+                break;
+            case 1:
+                globalCtx->nextEntranceIndex = 0x04F6; //Bolero
+                break;
+            case 2:
+                globalCtx->nextEntranceIndex = 0x0604; //Serenade
+                break;
+            case 3:
+                globalCtx->nextEntranceIndex = 0x01F1; //Requiem
+                break;
+            case 4:
+                globalCtx->nextEntranceIndex = 0x0568; //Nocturne
+                break;
+            case 5:
+                globalCtx->nextEntranceIndex = 0x05F4; //Prelude
+                break;
+            default:
+                globalCtx->sceneLoadFlag = 0; //if something goes wrong, the animation plays normally
         }
-        //Make camera-panning cutscene end immediately
-        if(CsTimer < 37){
-            CsTimer = 37;
+        //Unset Zoneout Type -3 to avoid cutscene at destination (technically it's not needed)
+        if(gSaveContext.respawnFlag == -3){
+            gSaveContext.respawnFlag = 0;
         }
-        //Unset Zoneout Type -3 to avoid cutscene at destination
-        gSaveContext.respawnFlag = 0;
     }
-*/
 
     //Door of Time, the opening cutscene is playing (only regular one, not beta CS #03)
     if(thisx->params == 0x000D && globalCtx->csCtx.segment == DoT_Opening_Cutscene_Pointer){

--- a/code/src/demo_kankyo.c
+++ b/code/src/demo_kankyo.c
@@ -35,8 +35,13 @@ void DemoKankyo_rUpdate(Actor* thisx, GlobalContext* globalCtx){
             default:
                 globalCtx->sceneLoadFlag = 0; //if something goes wrong, the animation plays normally
         }
-        //Unset Zoneout Type -3 to avoid cutscene at destination (technically it's not needed)
-        if(gSaveContext.respawnFlag == -3){
+
+        if(gSaveContext.gameMode != 0){
+            //During DHWW the cutscene must play at the destination
+            gSaveContext.respawnFlag = -3;
+        }
+        else if(gSaveContext.respawnFlag == -3){
+            //Unset Zoneout Type -3 to avoid cutscene at destination (technically it's not needed)
             gSaveContext.respawnFlag = 0;
         }
     }

--- a/code/src/entrance.c
+++ b/code/src/entrance.c
@@ -62,6 +62,16 @@ void Entrance_Init(void) {
         gEntranceTable[index].field = 0x0102;
     }
 
+    // Delete the title card for Sacred Forest Meadow from Minuet
+    for (index = 0x600; index < 0x604; ++index) {
+        gEntranceTable[index].field &= ~0x4000;
+    }
+
+    // Delete the title card for Temple of Time from Prelude/Savewarp
+    for (index = 0x5F4; index < 0x5F8; ++index) {
+        gEntranceTable[index].field &= ~0x4000;
+    }
+
     // Delete the title card for Sacred Forest Meadow from Forest Temple Blue Warp
     for (index = 0x608; index < 0x60C; ++index) {
         gEntranceTable[index].field = 0x0102;

--- a/code/src/hooks.s
+++ b/code/src/hooks.s
@@ -516,6 +516,14 @@ hook_FastOwlCutscenes:
     mov r1,#0xa
     bx lr
 
+.global hook_ShortenRainbowBridgeCS
+hook_ShortenRainbowBridgeCS:
+    push {r0-r12, lr}
+    bl ShortenRainbowBridgeCS
+    pop {r0-r12, lr}
+    cpy r4,r0
+    bx lr
+
 .section .loader
 .global hook_into_loader
 hook_into_loader:

--- a/code/src/patches.s
+++ b/code/src/patches.s
@@ -1181,6 +1181,21 @@ FastOwlCutscenes_patch:
 BugsRecatchable_patch:
     nop
     
+.section .patch_SkipDaruniaDanceOne
+.global SkipDaruniaDanceOne_patch
+SkipDaruniaDanceOne_patch:
+    nop
+    
+.section .patch_SkipDaruniaDanceTwo
+.global SkipDaruniaDanceTwo_patch
+SkipDaruniaDanceTwo_patch:
+    nop
+
+.section .patch_SkipDaruniaDanceThree
+.global SkipDaruniaDanceThree_patch
+SkipDaruniaDanceThree_patch:
+    nop
+
 .section .patch_loader
 .global loader_patch
 

--- a/code/src/patches.s
+++ b/code/src/patches.s
@@ -1176,6 +1176,11 @@ PlayerGetCustomTunicCMAB_patch:
 FastOwlCutscenes_patch:
     bl hook_FastOwlCutscenes
 
+.section .patch_BugsRecatchable
+.global BugsRecatchable_patch
+BugsRecatchable_patch:
+    nop
+    
 .section .patch_loader
 .global loader_patch
 

--- a/code/src/patches.s
+++ b/code/src/patches.s
@@ -1196,6 +1196,11 @@ SkipDaruniaDanceTwo_patch:
 SkipDaruniaDanceThree_patch:
     nop
 
+.section .patch_ShortenRainbowBridgeCS
+.global ShortenRainbowBridgeCS_patch
+ShortenRainbowBridgeCS_patch:
+    bl hook_ShortenRainbowBridgeCS
+
 .section .patch_loader
 .global loader_patch
 

--- a/code/src/rainbow_bridge.c
+++ b/code/src/rainbow_bridge.c
@@ -2,6 +2,8 @@
 #include "settings.h"
 #include "savefile.h"
 
+#define CsTimer (gGlobalContext->csCtx.frames)
+
 u32 BgGjyoBridge_ConditionVanilla(void) {
     return ((gSaveContext.questItems & 0x8) && (gSaveContext.questItems & 0x10)
         && (gSaveContext.items[ItemSlots[ITEM_ARROW_LIGHT]] == ITEM_ARROW_LIGHT));
@@ -42,4 +44,10 @@ u32 BgGjyoBridge_CheckCondition(void) {
         default:
             return BgGjyoBridge_ConditionVanilla();
     }
+}
+
+void ShortenRainbowBridgeCS() {
+    if(CsTimer < 230) CsTimer = 230;
+    else if(CsTimer > 405 && CsTimer < 490) CsTimer = 490;
+    else if(CsTimer > 535 && CsTimer < 779) CsTimer = 779;
 }


### PR DESCRIPTION
Bugs can now be caught again after being dropped on soft soil patches, like in the original OoT.

The Rainbow bridge cutscene, Darunia dance cutscene and warp songs animations have been shortened / removed.