### PR TITLE
Clear custom message data between seed generations

### DIFF
--- a/code/src/settings.h
+++ b/code/src/settings.h
@@ -303,6 +303,7 @@ typedef struct {
   u8 itemPoolValue;
   u8 iceTrapValue;
 
+  u8 customTunicColors;
   u8 coloredKeys;
   u8 mirrorWorld;
 

--- a/source/custom_messages.cpp
+++ b/source/custom_messages.cpp
@@ -411,6 +411,13 @@ constexpr std::array DungeonColors = {
       return Text{"","",""}+UNSKIPPABLE()+INSTANT_TEXT_ON()+text+INSTANT_TEXT_OFF()+MESSAGE_END();
     }
 
+    void ClearMessages() {
+        messageEntries.clear();
+        arrangedMessageEntries.clear();
+        messageData.str("");
+        arrangedMessageData = "";
+    }
+
     std::string MESSAGE_END()          { return  "\x7F\x00"s; }
     std::string WAIT_FOR_INPUT()       { return  "\x7F\x01"s; }
     std::string HORIZONTAL_SPACE(u8 x) { return  "\x7F\x02"s + char(x); }

--- a/source/custom_messages.hpp
+++ b/source/custom_messages.hpp
@@ -28,6 +28,7 @@ namespace CustomMessages {
 
     void CreateAlwaysIncludedMessages();
     Text AddColorsAndFormat(Text text, const std::vector<u8>& colors = {});
+    void ClearMessages();
 
     std::string MESSAGE_END();
     std::string WAIT_FOR_INPUT();

--- a/source/patch.cpp
+++ b/source/patch.cpp
@@ -362,6 +362,8 @@ bool WritePatch() {
     return false;
   }
   totalRW += messageDataSize;
+  CitraPrint(std::to_string(totalRW));
+  sleep(0.1);
 
   // Write message entries address to code
   u32 messageEntriesOffset = (messageDataOffset + messageDataSize + 3) & ~3; //round up and align with u32
@@ -387,6 +389,8 @@ bool WritePatch() {
     return false;
   }
   totalRW += messageEntriesSize;
+  CitraPrint(std::to_string(totalRW));
+  sleep(0.1);
 
   // Write ptrCustomMessageEntries address to code
   patchOffset = V_TO_P(PTRCUSTOMMESSAGEENTRIES_ADDR);

--- a/source/patch.cpp
+++ b/source/patch.cpp
@@ -509,58 +509,60 @@ bool WritePatch() {
   |       custom assets      |
   --------------------------*/
 
-  Cosmetics::Color_RGB kokiriTunicColor = Cosmetics::HexStrToColorRGB(Settings::finalKokiriTunicColor);
-  Cosmetics::Color_RGB goronTunicColor  = Cosmetics::HexStrToColorRGB(Settings::finalGoronTunicColor);
-  Cosmetics::Color_RGB zoraTunicColor   = Cosmetics::HexStrToColorRGB(Settings::finalZoraTunicColor);
+  if (Settings::CustomTunicColors) {
+    Cosmetics::Color_RGB childTunicColor  = Cosmetics::HexStrToColorRGB(Settings::finalChildTunicColor);
+    Cosmetics::Color_RGB kokiriTunicColor = Cosmetics::HexStrToColorRGB(Settings::finalKokiriTunicColor);
+    Cosmetics::Color_RGB goronTunicColor  = Cosmetics::HexStrToColorRGB(Settings::finalGoronTunicColor);
+    Cosmetics::Color_RGB zoraTunicColor   = Cosmetics::HexStrToColorRGB(Settings::finalZoraTunicColor);
 
-  // Delete assets if it exists
-  Handle assetsOut;
-  const char* assetsOutPath = "/luma/titles/0004000000033500/romfs/actor/zelda_gi_melody.zar";
-  const char* assetsInPath = "romfs:/zelda_gi_melody.zar";
-  FSUSER_DeleteFile(sdmcArchive, fsMakePath(PATH_ASCII, assetsOutPath));
+    // Delete assets if it exists
+    Handle assetsOut;
+    const char* assetsOutPath = "/luma/titles/0004000000033500/romfs/actor/zelda_gi_melody.zar";
+    const char* assetsInPath = "romfs:/zelda_gi_melody.zar";
+    FSUSER_DeleteFile(sdmcArchive, fsMakePath(PATH_ASCII, assetsOutPath));
 
-  // Open assets destination
-  if (!R_SUCCEEDED(res = FSUSER_OpenFile(&assetsOut, sdmcArchive, fsMakePath(PATH_ASCII, assetsOutPath), FS_OPEN_WRITE | FS_OPEN_CREATE, 0))) {
-    return false;
-  }
-
-  if (auto file = FILEPtr{std::fopen(assetsInPath, "r"), std::fclose}) {
-    // obtain assets size
-    fseek(file.get(), 0, SEEK_END);
-    const auto lSize = static_cast<size_t>(ftell(file.get()));
-    rewind(file.get());
-
-    // copy assets into the buffer
-    std::vector<char> buffer(lSize);
-    fread(buffer.data(), 1, buffer.size(), file.get());
-
-    // edit assets as needed
-    const size_t adultTunicOffsetInZAR = 0x101F8;
-    const size_t childTunicOffsetInZAR = 0x1E7D8;
-
-    WriteFloatToBuffer(buffer, kokiriTunicColor.r, adultTunicOffsetInZAR + 0x70);
-    WriteFloatToBuffer(buffer, kokiriTunicColor.g, adultTunicOffsetInZAR + 0x98);
-    WriteFloatToBuffer(buffer, kokiriTunicColor.b, adultTunicOffsetInZAR + 0xC0);
-
-    WriteFloatToBuffer(buffer, goronTunicColor.r, adultTunicOffsetInZAR + 0x78);
-    WriteFloatToBuffer(buffer, goronTunicColor.g, adultTunicOffsetInZAR + 0xA0);
-    WriteFloatToBuffer(buffer, goronTunicColor.b, adultTunicOffsetInZAR + 0xC8);
-
-    WriteFloatToBuffer(buffer, zoraTunicColor.r, adultTunicOffsetInZAR + 0x80);
-    WriteFloatToBuffer(buffer, zoraTunicColor.g, adultTunicOffsetInZAR + 0xA8);
-    WriteFloatToBuffer(buffer, zoraTunicColor.b, adultTunicOffsetInZAR + 0xD0);
-
-    WriteFloatToBuffer(buffer, kokiriTunicColor.r, childTunicOffsetInZAR + 0x70);
-    WriteFloatToBuffer(buffer, kokiriTunicColor.g, childTunicOffsetInZAR + 0x88);
-    WriteFloatToBuffer(buffer, kokiriTunicColor.b, childTunicOffsetInZAR + 0xA0);
-
-    // Write the assets to final destination
-    if (!R_SUCCEEDED(res = FSFILE_Write(assetsOut, &bytesWritten, 0, buffer.data(), buffer.size(), FS_WRITE_FLUSH))) {
+    // Open assets destination
+    if (!R_SUCCEEDED(res = FSUSER_OpenFile(&assetsOut, sdmcArchive, fsMakePath(PATH_ASCII, assetsOutPath), FS_OPEN_WRITE | FS_OPEN_CREATE, 0))) {
       return false;
     }
-  }
 
-  FSFILE_Close(assetsOut);
+    if (auto file = FILEPtr{std::fopen(assetsInPath, "r"), std::fclose}) {
+      // obtain assets size
+      fseek(file.get(), 0, SEEK_END);
+      const auto lSize = static_cast<size_t>(ftell(file.get()));
+      rewind(file.get());
+
+      // copy assets into the buffer
+      std::vector<char> buffer(lSize);
+      fread(buffer.data(), 1, buffer.size(), file.get());
+
+      // edit assets as needed
+      const size_t adultTunicOffsetInZAR = 0x101F8;
+      const size_t childTunicOffsetInZAR = 0x1E7D8;
+
+      WriteFloatToBuffer(buffer, kokiriTunicColor.r, adultTunicOffsetInZAR + 0x70);
+      WriteFloatToBuffer(buffer, kokiriTunicColor.g, adultTunicOffsetInZAR + 0x98);
+      WriteFloatToBuffer(buffer, kokiriTunicColor.b, adultTunicOffsetInZAR + 0xC0);
+
+      WriteFloatToBuffer(buffer, goronTunicColor.r, adultTunicOffsetInZAR + 0x78);
+      WriteFloatToBuffer(buffer, goronTunicColor.g, adultTunicOffsetInZAR + 0xA0);
+      WriteFloatToBuffer(buffer, goronTunicColor.b, adultTunicOffsetInZAR + 0xC8);
+
+      WriteFloatToBuffer(buffer, zoraTunicColor.r, adultTunicOffsetInZAR + 0x80);
+      WriteFloatToBuffer(buffer, zoraTunicColor.g, adultTunicOffsetInZAR + 0xA8);
+      WriteFloatToBuffer(buffer, zoraTunicColor.b, adultTunicOffsetInZAR + 0xD0);
+
+      WriteFloatToBuffer(buffer, childTunicColor.r, childTunicOffsetInZAR + 0x70);
+      WriteFloatToBuffer(buffer, childTunicColor.g, childTunicOffsetInZAR + 0x88);
+      WriteFloatToBuffer(buffer, childTunicColor.b, childTunicOffsetInZAR + 0xA0);
+
+      // Write the assets to final destination
+      if (!R_SUCCEEDED(res = FSFILE_Write(assetsOut, &bytesWritten, 0, buffer.data(), buffer.size(), FS_WRITE_FLUSH))) {
+        return false;
+      }
+    }
+    FSFILE_Close(assetsOut);
+  }
 
   FSUSER_CloseArchive(sdmcArchive);
 

--- a/source/playthrough.cpp
+++ b/source/playthrough.cpp
@@ -1,5 +1,6 @@
 #include "playthrough.hpp"
 
+#include "custom_messages.hpp"
 #include "fill.hpp"
 #include "location_access.hpp"
 #include "logic.hpp"
@@ -18,6 +19,7 @@ namespace Playthrough {
       Random_Init(seed);
 
       overrides.clear();
+      CustomMessages::ClearMessages();
       ItemReset();
       HintReset();
       Exits::AccessReset();

--- a/source/setting_descriptions.cpp
+++ b/source/setting_descriptions.cpp
@@ -128,7 +128,7 @@ string_view ageDesc                   = "Choose which age Link will start as.\n"
 |      BOMBCHUS IN LOGIC       |                                                           //
 ------------------------------*/                                                           //
 string_view bombchuLogicDesc          = "Bombchus are properly considered in logic and\n"  //
-                                        "bombchu drops are forced on to guarentee a\n"     //
+                                        "bombchu drops are forced on to guarantee a\n"     //
                                         "replenishable source.\n"                          //
                                         "\n"                                               //
                                         "Bombchu Bowling is opened by bombchus.";          //

--- a/source/settings.cpp
+++ b/source/settings.cpp
@@ -811,7 +811,7 @@ namespace Settings {
   }
 
   //set default cosmetics where the default is not the first option
-  void SetDefaultCosmetics() {
+  static void SetDefaultCosmetics() {
     SilverGauntletsColor.SetSelectedIndex(3); //Silver
     GoldGauntletsColor.SetSelectedIndex(4);   //Gold
     KokiriTunicColor.SetSelectedIndex(3);     //Kokiri Green
@@ -865,7 +865,7 @@ namespace Settings {
   }
 
   //Include and Lock the desired locations
-  void IncludeAndHide(std::vector<LocationKey> locations) {
+  static void IncludeAndHide(std::vector<LocationKey> locations) {
     for (LocationKey loc : locations) {
       Location(loc)->GetExcludedOption()->SetSelectedIndex(INCLUDE);
       Location(loc)->GetExcludedOption()->Hide();
@@ -873,7 +873,7 @@ namespace Settings {
   }
 
   //Unlock the desired locations
-  void Unhide(std::vector<LocationKey> locations) {
+  static void Unhide(std::vector<LocationKey> locations) {
     for (LocationKey loc : locations) {
       Location(loc)->GetExcludedOption()->Unhide();
     }
@@ -882,7 +882,7 @@ namespace Settings {
   //This function will hide certain locations from the Excluded Locations
   //menu if the player's current settings would require non-junk to be placed
   //at those locations. Excluded locations will have junk placed at them.
-  void ResolveExcludedLocationConflicts() {
+  static void ResolveExcludedLocationConflicts() {
 
     //Force include shops if shopsanity is off
     std::vector<LocationKey> shopLocations = GetLocations(everyPossibleLocation, Category::cShop);
@@ -1296,7 +1296,7 @@ namespace Settings {
   bool ShuffleSpecialIndoorEntrances    = false;
 
   //Function to update cosmetics options depending on choices
-  void UpdateCosmetics() {
+  static void UpdateCosmetics() {
     if (KokiriTunicColor.Is(CUSTOM_COLOR)) {
       finalKokiriTunicColor = GetCustomColor(KokiriTunicColor.GetSelectedOptionText());
     } else if (KokiriTunicColor.Is(RANDOM_CHOICE)) {

--- a/source/settings.cpp
+++ b/source/settings.cpp
@@ -551,11 +551,14 @@ namespace Settings {
     "This will only affect the color on Link's model.",
   };
 
-  Option KokiriTunicColor           = Option::U8("Kokiri Tunic Color",     tunicOptions,    cosmeticDescriptions, OptionCategory::Cosmetic);
-  Option GoronTunicColor            = Option::U8("Goron Tunic Color",      tunicOptions,    cosmeticDescriptions, OptionCategory::Cosmetic);
-  Option ZoraTunicColor             = Option::U8("Zora Tunic Color",       tunicOptions,    cosmeticDescriptions, OptionCategory::Cosmetic);
-  Option SilverGauntletsColor       = Option::U8("Silver Gauntlets Color", gauntletOptions, cosmeticDescriptions, OptionCategory::Cosmetic);
-  Option GoldGauntletsColor         = Option::U8("Gold Gauntlets Color",   gauntletOptions, cosmeticDescriptions, OptionCategory::Cosmetic);
+  Option CustomTunicColors          = Option::Bool("Custom Tunic Colors",    {"Off", "On"},   {""},                 OptionCategory::Cosmetic);
+  Option ChildTunicColor            = Option::U8  ("  Child Tunic Color",    tunicOptions,    cosmeticDescriptions, OptionCategory::Cosmetic);
+  Option KokiriTunicColor           = Option::U8  ("  Kokiri Tunic Color",   tunicOptions,    cosmeticDescriptions, OptionCategory::Cosmetic);
+  Option GoronTunicColor            = Option::U8  ("  Goron Tunic Color",    tunicOptions,    cosmeticDescriptions, OptionCategory::Cosmetic);
+  Option ZoraTunicColor             = Option::U8  ("  Zora Tunic Color",     tunicOptions,    cosmeticDescriptions, OptionCategory::Cosmetic);
+  Option SilverGauntletsColor       = Option::U8  ("Silver Gauntlets Color", gauntletOptions, cosmeticDescriptions, OptionCategory::Cosmetic);
+  Option GoldGauntletsColor         = Option::U8  ("Gold Gauntlets Color",   gauntletOptions, cosmeticDescriptions, OptionCategory::Cosmetic);
+  std::string finalChildTunicColor      = ChildTunicColor.GetSelectedOptionText();
   std::string finalKokiriTunicColor     = KokiriTunicColor.GetSelectedOptionText();
   std::string finalGoronTunicColor      = GoronTunicColor.GetSelectedOptionText();
   std::string finalZoraTunicColor       = ZoraTunicColor.GetSelectedOptionText();
@@ -566,6 +569,8 @@ namespace Settings {
   Option MirrorWorld = Option::Bool("Mirror World",         {"Off", "On"},   {mirrorWorldDesc}, OptionCategory::Cosmetic);
 
   std::vector<Option *> cosmeticOptions = {
+    &CustomTunicColors,
+    &ChildTunicColor,
     &KokiriTunicColor,
     &GoronTunicColor,
     &ZoraTunicColor,
@@ -707,6 +712,7 @@ namespace Settings {
     ctx.itemPoolValue        = ItemPoolValue.Value<u8>();
     ctx.iceTrapValue         = IceTrapValue.Value<u8>();
 
+    ctx.customTunicColors    = (CustomTunicColors) ? 1 : 0;
     ctx.mirrorWorld          = (MirrorWorld) ? 1 : 0;
     ctx.coloredKeys          = (ColoredKeys) ? 1 : 0;
 
@@ -814,6 +820,7 @@ namespace Settings {
   static void SetDefaultCosmetics() {
     SilverGauntletsColor.SetSelectedIndex(3); //Silver
     GoldGauntletsColor.SetSelectedIndex(4);   //Gold
+    ChildTunicColor.SetSelectedIndex(3);      //Kokiri Green
     KokiriTunicColor.SetSelectedIndex(3);     //Kokiri Green
     GoronTunicColor.SetSelectedIndex(4);      //Goron Red
     ZoraTunicColor.SetSelectedIndex(5);       //Zora Blue
@@ -1191,6 +1198,19 @@ namespace Settings {
       }
     }
 
+    //Tunic Colors
+    if (CustomTunicColors) {
+      ChildTunicColor.Unhide();
+      KokiriTunicColor.Unhide();
+      GoronTunicColor.Unhide();
+      ZoraTunicColor.Unhide();
+    } else {
+      ChildTunicColor.Hide();
+      KokiriTunicColor.Hide();
+      GoronTunicColor.Hide();
+      ZoraTunicColor.Hide();
+    }
+
     ResolveExcludedLocationConflicts();
   }
 
@@ -1295,57 +1315,88 @@ namespace Settings {
   bool ShuffleInteriorEntrances         = false;
   bool ShuffleSpecialIndoorEntrances    = false;
 
+  template <typename colorsArray>
+  static void ChooseFinalColor(const Option& cosmeticOption, std::string& colorStr, const colorsArray& colors) {
+    if (cosmeticOption.Is(CUSTOM_COLOR)) {
+      colorStr = GetCustomColor(cosmeticOption.GetSelectedOptionText());
+    } else if (cosmeticOption.Is(RANDOM_CHOICE)) {
+      colorStr = colors[rand() % colors.size()]; //use default rand to not interfere with seed
+    } else if (cosmeticOption.Is(RANDOM_COLOR)) {
+      colorStr = RandomColor();
+    } else {
+      colorStr = colors[cosmeticOption.GetSelectedOptionIndex() - NON_COLOR_COUNT];
+    }
+  }
+
   //Function to update cosmetics options depending on choices
   static void UpdateCosmetics() {
-    if (KokiriTunicColor.Is(CUSTOM_COLOR)) {
-      finalKokiriTunicColor = GetCustomColor(KokiriTunicColor.GetSelectedOptionText());
-    } else if (KokiriTunicColor.Is(RANDOM_CHOICE)) {
-      finalKokiriTunicColor = tunicColors[rand() % tunicColors.size()]; //use default rand to not interfere with seed
-    } else if (KokiriTunicColor.Is(RANDOM_COLOR)) {
-      finalKokiriTunicColor = RandomColor();
-    } else {
-      finalKokiriTunicColor = tunicColors[KokiriTunicColor.GetSelectedOptionIndex() - NON_COLOR_COUNT];
-    }
 
-    if (GoronTunicColor.Is(CUSTOM_COLOR)) {
-      finalGoronTunicColor = GetCustomColor(GoronTunicColor.GetSelectedOptionText());
-    } else if (GoronTunicColor.Is(RANDOM_CHOICE)) {
-      finalGoronTunicColor = tunicColors[rand() % tunicColors.size()]; //use default rand to not interfere with seed
-    } else if (GoronTunicColor.Is(RANDOM_COLOR)) {
-      finalGoronTunicColor = RandomColor();
-    } else {
-      finalGoronTunicColor = tunicColors[GoronTunicColor.GetSelectedOptionIndex() - NON_COLOR_COUNT];
-    }
+    ChooseFinalColor(ChildTunicColor, finalChildTunicColor, tunicColors);
+    ChooseFinalColor(KokiriTunicColor, finalKokiriTunicColor, tunicColors);
+    ChooseFinalColor(GoronTunicColor, finalGoronTunicColor, tunicColors);
+    ChooseFinalColor(ZoraTunicColor, finalZoraTunicColor, tunicColors);
+    ChooseFinalColor(SilverGauntletsColor, finalSilverGauntletsColor, gauntletColors);
+    ChooseFinalColor(GoldGauntletsColor, finalGoldGauntletsColor, gauntletColors);
 
-    if (ZoraTunicColor.Is(CUSTOM_COLOR)) {
-      finalZoraTunicColor = GetCustomColor(ZoraTunicColor.GetSelectedOptionText());
-    } else if (ZoraTunicColor.Is(RANDOM_CHOICE)) {
-      finalZoraTunicColor = tunicColors[rand() % tunicColors.size()]; //use default rand to not interfere with seed
-    } else if (ZoraTunicColor.Is(RANDOM_COLOR)) {
-      finalZoraTunicColor = RandomColor();
-    } else {
-      finalZoraTunicColor = tunicColors[ZoraTunicColor.GetSelectedOptionIndex() - NON_COLOR_COUNT];
-    }
-
-    if (SilverGauntletsColor.Is(CUSTOM_COLOR)) {
-      finalSilverGauntletsColor = GetCustomColor(SilverGauntletsColor.GetSelectedOptionText());
-    } else if (SilverGauntletsColor.Is(RANDOM_CHOICE)) {
-      finalSilverGauntletsColor = gauntletColors[rand() % gauntletColors.size()]; //use default rand to not interfere with seed
-    } else if (SilverGauntletsColor.Is(RANDOM_COLOR)) {
-      finalSilverGauntletsColor = RandomColor();
-    } else {
-      finalSilverGauntletsColor = gauntletColors[SilverGauntletsColor.GetSelectedOptionIndex() - NON_COLOR_COUNT];
-    }
-
-    if (GoldGauntletsColor.Is(CUSTOM_COLOR)) {
-      finalGoldGauntletsColor = GetCustomColor(GoldGauntletsColor.GetSelectedOptionText());
-    } else if (GoldGauntletsColor.Is(RANDOM_CHOICE)) {
-      finalGoldGauntletsColor = gauntletColors[rand() % gauntletColors.size()]; //use default rand to not interfere with seed
-    } else if (GoldGauntletsColor.Is(RANDOM_COLOR)) {
-      finalGoldGauntletsColor = RandomColor();
-    } else {
-      finalGoldGauntletsColor = gauntletColors[GoldGauntletsColor.GetSelectedOptionIndex() - NON_COLOR_COUNT];
-    }
+    // if (KokiriTunicColor.Is(CUSTOM_COLOR)) {
+    //   finalKokiriTunicColor = GetCustomColor(KokiriTunicColor.GetSelectedOptionText());
+    // } else if (KokiriTunicColor.Is(RANDOM_CHOICE)) {
+    //   finalKokiriTunicColor = tunicColors[rand() % tunicColors.size()]; //use default rand to not interfere with seed
+    // } else if (KokiriTunicColor.Is(RANDOM_COLOR)) {
+    //   finalKokiriTunicColor = RandomColor();
+    // } else {
+    //   finalKokiriTunicColor = tunicColors[KokiriTunicColor.GetSelectedOptionIndex() - NON_COLOR_COUNT];
+    // }
+    //
+    // if (KokiriTunicColor.Is(CUSTOM_COLOR)) {
+    //   finalKokiriTunicColor = GetCustomColor(KokiriTunicColor.GetSelectedOptionText());
+    // } else if (KokiriTunicColor.Is(RANDOM_CHOICE)) {
+    //   finalKokiriTunicColor = tunicColors[rand() % tunicColors.size()]; //use default rand to not interfere with seed
+    // } else if (KokiriTunicColor.Is(RANDOM_COLOR)) {
+    //   finalKokiriTunicColor = RandomColor();
+    // } else {
+    //   finalKokiriTunicColor = tunicColors[KokiriTunicColor.GetSelectedOptionIndex() - NON_COLOR_COUNT];
+    // }
+    //
+    // if (GoronTunicColor.Is(CUSTOM_COLOR)) {
+    //   finalGoronTunicColor = GetCustomColor(GoronTunicColor.GetSelectedOptionText());
+    // } else if (GoronTunicColor.Is(RANDOM_CHOICE)) {
+    //   finalGoronTunicColor = tunicColors[rand() % tunicColors.size()]; //use default rand to not interfere with seed
+    // } else if (GoronTunicColor.Is(RANDOM_COLOR)) {
+    //   finalGoronTunicColor = RandomColor();
+    // } else {
+    //   finalGoronTunicColor = tunicColors[GoronTunicColor.GetSelectedOptionIndex() - NON_COLOR_COUNT];
+    // }
+    //
+    // if (ZoraTunicColor.Is(CUSTOM_COLOR)) {
+    //   finalZoraTunicColor = GetCustomColor(ZoraTunicColor.GetSelectedOptionText());
+    // } else if (ZoraTunicColor.Is(RANDOM_CHOICE)) {
+    //   finalZoraTunicColor = tunicColors[rand() % tunicColors.size()]; //use default rand to not interfere with seed
+    // } else if (ZoraTunicColor.Is(RANDOM_COLOR)) {
+    //   finalZoraTunicColor = RandomColor();
+    // } else {
+    //   finalZoraTunicColor = tunicColors[ZoraTunicColor.GetSelectedOptionIndex() - NON_COLOR_COUNT];
+    // }
+    //
+    // if (SilverGauntletsColor.Is(CUSTOM_COLOR)) {
+    //   finalSilverGauntletsColor = GetCustomColor(SilverGauntletsColor.GetSelectedOptionText());
+    // } else if (SilverGauntletsColor.Is(RANDOM_CHOICE)) {
+    //   finalSilverGauntletsColor = gauntletColors[rand() % gauntletColors.size()]; //use default rand to not interfere with seed
+    // } else if (SilverGauntletsColor.Is(RANDOM_COLOR)) {
+    //   finalSilverGauntletsColor = RandomColor();
+    // } else {
+    //   finalSilverGauntletsColor = gauntletColors[SilverGauntletsColor.GetSelectedOptionIndex() - NON_COLOR_COUNT];
+    // }
+    //
+    // if (GoldGauntletsColor.Is(CUSTOM_COLOR)) {
+    //   finalGoldGauntletsColor = GetCustomColor(GoldGauntletsColor.GetSelectedOptionText());
+    // } else if (GoldGauntletsColor.Is(RANDOM_CHOICE)) {
+    //   finalGoldGauntletsColor = gauntletColors[rand() % gauntletColors.size()]; //use default rand to not interfere with seed
+    // } else if (GoldGauntletsColor.Is(RANDOM_COLOR)) {
+    //   finalGoldGauntletsColor = RandomColor();
+    // } else {
+    //   finalGoldGauntletsColor = gauntletColors[GoldGauntletsColor.GetSelectedOptionIndex() - NON_COLOR_COUNT];
+    // }
   }
 
   //Function to set flags depending on settings

--- a/source/settings.hpp
+++ b/source/settings.hpp
@@ -461,11 +461,14 @@ namespace Settings {
   extern Option LogicLensCastleMQ;
   extern Option LogicSpiritTrialHookshot;
 
+  extern Option CustomTunicColors;
+  extern Option ChildTunicColor;
   extern Option KokiriTunicColor;
   extern Option GoronTunicColor;
   extern Option ZoraTunicColor;
   extern Option SilverGauntletsColor;
   extern Option GoldGauntletsColor;
+  extern std::string finalChildTunicColor;
   extern std::string finalKokiriTunicColor;
   extern std::string finalGoronTunicColor;
   extern std::string finalZoraTunicColor;


### PR DESCRIPTION
Custom message data kept on growing in size each time a new playthrough was generated since the data from previous generations wasn't getting cleared. This fixes the bug where any new playthrough generations would crash on game boot.
- Added an extra setting for separate child tunic color
- Added customTunicColors variable to gSettingsContext for future use