### PR TITLE
Fixed cast from seed string to uint32_t

### DIFF
--- a/source/settings.cpp
+++ b/source/settings.cpp
@@ -1115,7 +1115,8 @@ namespace Settings {
   // Hides all relevant options
   void RandomizeAllSettings() {
     //Init Random_ interface for consistency in racing
-    Random_Init(seed);
+
+    Random_Init(static_cast<uint32_t>(std::stoul(seed)));
 
     // Open Settings
     if (RandomizeOpen) {


### PR DESCRIPTION
I incorrectly cast the seed to Randomize_Init in the RandomizeAllSettings function, so it doesn't compile currently. This fixes that and allow it to compile.