### PR TITLE
Shopsanity: Fix issues with Goron Shop right side

### DIFF
--- a/code/oot.ld
+++ b/code/oot.ld
@@ -168,7 +168,7 @@ SECTIONS
 		*(.patch_PoeCollectorCheckPoints)
 	}
 
-	.patch_GoronShopPurchaseableCheck 0x1912EC : {
+	.patch_GoronShopPurchaseableCheck 0x19120C : {
 		*(.patch_GoronShopPurchaseableCheck)
 	}
 

--- a/code/oot.ld
+++ b/code/oot.ld
@@ -168,6 +168,10 @@ SECTIONS
 		*(.patch_PoeCollectorCheckPoints)
 	}
 
+	.patch_GoronShopPurchaseableCheck 0x1912EC : {
+		*(.patch_GoronShopPurchaseableCheck)
+	}
+
 	.patch_PlayerEditAndRetrieveCMB 0x191970 : {
 		*(.patch_PlayerEditAndRetrieveCMB)
 	}

--- a/code/src/patches.s
+++ b/code/src/patches.s
@@ -1164,7 +1164,7 @@ DecoratedChest_patch:
 .section .patch_GoronShopPurchaseableCheck
 .global GoronShopPurchaseableCheck_patch
 GoronShopPurchaseableCheck_patch:
-    b 0x19133C
+    nop
 
 .section .patch_PlayerEditAndRetrieveCMB
 .global PlayerEditAndRetrieveCMB_patch

--- a/code/src/patches.s
+++ b/code/src/patches.s
@@ -1161,6 +1161,11 @@ ReadGossipStoneHints_patch:
 DecoratedChest_patch:
     bl hook_DecoratedChest
 
+.section .patch_GoronShopPurchaseableCheck
+.global GoronShopPurchaseableCheck_patch
+GoronShopPurchaseableCheck_patch:
+    b 0x19133C
+
 .section .patch_PlayerEditAndRetrieveCMB
 .global PlayerEditAndRetrieveCMB_patch
 PlayerEditAndRetrieveCMB_patch:

--- a/code/src/shops.c
+++ b/code/src/shops.c
@@ -257,11 +257,11 @@ void ShopsanityItem_InitializeRegularShopItem(EnGirlA* item, GlobalContext* glob
                                    shopItemEntry->cmabIndex, shopItemEntry->cmabIndex2, 0xFF);
         item->getItemId = shopItemEntry->getItemId;
         item->canBuyFunc = shopItemEntry->canBuyFunc;
-        item->itemGiveFunc = shopItemEntry->itemGiveFunc;
-        item->buyEventFunc = shopItemEntry->buyEventFunc;
         if (item->getItemId == GI_TUNIC_GORON || item->getItemId == GI_TUNIC_ZORA) { //Override buyable functions for tunics
             item->canBuyFunc = ShopsanityItem_CanBuy;
         }
+        item->itemGiveFunc = shopItemEntry->itemGiveFunc;
+        item->buyEventFunc = shopItemEntry->buyEventFunc;
         item->basePrice = shopItemEntry->price;
         item->itemCount = shopItemEntry->count;
         item->actor.textId = shopItemEntry->itemDescTextId;

--- a/source/item_pool.cpp
+++ b/source/item_pool.cpp
@@ -14,7 +14,7 @@ using namespace Dungeon;
 
 std::vector<ItemKey> ItemPool = {};
 std::vector<ItemKey> PendingJunkPool = {};
-std::vector<u16> IceTrapModels = {};
+std::vector<u8> IceTrapModels = {};
 const std::array<ItemKey, 9> dungeonRewards = {
   KOKIRI_EMERALD,
   GORON_RUBY,

--- a/source/item_pool.hpp
+++ b/source/item_pool.hpp
@@ -16,4 +16,4 @@ void GenerateItemPool();
 void AddJunk();
 
 extern std::vector<ItemKey> ItemPool;
-extern std::vector<u16> IceTrapModels;
+extern std::vector<u8> IceTrapModels;

--- a/source/shops.cpp
+++ b/source/shops.cpp
@@ -16,7 +16,7 @@ std::vector<ItemAndPrice> NonShopItems = {};
 
 //Set vanilla shop item locations before potentially shuffling
 void PlaceVanillaShopItems() {
-  std::vector<ItemKey> VanillaShopItems = {
+  const std::vector<ItemKey> VanillaShopItems = {
     //Vanilla KF
     BUY_DEKU_SHIELD,
     BUY_DEKU_NUT_5,
@@ -242,7 +242,7 @@ int GetShopsanityReplaceAmount() {
   }
 }
 
-//A dictionary that maps a u16 to an array of 3 strings, which contain the easy, medium, and hard trick names respectively
+//A dictionary that maps a u8 to an array of 3 strings, which contain the easy, medium, and hard trick names respectively
 static std::map<u8, std::array<std::string, 3>> IceTrapNames = {
   {GI_SWORD_KOKIRI, {"Butter Knife", "Kokiri Knife", "Kokiri's Sword"}},
   {GI_SWORD_BGS, {"Goron's Not-Broken Sword", "Big Goron Sword", "Biggoron's Sword"}},


### PR DESCRIPTION
Adds a patch to completely circumvent the special treatment given to the items on the right side of the Goron City shop, which fixes both being unable to buy those items until finishing DC, some items crashing, and bottle items not going in the bottle.

Also read as: Firing the Goron shopkeeper and getting a new one