### PR TITLE
Moving COMMITNUM to the randomizer.hpp file

### DIFF
--- a/linux_build_rando.sh
+++ b/linux_build_rando.sh
@@ -3,8 +3,7 @@
 compile() {
   # If building manually just replace SHA with your own text.
   export commitHashShort=$(echo ${GITHUB_SHA::6})
-  sed -i "s/COMMITNUM/$commitHashShort/" ./source/menu.cpp
-  sed -i "s/COMMITNUM/$commitHashShort/" ./source/settings.cpp
+  sed -i "s/develop/${commitHashShort:-develop}/" ./source/randomizer.hpp
   make
   bannertoolexec makebanner -i ./banner.png -a ./audio.wav -o ./banner.bnr
   bannertoolexec makesmdh -s "Ocarina of Time 3D Randomizer" -l "A different Ocarina of Time experience" -p "Gamestabled & Gymnast86" -i icon.png -o ./icon.icn

--- a/source/menu.cpp
+++ b/source/menu.cpp
@@ -42,7 +42,7 @@ void PrintTopScreen() {
   consoleSelect(&topScreen);
   consoleClear();
   printf("\x1b[2;11H%sOcarina of Time 3D Randomizer%s", CYAN, RESET);
-  printf("\x1b[3;18H%s%s-COMMITNUM%s", CYAN, RANDOMIZER_VERSION, RESET);
+  printf("\x1b[3;18H%s%s-%s%s", CYAN, RANDOMIZER_VERSION, COMMIT_NUMBER, RESET);
   printf("\x1b[4;10HA/B/D-pad: Navigate Menu\n");
   printf("            Select: Exit to Homebrew Menu\n");
   printf("                 Y: New Random Seed\n");

--- a/source/randomizer.hpp
+++ b/source/randomizer.hpp
@@ -1,3 +1,4 @@
 #pragma once
 
 #define RANDOMIZER_VERSION "v1.1.1"
+#define COMMIT_NUMBER "develop"

--- a/source/settings.cpp
+++ b/source/settings.cpp
@@ -18,7 +18,7 @@ using namespace Trial;
 
 namespace Settings {
   std::string seed;
-  std::string version = RANDOMIZER_VERSION "-COMMITNUM";
+  std::string version = RANDOMIZER_VERSION "-" COMMIT_NUMBER;
   std::array<u8, 5> hashIconIndexes;
 
   //                                        Setting name,              Options,                                                                     Setting Descriptions (assigned in setting_descriptions.cpp)


### PR DESCRIPTION
This pull request moves the COMMITNUM placeholder as `COMMIT_NUMBER` to the `randomizer.hpp` file next to the `RANDOMIZER_VERSION`, to have it in one place for all. Changed `menu.cpp` and `settings.cpp` to use the new variable.

With this change, only the `randomizer.hpp` file has to be modified by the Github Action during build (done by `linux_build_rando.sh`), making it available everywhere without the need to modify more files in the future.

Additionally I changed the default value to "develop" when the project is not build in the Github Action, to more please the eye when locally testing the app.