### PR TITLE
More cutscene skips and minor changes

### DIFF
--- a/code/src/actor.c
+++ b/code/src/actor.c
@@ -26,6 +26,7 @@
 #include "demo_kankyo.h"
 #include "lake_hylia_objects.h"
 #include "graveyard_objects.h"
+#include "windmill_man.h"
 
 #define OBJECT_GI_KEY 170
 #define OBJECT_GI_HEARTS 189
@@ -82,6 +83,8 @@ void Actor_Init() {
 
     gActorOverlayTable[0x14D].initInfo->init = EnOwl_DespawnInit; //Despawns unnecessary owls
     gActorOverlayTable[0x14D].initInfo->update = EnOwl_rUpdate;
+
+    gActorOverlayTable[0x153].initInfo->update = EnFu_rUpdate;
 
     gActorOverlayTable[0x15E].initInfo->init = EnGanonOrgan_rInit;
 

--- a/code/src/actor.c
+++ b/code/src/actor.c
@@ -25,6 +25,7 @@
 #include "collapsing_castle.h"
 #include "demo_kankyo.h"
 #include "lake_hylia_objects.h"
+#include "graveyard_objects.h"
 
 #define OBJECT_GI_KEY 170
 #define OBJECT_GI_HEARTS 189
@@ -53,6 +54,8 @@ void Actor_Init() {
     gActorOverlayTable[0x8B].initInfo->destroy = DemoEffect_rDestroy;
 
     gActorOverlayTable[0x8C].initInfo->update = DemoKankyo_rUpdate;
+
+    gActorOverlayTable[0x9C].initInfo->update = BgSpot02Objects_rUpdate;
 
     gActorOverlayTable[0xC3].initInfo->draw = EnNb_rDraw;
 

--- a/code/src/graveyard_objects.c
+++ b/code/src/graveyard_objects.c
@@ -1,0 +1,16 @@
+#include "z3D/z3D.h"
+#include "graveyard_objects.h"
+
+#define CsTimer (gGlobalContext->csCtx.frames)
+
+#define BgSpot02Objects_Update_addr 0x3831AC
+#define BgSpot02Objects_Update ((ActorFunc)BgSpot02Objects_Update_addr)
+
+void BgSpot02Objects_rUpdate(Actor* thisx, GlobalContext* globalCtx){
+    BgSpot02Objects_Update(thisx, globalCtx);
+    // Royal Family's Tomb.        Tomb opened (or opening).                Just for safety in case of WW.
+    if(thisx->params == 0x0002 && (gSaveContext.eventChkInf[1] & 0x2000) && gSaveContext.sceneSetupIndex < 4){
+        if(CsTimer>0 && CsTimer<740) CsTimer=740;
+        else if (CsTimer>740 && CsTimer<869) CsTimer = 869;
+    }
+}

--- a/code/src/graveyard_objects.h
+++ b/code/src/graveyard_objects.h
@@ -1,0 +1,8 @@
+#ifndef _GRAVEYARD_OBJECTS_H_
+#define _GRAVEYARD_OBJECTS_H_
+
+#include "z3D/z3D.h"
+
+void BgSpot02Objects_rUpdate(Actor* thisx, GlobalContext* globalCtx);
+
+#endif //_GRAVEYARD_OBJECTS_H_

--- a/code/src/item_effect.c
+++ b/code/src/item_effect.c
@@ -101,6 +101,7 @@ void ItemEffect_GiveSong(SaveContext* saveCtx, s16 questBit, s16 arg2) {
     //give epona for Skip Epona Race setting
     if (questBit == 13 && gSettingsContext.skipEponaRace == SKIP) {
       saveCtx->eventChkInf[0x1] |= 0x0100;
+      gSaveContext.horseData.pos.y = 0xF000; //place Epona OoB, so you can't reach her without playing the song
     }
 }
 

--- a/code/src/windmill_man.c
+++ b/code/src/windmill_man.c
@@ -1,0 +1,16 @@
+#include "z3D/z3D.h"
+#include "windmill_man.h"
+
+#define CsTimer (gGlobalContext->csCtx.frames)
+
+#define EnFu_Update_addr 0x1B1328
+#define EnFu_Update ((ActorFunc)EnFu_Update_addr)
+
+void EnFu_rUpdate(Actor* thisx, GlobalContext* globalCtx){
+    EnFu_Update(thisx, globalCtx);
+
+    if(CsTimer>80 && CsTimer<480){
+        CsTimer=480;
+        gSaveContext.eventChkInf[6] |= 0x0080;
+    }
+}

--- a/code/src/windmill_man.h
+++ b/code/src/windmill_man.h
@@ -1,0 +1,8 @@
+#ifndef _WINDMILL_MAN_H_
+#define _WINDMILL_MAN_H_
+
+#include "z3D/z3D.h"
+
+void EnFu_rUpdate(Actor* thisx, GlobalContext* globalCtx);
+
+#endif //_WINDMILL_MAN_H_

--- a/source/menu.cpp
+++ b/source/menu.cpp
@@ -564,8 +564,8 @@ void GenerateRandomizer() {
       printf("\x1b[14;10HQuit out using the home menu. Then\n");
       printf("\x1b[15;10Henable game patching and launch OoT3D!\n");
     } else if (Settings::PlayOption == PATCH_CITRA) {
-      printf("\x1b[14;10HCopy code.ips and exheader.bin to the\n");
-      printf("\x1b[15;10HOoT3D mods folder, then launch OoT3D!\n");
+      printf("\x1b[14;10HCopy code.ips, exheader.bin and romfs to\n");
+      printf("\x1b[15;10Hthe OoT3D mods folder, then launch OoT3D!\n");
     }
 
     const auto& randomizerHash = GetRandomizerHash();


### PR DESCRIPTION
- The cutscenes showing the Royal Family's Tomb opening and the well draining are skipped.
- Generating a seed for Citra tells the player to move the romfs folder alongside the other files.
- If Skip Epona Race is enabled, getting Epona's Song will place the horse out of bounds, in order to preserve the Ocarina requirement used in the logic.