### PR TITLE
Shopsanity: Several small (But still important) changes

### DIFF
--- a/code/src/shops.c
+++ b/code/src/shops.c
@@ -72,27 +72,30 @@ void ShopsanityItem_BuyEventFunc(GlobalContext* globalCtx, EnGirlA* item) {
 
 s32 ShopsanityItem_CanBuy(GlobalContext* globalCtx, EnGirlA* item) {
     if (item->basePrice <= gSaveContext.rupees) { //Has enough rupees
-        u8 id = ((ShopsanityItem*)item)->itemRow->actionId;
-        if (ShopsanityItem_IsBombs(id)) {
-            if ((gSaveContext.upgrades >> 3) & 0x7) { //Has bomb bag
-                return CANBUY_RESULT_0;
+        //Tunics are non-ShopsanityItem objects passed to this function, so don't check those
+        if (!(item->getItemId == GI_TUNIC_GORON || item->getItemId == GI_TUNIC_ZORA)) {
+            u8 id = ((ShopsanityItem*)item)->itemRow->actionId;
+            if (ShopsanityItem_IsBombs(id)) {
+                if ((gSaveContext.upgrades >> 3) & 0x7) { //Has bomb bag
+                    return CANBUY_RESULT_0;
+                }
+                return CANBUY_RESULT_CANT_GET_NOW;
             }
-            return CANBUY_RESULT_CANT_GET_NOW;
-        }
-        else if (ShopsanityItem_IsArrows(id)) {
-            if (gSaveContext.upgrades & 0x7) { //Has bow
-                return CANBUY_RESULT_0;
+            else if (ShopsanityItem_IsArrows(id)) {
+                if (gSaveContext.upgrades & 0x7) { //Has bow
+                    return CANBUY_RESULT_0;
+                }
+                return CANBUY_RESULT_CANT_GET_NOW;
             }
-            return CANBUY_RESULT_CANT_GET_NOW;
-        }
-        else if (ShopsanityItem_IsSeeds(id)) {
-            if ((gSaveContext.upgrades >> 14) & 0x7) { //Has slingshot
-                return CANBUY_RESULT_0;
+            else if (ShopsanityItem_IsSeeds(id)) {
+                if ((gSaveContext.upgrades >> 14) & 0x7) { //Has slingshot
+                    return CANBUY_RESULT_0;
+                }
+                return CANBUY_RESULT_CANT_GET_NOW;
             }
-            return CANBUY_RESULT_CANT_GET_NOW;
-        }
-        else if (ShopsanityItem_IsBombchus(id)) {
-            return Shop_CheckCanBuyBombchus();
+            else if (ShopsanityItem_IsBombchus(id)) {
+                return Shop_CheckCanBuyBombchus();
+            }
         }
         return CANBUY_RESULT_0;
     } else { //Not enough rupees

--- a/code/src/shops.c
+++ b/code/src/shops.c
@@ -35,6 +35,8 @@ s32 numShopItemsLoaded = 0; // Used to determine params. Reset this to 0 in ossa
 
 #define EnGirlA_InitializeItemAction ((EnGirlAActionFunc)0x14D5C8)
 
+//Checks for if item is of a certain type
+
 u8 ShopsanityItem_IsBombs(u8 id) {
     return id == ITEM_BOMB || id == ITEM_BOMBS_5 || id == ITEM_BOMBS_10 || id == ITEM_BOMBS_20 || id == ITEM_BOMBS_30;
 }
@@ -55,6 +57,10 @@ u8 ShopsanityItem_IsNuts(u8 id) {
     return id == ITEM_NUT || id == ITEM_NUTS_5 || id == ITEM_NUTS_10;
 }
 
+u8 ShopsanityItem_IsSticks(u8 id) {
+    return id == ITEM_STICK || id == ITEM_STICKS_5 || id == ITEM_STICKS_10;
+}
+
 
 void ShopsanityItem_BuyEventFunc(GlobalContext* globalCtx, EnGirlA* item) {
     ShopsanityItem* shopItem = (ShopsanityItem*)item;
@@ -63,7 +69,8 @@ void ShopsanityItem_BuyEventFunc(GlobalContext* globalCtx, EnGirlA* item) {
 
     u8 id = shopItem->itemRow->actionId;
     //Make it so ammo does not sell out
-    if (!(ShopsanityItem_IsBombs(id) || ShopsanityItem_IsArrows(id) || ShopsanityItem_IsSeeds(id) || ShopsanityItem_IsBombchus(id) || ShopsanityItem_IsNuts(id))) {
+    if (!(ShopsanityItem_IsBombs(id) || ShopsanityItem_IsArrows(id) || ShopsanityItem_IsSeeds(id) || 
+        ShopsanityItem_IsBombchus(id) || ShopsanityItem_IsNuts(id) || ShopsanityItem_IsSticks(id))) {
         if (gSaveContext.entranceIndex == 0x00B7) {
             gSaveContext.sceneFlags[SCENE_BAZAAR + SHOP_KAKARIKO_BAZAAR].unk |= itemBit;
         } else {

--- a/code/src/shops.c
+++ b/code/src/shops.c
@@ -51,6 +51,10 @@ u8 ShopsanityItem_IsBombchus(u8 id) {
     return id == ITEM_BOMBCHU || id == ITEM_BOMBCHUS_5 || id == ITEM_BOMBCHUS_20;
 }
 
+u8 ShopsanityItem_IsNuts(u8 id) {
+    return id == ITEM_NUT || id == ITEM_NUTS_5 || id == ITEM_NUTS_10;
+}
+
 
 void ShopsanityItem_BuyEventFunc(GlobalContext* globalCtx, EnGirlA* item) {
     ShopsanityItem* shopItem = (ShopsanityItem*)item;
@@ -59,7 +63,7 @@ void ShopsanityItem_BuyEventFunc(GlobalContext* globalCtx, EnGirlA* item) {
 
     u8 id = shopItem->itemRow->actionId;
     //Make it so ammo does not sell out
-    if (!(ShopsanityItem_IsBombs(id) || ShopsanityItem_IsArrows(id) || ShopsanityItem_IsSeeds(id) || ShopsanityItem_IsBombchus(id))) {
+    if (!(ShopsanityItem_IsBombs(id) || ShopsanityItem_IsArrows(id) || ShopsanityItem_IsSeeds(id) || ShopsanityItem_IsBombchus(id) || ShopsanityItem_IsNuts(id))) {
         if (gSaveContext.entranceIndex == 0x00B7) {
             gSaveContext.sceneFlags[SCENE_BAZAAR + SHOP_KAKARIKO_BAZAAR].unk |= itemBit;
         } else {
@@ -92,9 +96,6 @@ s32 ShopsanityItem_CanBuy(GlobalContext* globalCtx, EnGirlA* item) {
                     return CANBUY_RESULT_0;
                 }
                 return CANBUY_RESULT_CANT_GET_NOW;
-            }
-            else if (ShopsanityItem_IsBombchus(id)) {
-                return Shop_CheckCanBuyBombchus();
             }
         }
         return CANBUY_RESULT_0;

--- a/source/custom_messages.cpp
+++ b/source/custom_messages.cpp
@@ -308,10 +308,18 @@ constexpr std::array DungeonColors = {
                 name = "Green Rupee"; //^
             }
             //Message to display when hovering over the item
-            CreateMessage(0x9200+shopitems*2, 0, 0, 0,
-                INSTANT_TEXT_ON()+COLOR(QM_RED)+name+": "+price+" Rupees"+NEWLINE()+COLOR(QM_WHITE)+"Special deal! ONE LEFT!"+NEWLINE()+"Get it while it lasts!"+SHOP_MESSAGE_BOX()+MESSAGE_END(),
-                INSTANT_TEXT_ON()+COLOR(QM_RED)+name+": "+price+" rubis"+NEWLINE()+COLOR(QM_WHITE)+"Offre spéciale! DERNIER EN STOCK!"+NEWLINE()+"Faites vite!"+SHOP_MESSAGE_BOX()+MESSAGE_END(),
-                INSTANT_TEXT_ON()+COLOR(QM_RED)+name+": "+price+" rupias"+NEWLINE()+COLOR(QM_WHITE)+"¡Oferta especial! ¡UNO RESTANTE!"+NEWLINE()+"¡Obtiene mientras dure!"+SHOP_MESSAGE_BOX()+MESSAGE_END());
+            if (IsRepurchaseable(name)) { //Different checkbox for repurchaseable items
+                CreateMessage(0x9200+shopitems*2, 0, 0, 0,
+                    INSTANT_TEXT_ON()+COLOR(QM_RED)+name+": "+price+" Rupees"+NEWLINE()+COLOR(QM_WHITE)+"Special deal!"+NEWLINE()+"Buy as many as you want!"+SHOP_MESSAGE_BOX()+MESSAGE_END(),
+                    INSTANT_TEXT_ON()+COLOR(QM_RED)+name+": "+price+" rubis"+NEWLINE()+COLOR(QM_WHITE)+"Offre spéciale!"+NEWLINE()+"Achetez-en à volonté!"+SHOP_MESSAGE_BOX()+MESSAGE_END(),
+                    INSTANT_TEXT_ON()+COLOR(QM_RED)+name+": "+price+" rupias"+NEWLINE()+COLOR(QM_WHITE)+"¡Oferta especial!"+NEWLINE()+"¡Compra tantos como quieras!"+SHOP_MESSAGE_BOX()+MESSAGE_END());
+            }
+            else { //Normal textbox
+                CreateMessage(0x9200+shopitems*2, 0, 0, 0,
+                    INSTANT_TEXT_ON()+COLOR(QM_RED)+name+": "+price+" Rupees"+NEWLINE()+COLOR(QM_WHITE)+"Special deal! ONE LEFT!"+NEWLINE()+"Get it while it lasts!"+SHOP_MESSAGE_BOX()+MESSAGE_END(),
+                    INSTANT_TEXT_ON()+COLOR(QM_RED)+name+": "+price+" rubis"+NEWLINE()+COLOR(QM_WHITE)+"Offre spéciale! DERNIER EN STOCK!"+NEWLINE()+"Faites vite!"+SHOP_MESSAGE_BOX()+MESSAGE_END(),
+                    INSTANT_TEXT_ON()+COLOR(QM_RED)+name+": "+price+" rupias"+NEWLINE()+COLOR(QM_WHITE)+"¡Oferta especial! ¡SOLO QUEDA UNA UNIDAD!"+NEWLINE()+"¡Hazte con ella antes de que se agote!"+SHOP_MESSAGE_BOX()+MESSAGE_END());
+            }
             //Message to display when going to buy the item
             CreateMessage(0x9200+shopitems*2+1, 0, 0, 0,
                 INSTANT_TEXT_ON()+name+": "+price+" Rupees"+INSTANT_TEXT_OFF()+NEWLINE()+NEWLINE()+TWO_WAY_CHOICE()+COLOR(QM_GREEN)+"Buy"+NEWLINE()+"Don't buy"+COLOR(QM_WHITE)+INSTANT_TEXT_OFF()+MESSAGE_END(),

--- a/source/custom_messages.cpp
+++ b/source/custom_messages.cpp
@@ -308,7 +308,7 @@ constexpr std::array DungeonColors = {
                 name = "Green Rupee"; //^
             }
             //Message to display when hovering over the item
-            if (IsRepurchaseable(name)) { //Different checkbox for repurchaseable items
+            if (NonShopItems[shopitems].Repurchaseable) { //Different checkbox for repurchaseable items
                 CreateMessage(0x9200+shopitems*2, 0, 0, 0,
                     INSTANT_TEXT_ON()+COLOR(QM_RED)+name+": "+price+" Rupees"+NEWLINE()+COLOR(QM_WHITE)+"Special deal!"+NEWLINE()+"Buy as many as you want!"+SHOP_MESSAGE_BOX()+MESSAGE_END(),
                     INSTANT_TEXT_ON()+COLOR(QM_RED)+name+": "+price+" rubis"+NEWLINE()+COLOR(QM_WHITE)+"Offre spéciale!"+NEWLINE()+"Achetez-en à volonté!"+SHOP_MESSAGE_BOX()+MESSAGE_END(),

--- a/source/fill.cpp
+++ b/source/fill.cpp
@@ -674,7 +674,7 @@ int Fill() {
             int itemindex = indices[j];
             ShopItems[i*8+itemindex-1] = NONE; //Clear item so it can be filled during the general fill algo
             int shopsanityPrice = GetRandomShopPrice();
-            ShopItemsPrices[i*8+itemindex-1] = shopsanityPrice; //Set price in ShopItemsPrices vector so it can be retrieved later by the patch
+            NonShopItems[TransformShopIndex(i*8+itemindex-1)].Price = shopsanityPrice; //Set price to be retrieved by the patch and textboxes
             Location(ShopLocationLists[i][itemindex - 1])->SetShopsanityPrice(shopsanityPrice);
           }
         }

--- a/source/fill.cpp
+++ b/source/fill.cpp
@@ -659,6 +659,7 @@ int Fill() {
         ItemAndPrice init;
         init.Name = "No Item";
         init.Price = -1;
+        init.Repurchaseable = false;
         NonShopItems.assign(32, init);
         //Indices from OoTR. So shopsanity one will overwrite 7, three will overwrite 7, 5, 8, etc.
         const std::array<int, 4> indices = {7, 5, 8, 6}; 

--- a/source/fill.cpp
+++ b/source/fill.cpp
@@ -649,28 +649,24 @@ int Fill() {
     FillExcludedLocations();
 
     //Place shop items first, since a buy shield is needed to place a dungeon reward on Gohma due to access
-    SetVanillaShopItems(); //Set ShopItems vector to default, vanilla values
     if (Shopsanity.Is(SHOPSANITY_OFF)) {
-      PlaceShopItems(); //Just place vanilla items
+      SetVanillaShopItems(); //Set ShopItems vector to default, vanilla values
+      PlaceShopItems(); //Just place these vanilla items
     } else {
-      if (Shopsanity.Is(SHOPSANITY_ZERO)) { //Shopsanity 0
-        Shuffle(ShopItems); //Shuffle shop items amongst themselves
-      }
-      else { //Shopsanity 1-4, random
-        const std::array<int, 4> indices = {7, 5, 8, 6}; //Indices from OoTR. So shopsanity one will overwrite 7, three will overwrite 7, 5, 8, etc.
-
-        //Shuffle shop items making sure to not place minShopItems in shop slots which can be overwritten
-        std::vector<int> indicesToExclude;
-        int max = Shopsanity.Is(SHOPSANITY_RANDOM) ? 4 : GetShopsanityReplaceAmount(); //With random it's up to 4 so to be safe we exclude all 4, otherwise exclude amount from settings
-        for(int i = 0; i < max; i++) {
-          indicesToExclude.push_back(indices[i]);
-        }
-        ShuffleShop(ShopItems, indicesToExclude); //Shuffle shop items, making sure some will not be overwritten
-
+      int total_replaced = 0;
+      if (Shopsanity.IsNot(SHOPSANITY_ZERO)) { //Shopsanity 1-4, random
+        //Initialize NonShopItems
+        ItemAndPrice init;
+        init.Name = "No Item";
+        init.Price = -1;
+        NonShopItems.assign(32, init);
+        //Indices from OoTR. So shopsanity one will overwrite 7, three will overwrite 7, 5, 8, etc.
+        const std::array<int, 4> indices = {7, 5, 8, 6}; 
         //Overwrite appropriate number of shop items
         for (size_t i = 0; i < ShopLocationLists.size(); i++) {
           int num_to_replace = GetShopsanityReplaceAmount(); //1-4 shop items will be overwritten, depending on settings
-          for(int j = 0; j < num_to_replace; j++) {
+          total_replaced += num_to_replace;
+          for (int j = 0; j < num_to_replace; j++) {
             int itemindex = indices[j];
             ShopItems[i*8+itemindex-1] = NONE; //Clear item so it can be filled during the general fill algo
             int shopsanityPrice = GetRandomShopPrice();
@@ -681,7 +677,9 @@ int Fill() {
       }
       //Get all locations and items that don't have a shopsanity price attached
       std::vector<LocationKey> shopLocations = {};
-      std::vector<ItemKey> shopItems = FilterFromPool(ShopItems, [](const ItemKey i){return i != NONE;});
+      //Get as many vanilla shop items as the total number of shop items minus the number of replaced items
+      //So shopsanity 0 will get all 64 vanilla items, shopsanity 4 will get 32, etc.
+      std::vector<ItemKey> shopItems = GetMinVanillaShopItems(total_replaced);
 
       for (size_t i = 0; i < ShopLocationLists.size(); i++) {
         for (size_t j = 0; j < ShopLocationLists[i].size(); j++) {

--- a/source/item_list.cpp
+++ b/source/item_list.cpp
@@ -162,23 +162,23 @@ void ItemTable_Init() {                               //Name                    
     itemTable[MILK]                              = Item("Milk",             ITEMTYPE_ITEM, GI_MILK,              false, &noVariable, NONE);
 
     //Refills
-    itemTable[BOMBS_5]                           = Item("Bombs (5)",           ITEMTYPE_ITEM, GI_BOMBS_5,        false, &noVariable,  BOMBS_5);
-    itemTable[BOMBS_10]                          = Item("Bombs (10)",          ITEMTYPE_ITEM, GI_BOMBS_10,       false, &noVariable,  BOMBS_10);
-    itemTable[BOMBS_20]                          = Item("Bombs (20)",          ITEMTYPE_ITEM, GI_BOMBS_20,       false, &noVariable,  BOMBS_20);
-    itemTable[BOMBCHU_5]                         = Item("Bombchu (5)",         ITEMTYPE_ITEM, GI_BOMBCHUS_5,     true,  &Bombchus5,   BOMBCHU_5);
-    itemTable[BOMBCHU_10]                        = Item("Bombchu (10)",        ITEMTYPE_ITEM, GI_BOMBCHUS_10,    true,  &Bombchus10,  BOMBCHU_10);
-    itemTable[BOMBCHU_20]                        = Item("Bombchu (20)",        ITEMTYPE_ITEM, GI_BOMBCHUS_20,    true,  &Bombchus20,  BOMBCHU_20);
-    itemTable[BOMBCHU_DROP]                      = Item("Bombchu Drop",        ITEMTYPE_DROP, GI_BOMBCHUS_10,    true,  &BombchuDrop, NONE);
-    itemTable[ARROWS_5]                          = Item("Arrows (5)",          ITEMTYPE_ITEM, GI_ARROWS_SMALL,   false, &noVariable,  ARROWS_5);
-    itemTable[ARROWS_10]                         = Item("Arrows (10)",         ITEMTYPE_ITEM, GI_ARROWS_MEDIUM,  false, &noVariable,  ARROWS_10);
-    itemTable[ARROWS_30]                         = Item("Arrows (30)",         ITEMTYPE_ITEM, GI_ARROWS_LARGE,   false, &noVariable,  ARROWS_30);
-    itemTable[DEKU_NUTS_5]                       = Item("Deku Nuts (5)",       ITEMTYPE_ITEM, GI_NUTS_5,         false, &noVariable,  DEKU_NUTS_5);
-    itemTable[DEKU_NUTS_10]                      = Item("Deku Nuts (10)",      ITEMTYPE_ITEM, GI_NUTS_10,        false, &noVariable,  DEKU_NUTS_10);
-    itemTable[DEKU_SEEDS_30]                     = Item("Deku Seeds (30)",     ITEMTYPE_ITEM, GI_SEEDS_30,       false, &noVariable,  DEKU_SEEDS_30);
-    itemTable[DEKU_STICK_1]                      = Item("Deku Stick (1)",      ITEMTYPE_ITEM, GI_STICKS_1,       false, &noVariable,  DEKU_STICK_1);
-    itemTable[RED_POTION_REFILL]                 = Item("Red Potion Refill",   ITEMTYPE_ITEM, GI_POTION_RED,     false, &noVariable,  NONE);
-    itemTable[GREEN_POTION_REFILL]               = Item("Green Potion Refill", ITEMTYPE_ITEM, GI_POTION_GREEN,   false, &noVariable,  NONE);
-    itemTable[BLUE_POTION_REFILL]                = Item("Blue Potion Refill",  ITEMTYPE_ITEM, GI_POTION_BLUE,    false, &noVariable,  NONE);
+    itemTable[BOMBS_5]                           = Item("Bombs (5)",           ITEMTYPE_REFILL, GI_BOMBS_5,        false, &noVariable,  BOMBS_5);
+    itemTable[BOMBS_10]                          = Item("Bombs (10)",          ITEMTYPE_REFILL, GI_BOMBS_10,       false, &noVariable,  BOMBS_10);
+    itemTable[BOMBS_20]                          = Item("Bombs (20)",          ITEMTYPE_REFILL, GI_BOMBS_20,       false, &noVariable,  BOMBS_20);
+    itemTable[BOMBCHU_5]                         = Item("Bombchu (5)",         ITEMTYPE_REFILL, GI_BOMBCHUS_5,     true,  &Bombchus5,   BOMBCHU_5);
+    itemTable[BOMBCHU_10]                        = Item("Bombchu (10)",        ITEMTYPE_REFILL, GI_BOMBCHUS_10,    true,  &Bombchus10,  BOMBCHU_10);
+    itemTable[BOMBCHU_20]                        = Item("Bombchu (20)",        ITEMTYPE_REFILL, GI_BOMBCHUS_20,    true,  &Bombchus20,  BOMBCHU_20);
+    itemTable[BOMBCHU_DROP]                      = Item("Bombchu Drop",        ITEMTYPE_DROP,   GI_BOMBCHUS_10,    true,  &BombchuDrop, NONE);
+    itemTable[ARROWS_5]                          = Item("Arrows (5)",          ITEMTYPE_REFILL, GI_ARROWS_SMALL,   false, &noVariable,  ARROWS_5);
+    itemTable[ARROWS_10]                         = Item("Arrows (10)",         ITEMTYPE_REFILL, GI_ARROWS_MEDIUM,  false, &noVariable,  ARROWS_10);
+    itemTable[ARROWS_30]                         = Item("Arrows (30)",         ITEMTYPE_REFILL, GI_ARROWS_LARGE,   false, &noVariable,  ARROWS_30);
+    itemTable[DEKU_NUTS_5]                       = Item("Deku Nuts (5)",       ITEMTYPE_REFILL, GI_NUTS_5,         false, &noVariable,  DEKU_NUTS_5);
+    itemTable[DEKU_NUTS_10]                      = Item("Deku Nuts (10)",      ITEMTYPE_REFILL, GI_NUTS_10,        false, &noVariable,  DEKU_NUTS_10);
+    itemTable[DEKU_SEEDS_30]                     = Item("Deku Seeds (30)",     ITEMTYPE_REFILL, GI_SEEDS_30,       false, &noVariable,  DEKU_SEEDS_30);
+    itemTable[DEKU_STICK_1]                      = Item("Deku Stick (1)",      ITEMTYPE_REFILL, GI_STICKS_1,       false, &noVariable,  DEKU_STICK_1);
+    itemTable[RED_POTION_REFILL]                 = Item("Red Potion Refill",   ITEMTYPE_REFILL, GI_POTION_RED,     false, &noVariable,  NONE);
+    itemTable[GREEN_POTION_REFILL]               = Item("Green Potion Refill", ITEMTYPE_REFILL, GI_POTION_GREEN,   false, &noVariable,  NONE);
+    itemTable[BLUE_POTION_REFILL]                = Item("Blue Potion Refill",  ITEMTYPE_REFILL, GI_POTION_BLUE,    false, &noVariable,  NONE);
 
     //Treasure Game
     itemTable[TREASURE_GAME_HEART]               = Item("Piece of Heart (Treasure Chest Minigame)", ITEMTYPE_ITEM, GI_HEART_PIECE_WIN,  false, &noVariable, TREASURE_GAME_HEART);

--- a/source/item_location.cpp
+++ b/source/item_location.cpp
@@ -1443,11 +1443,8 @@ void PlaceItemInLocation(LocationKey locKey, ItemKey item, bool applyEffectImmed
 
   //If we're placing a non-shop item in a shop location, we want to record it for custom messages
   if (ItemTable(item).GetItemType() != ITEMTYPE_SHOP && loc->IsCategory(Category::cShop)) {
-    ItemAndPrice newpair;
-    newpair.Name = ItemTable(item).GetName();
     int index = GetShopIndex(locKey);
-    newpair.Price = ShopItemsPrices[index];
-    NonShopItems[TransformShopIndex(index)] = newpair;
+    NonShopItems[TransformShopIndex(index)].Name = ItemTable(item).GetName();
   }
 
   loc->SetPlacedItem(item);

--- a/source/item_location.cpp
+++ b/source/item_location.cpp
@@ -1443,8 +1443,9 @@ void PlaceItemInLocation(LocationKey locKey, ItemKey item, bool applyEffectImmed
 
   //If we're placing a non-shop item in a shop location, we want to record it for custom messages
   if (ItemTable(item).GetItemType() != ITEMTYPE_SHOP && loc->IsCategory(Category::cShop)) {
-    int index = GetShopIndex(locKey);
-    NonShopItems[TransformShopIndex(index)].Name = ItemTable(item).GetName();
+    int index = TransformShopIndex(GetShopIndex(locKey));
+    NonShopItems[index].Name = ItemTable(item).GetName();
+    NonShopItems[index].Repurchaseable = ItemTable(item).GetItemType() == ITEMTYPE_REFILL;
   }
 
   loc->SetPlacedItem(item);

--- a/source/item_location.hpp
+++ b/source/item_location.hpp
@@ -114,6 +114,9 @@ public:
     }
 
     u16 GetPrice() const {
+      if (ItemTable(placedItem).GetItemType() == ITEMTYPE_SHOP) {
+        return ItemTable(placedItem).GetPrice();
+      }
       return price;
     }
 

--- a/source/patch.cpp
+++ b/source/patch.cpp
@@ -268,15 +268,8 @@ bool WritePatch() {
   if (Settings::Shopsanity.IsNot(SHOPSANITY_OFF) && Settings::Shopsanity.IsNot(SHOPSANITY_ZERO)) {
     //Get prices from shop item vector
     std::array<s32, 32> rShopsanityPrices{};
-    int i = 4;
-    while (i < 64) {
-      rShopsanityPrices[TransformShopIndex(i)] = ShopItemsPrices[i];
-      if (i % 8 == 7) { //Last index for this shop, skip ahead to relevant index of next shop
-        i += 5;
-      }
-      else { //Go to next item within shop
-        i++;
-      }
+    for (int i = 0; i < 32; i++) {
+      rShopsanityPrices[i] = NonShopItems[i].Price;
     }
 
     // Write shopsanity item prices address to code

--- a/source/shops.cpp
+++ b/source/shops.cpp
@@ -241,6 +241,14 @@ int TransformShopIndex(int index) {
   return 4*((index / 4) / 2) + index % 4;
 }
 
+bool IsRepurchaseable(std::string name) {
+  return name == "Bombs (5)" || name == "Bombs (10)" || name == "Bombs (20)" ||
+         name == "Arrows (5)" || name == "Arrows (10)" || name == "Arrows (30)" ||
+         name == "Bombchu (5)" || name == "Bombchu (10)" || name == "Bombchu (20)" ||
+         name == "Deku Nuts (5)" || name == "Deku Nuts (10)" ||
+         name == "Deku Seeds (30)";
+}
+
 //Place each shop item from the shop item array into the appropriate location
 void PlaceShopItems() {
   for (size_t i = 0; i < ShopLocationLists.size(); i++) {

--- a/source/shops.cpp
+++ b/source/shops.cpp
@@ -241,14 +241,6 @@ int TransformShopIndex(int index) {
   return 4*((index / 4) / 2) + index % 4;
 }
 
-bool IsRepurchaseable(std::string name) {
-  return name == "Bombs (5)" || name == "Bombs (10)" || name == "Bombs (20)" ||
-         name == "Arrows (5)" || name == "Arrows (10)" || name == "Arrows (30)" ||
-         name == "Bombchu (5)" || name == "Bombchu (10)" || name == "Bombchu (20)" ||
-         name == "Deku Nuts (5)" || name == "Deku Nuts (10)" ||
-         name == "Deku Seeds (30)";
-}
-
 //Place each shop item from the shop item array into the appropriate location
 void PlaceShopItems() {
   for (size_t i = 0; i < ShopLocationLists.size(); i++) {

--- a/source/shops.cpp
+++ b/source/shops.cpp
@@ -12,7 +12,6 @@
 using namespace Settings;
 
 std::vector<ItemKey> ShopItems = {};
-std::array<int, 64> ShopItemsPrices;
 std::vector<ItemAndPrice> NonShopItems = {};
 //Shop items we don't want to overwrite
 const std::array<ItemKey, 15> minShopItems = {

--- a/source/shops.hpp
+++ b/source/shops.hpp
@@ -9,6 +9,7 @@
 struct ItemAndPrice {
     std::string Name;
     int Price;
+    bool Repurchaseable;
 };
 
 extern void SetVanillaShopItems();
@@ -19,7 +20,6 @@ extern int GetShopsanityReplaceAmount();
 extern std::string GetIceTrapName(u8 id);
 extern int GetShopIndex(LocationKey loc);
 extern int TransformShopIndex(int index);
-extern bool IsRepurchaseable(std::string name);
 extern void PlaceShopItems();
 
 extern std::vector<ItemKey> ShopItems;

--- a/source/shops.hpp
+++ b/source/shops.hpp
@@ -19,6 +19,7 @@ extern int GetShopsanityReplaceAmount();
 extern std::string GetIceTrapName(u8 id);
 extern int GetShopIndex(LocationKey loc);
 extern int TransformShopIndex(int index);
+extern bool IsRepurchaseable(std::string name);
 extern void PlaceShopItems();
 
 extern std::vector<ItemKey> ShopItems;

--- a/source/shops.hpp
+++ b/source/shops.hpp
@@ -12,6 +12,7 @@ struct ItemAndPrice {
 };
 
 extern void SetVanillaShopItems();
+extern std::vector<ItemKey> GetMinVanillaShopItems(int total_replaced);
 extern int GetRandomShopPrice();
 extern s16 GetRandomScrubPrice();
 extern int GetShopsanityReplaceAmount();
@@ -19,7 +20,6 @@ extern std::string GetIceTrapName(u8 id);
 extern int GetShopIndex(LocationKey loc);
 extern int TransformShopIndex(int index);
 extern void PlaceShopItems();
-extern void ShuffleShop(std::vector<ItemKey>& ShopItems, std::vector<int> indicesToExclude);
 
 extern std::vector<ItemKey> ShopItems;
 extern std::vector<ItemAndPrice> NonShopItems;

--- a/source/shops.hpp
+++ b/source/shops.hpp
@@ -22,5 +22,4 @@ extern void PlaceShopItems();
 extern void ShuffleShop(std::vector<ItemKey>& ShopItems, std::vector<int> indicesToExclude);
 
 extern std::vector<ItemKey> ShopItems;
-extern std::array<int, 64> ShopItemsPrices;
 extern std::vector<ItemAndPrice> NonShopItems;


### PR DESCRIPTION
* Deku nuts and sticks now repurchaseable
* Buyability check removed for non-shop bombchus
* New text boxes for repurchaseable items
* Fix crash when buying tunics
* Change the way minshopitems is handled

To be done:
* Finalize ice trap names
* Fix price distribution