### PR TITLE
Give users the option to turn custom small key colors on/off

### DIFF
--- a/code/src/custom_models.c
+++ b/code/src/custom_models.c
@@ -2,6 +2,7 @@
 #include "string.h"
 #include "custom_models.h"
 #include "objects.h"
+#include "settings.h"
 
 #define EDIT_BYTE(offset_, val_) (BASE_[offset_] = val_)
 
@@ -19,7 +20,7 @@ u8 SmallKeyData[][7] = {
 
 void CustomModel_EditLinkToCustomTunic(void* linkCMB) {
     char* BASE_ = (char*)linkCMB;
-    
+
     // Edit combinerIndices
     EDIT_BYTE(0x6C4, 0x03);// Update combinerCount
     EDIT_BYTE(0x6CC, 0x0B); EDIT_BYTE(0x6CD, 0x00);// Add new combiner index (Replacing one of the combiners used by unused deku stick)
@@ -67,7 +68,7 @@ void CustomModel_EditHeartContainerToDoubleDefense(void* heartContainerCMB) {
 
     EDIT_BYTE(0xDB, 0x01);
     EDIT_BYTE(0xE8, 0x01);
-    EDIT_BYTE(0x17C, 0x19); EDIT_BYTE(0x17D, 0x19); EDIT_BYTE(0x17E, 0x19); 
+    EDIT_BYTE(0x17C, 0x19); EDIT_BYTE(0x17D, 0x19); EDIT_BYTE(0x17E, 0x19);
     EDIT_BYTE(0x180, 0x00); EDIT_BYTE(0x181, 0x00); EDIT_BYTE(0x182, 0x00); EDIT_BYTE(0x183, 0xB2);
     EDIT_BYTE(0x1FC, 0x01);
     EDIT_BYTE(0x20D, 0x00);
@@ -79,10 +80,12 @@ void CustomModel_EditHeartContainerToDoubleDefense(void* heartContainerCMB) {
 }
 
 void CustomModel_ApplyColorEditsToSmallKey(void* smallKeyCMB, s32 keyType) {
-    char* BASE_ = (char*)smallKeyCMB;
+    if (gSettingsContext.coloredKeys == ON) {
+        char* BASE_ = (char*)smallKeyCMB;
 
-    for (s32 i = 0; i < 7; i++) {
-        EDIT_BYTE(0x12C + i, SmallKeyData[keyType][i]);
+        for (s32 i = 0; i < 7; i++) {
+            EDIT_BYTE(0x12C + i, SmallKeyData[keyType][i]);
+        }
     }
 }
 
@@ -111,7 +114,7 @@ void CustomModel_EditTitleScreenLogo(void* titleScreenZAR) {
     EDIT_BYTE(0x37FF3, 0x40); EDIT_BYTE(0x38133, 0x40); EDIT_BYTE(0x38273, 0x40); EDIT_BYTE(0x383B3, 0x40);
     EDIT_BYTE(0x384F3, 0x40); EDIT_BYTE(0x38633, 0x40);
 
-    // g_title_fire.cmab 
+    // g_title_fire.cmab
     EDIT_BYTE(0x5E570, 0x01);// Change keyframe count to 1 so we only have to change one keyframe
     EDIT_BYTE(0x5E580, 0x0A); EDIT_BYTE(0x5E581, 0xD7); EDIT_BYTE(0x5E582, 0x23); EDIT_BYTE(0x5E583, 0x3D);// Red to 0.04
     EDIT_BYTE(0x5E660, 0x01);

--- a/code/src/settings.h
+++ b/code/src/settings.h
@@ -252,7 +252,6 @@ typedef struct {
   u8 bombchuDrops;
   u8 randomMQDungeons;
   u8 mqDungeonCount;
-  u8 mirrorWorld;
 
   u8 shuffleRewards;
   u8 linksPocketItem;
@@ -303,6 +302,9 @@ typedef struct {
 
   u8 itemPoolValue;
   u8 iceTrapValue;
+
+  u8 coloredKeys;
+  u8 mirrorWorld;
 
   u8 dekuTreeDungeonMode;
   u8 dodongosCavernDungeonMode;

--- a/source/logic.cpp
+++ b/source/logic.cpp
@@ -444,7 +444,7 @@ namespace Logic {
     CanChildAttack  = IsChild && (Slingshot || Boomerang || Sticks || KokiriSword || HasExplosives || CanUse(CanUseItem::Dins_Fire));
     CanChildDamage  = IsChild && (Slingshot ||              Sticks || KokiriSword || HasExplosives || CanUse(CanUseItem::Dins_Fire));
     CanStunDeku     = IsAdult || (Slingshot || Boomerang || Sticks || KokiriSword || HasExplosives || CanUse(CanUseItem::Dins_Fire) || Nuts || DekuShield);
-    CanCutShrubs    = IsAdult || Sticks || KokiriSword || Boomerang || HasExplosives;
+    CanCutShrubs    = IsAdult /*|| Sticks*/ || KokiriSword || Boomerang || HasExplosives;
     CanDive         = ProgressiveScale >= 1;
     CanLeaveForest  = OpenForest.IsNot(OPENFOREST_CLOSED) || IsAdult || DekuTreeClear;
     CanPlantBugs    = IsChild && Bugs;

--- a/source/setting_descriptions.cpp
+++ b/source/setting_descriptions.cpp
@@ -3,16 +3,17 @@
 //Setting descriptions are mostly copied from OoT Randomizer tooltips with minor edits
 
 /*------------------------------
-|      RANDOMIZE SETTINGS      |
-------------------------------*/
-string_view openRandomize             = "Randomize all Open Settings except for Logic rules.";
-string_view worldRandomize            = "Randomize all World Settings except for MQ dungeons";
-string_view shuffleRandomize          = "Randomize all Shuffle Settings";
-string_view dungeonRandomize          = "Randomize all Dungeon Shuffle Settings";
-
-/*------------------------------
-|            LOGIC             |                           *SCREEN WIDTH*
+|      RANDOMIZE SETTINGS      |                            *SCREEN WIDTH*
 ------------------------------*/       /*--------------------------------------------------*/
+string_view openRandomize             = "Randomize all Open Settings except for Logic rules";
+string_view worldRandomize            = "Randomize all World Settings except for MQ\n"     //
+                                        "dungeons";                                        //
+string_view shuffleRandomize          = "Randomize all Shuffle Settings";                  //
+string_view dungeonRandomize          = "Randomize all Dungeon Shuffle Settings";          //
+                                                                                           //
+/*------------------------------                                                           //
+|            LOGIC             |                                                           //
+------------------------------*/                                                           //
 string_view logicGlitchless           = "No glitches are required, but may require some\n" //
                                         "minor tricks. Add minor tricks to consider for\n" //
                                         "logic in Detailed Logic Settings.";               //
@@ -561,6 +562,16 @@ string_view childHammerDesc           = "Child Link can swing the Megaton Hammer
                                         "\n"                                               //
                                         "This setting will not change the logic.";         //
                                                                                            //
+/*------------------------------                                                           //
+|         COLORED KEYS         |                                                           //
+------------------------------*/                                                           //
+string_view coloredKeysDesc           = "If set, small key models will be colored\n"       //
+                                        "differently depending on which dungeon they can be"
+                                        "used in. Forest Temple keys are green. Fire Temple"
+                                        "keys are red. etc.\n"                             //
+                                        "\n"                                               //
+                                        "It may be hard to tell some colors apart if you\n"//
+                                        "are colorblind.";                                 //
 /*------------------------------                                                           //
 |         MIRROR WORLD         |                                                           //
 ------------------------------*/                                                           //

--- a/source/setting_descriptions.hpp
+++ b/source/setting_descriptions.hpp
@@ -55,8 +55,6 @@ extern string_view randomMQDungeonsDesc;
 
 extern string_view mqDungeonCountDesc;
 
-extern string_view mirrorWorldDesc;
-
 extern string_view shuffleRewardsEndOfDungeon;
 extern string_view shuffleRewardsAnyDungeon;
 extern string_view shuffleRewardsOverworld;
@@ -200,6 +198,10 @@ extern string_view adultStickDesc;
 extern string_view adultBoomerangDesc;
 
 extern string_view childHammerDesc;
+
+extern string_view coloredKeysDesc;
+
+extern string_view mirrorWorldDesc;
 
 extern string_view ToggleAllDetailedLogicDesc;
 extern string_view LogicGrottosWithoutAgonyDesc;

--- a/source/settings.cpp
+++ b/source/settings.cpp
@@ -562,6 +562,7 @@ namespace Settings {
   std::string finalSilverGauntletsColor = SilverGauntletsColor.GetSelectedOptionText();
   std::string finalGoldGauntletsColor   = GoldGauntletsColor.GetSelectedOptionText();
 
+  Option ColoredKeys = Option::Bool("Colored Keys",         {"Off", "On"},   {coloredKeysDesc}, OptionCategory::Cosmetic);
   Option MirrorWorld = Option::Bool("Mirror World",         {"Off", "On"},   {mirrorWorldDesc}, OptionCategory::Cosmetic);
 
   std::vector<Option *> cosmeticOptions = {
@@ -570,6 +571,7 @@ namespace Settings {
     &ZoraTunicColor,
     &SilverGauntletsColor,
     &GoldGauntletsColor,
+    &ColoredKeys,
     &MirrorWorld,
   };
 
@@ -655,7 +657,6 @@ namespace Settings {
     ctx.bombchuDrops         = (BombchuDrops) ? 1 : 0;
     ctx.randomMQDungeons     = (RandomMQDungeons) ? 1 : 0;
     ctx.mqDungeonCount       = MQDungeonCount.Value<u8>();
-    ctx.mirrorWorld          = (MirrorWorld) ? 1 : 0;
 
     ctx.shuffleRewards       = ShuffleRewards.Value<u8>();
     ctx.linksPocketItem      = LinksPocketItem.Value<u8>();
@@ -705,6 +706,9 @@ namespace Settings {
 
     ctx.itemPoolValue        = ItemPoolValue.Value<u8>();
     ctx.iceTrapValue         = IceTrapValue.Value<u8>();
+
+    ctx.mirrorWorld          = (MirrorWorld) ? 1 : 0;
+    ctx.coloredKeys          = (ColoredKeys) ? 1 : 0;
 
     ctx.linksPocketRewardBitMask = LinksPocketRewardBitMask;
 

--- a/source/settings.hpp
+++ b/source/settings.hpp
@@ -262,7 +262,6 @@ namespace Settings {
   extern Option BombchuDrops;
   extern Option RandomMQDungeons;
   extern Option MQDungeonCount;
-  extern Option MirrorWorld;
 
   extern Option ShuffleRewards;
   extern Option LinksPocketItem;
@@ -479,6 +478,9 @@ namespace Settings {
   extern std::string finalZoraTunicColor;
   extern std::string finalSilverGauntletsColor;
   extern std::string finalGoldGauntletsColor;
+
+  extern Option ColoredKeys;
+  extern Option MirrorWorld;
 
   extern u32 LinksPocketRewardBitMask;
   extern std::array<u32, 9> rDungeonRewardOverrides;

--- a/source/settings.hpp
+++ b/source/settings.hpp
@@ -322,13 +322,6 @@ namespace Settings {
   extern bool ShuffleInteriorEntrances;
   extern bool ShuffleSpecialIndoorEntrances;
 
-  extern bool ForestTrialSkip;
-  extern bool FireTrialSkip;
-  extern bool WaterTrialSkip;
-  extern bool SpiritTrialSkip;
-  extern bool ShadowTrialSkip;
-  extern bool LightTrialSkip;
-
   //Starting Inventory
   extern Option StartingConsumables;
   extern Option StartingMaxRupees;


### PR DESCRIPTION
- Add a new cosmetics option for turning key colors on/off
- Also fixed a logic error that assumed deku sticks could cut shrubs despite them not being able to