### PR TITLE
XML Files: Disable Entity Processing For Better Readibility

### DIFF
--- a/source/preset.cpp
+++ b/source/preset.cpp
@@ -79,7 +79,7 @@ static std::string PresetPath(std::string_view presetName, OptionCategory catego
 bool SavePreset(std::string_view presetName, OptionCategory category) {
   using namespace tinyxml2;
 
-  XMLDocument preset = XMLDocument();
+  XMLDocument preset = XMLDocument(false);
 
   // Create and insert the XML declaration
   preset.InsertEndChild(preset.NewDeclaration());

--- a/source/spoiler_log.cpp
+++ b/source/spoiler_log.cpp
@@ -187,17 +187,11 @@ static void WriteLocation(
   node->SetText(location->GetPlacedItemName().GetEnglish().c_str());
 
   if (withPadding) {
-    constexpr int16_t LONGEST_NAME = 59; // The longest name of a location, with escaped XML entities.
+    constexpr int16_t LONGEST_NAME = 56; // The longest name of a location.
     constexpr int16_t PRICE_ATTRIBUTE = 12; // Length of a 3-digit price attribute.
-
-    // Map of XML entities and the additional characters they use when escaped.
-    const std::map<char, int> entities = {{'\'', 5}, {'"', 5}, {'&', 4}, {'<', 3}, {'>', 3}};
 
     // Insert a padding so we get a kind of table in the XML document.
     int16_t requiredPadding = LONGEST_NAME - location->GetName().length();
-    for (auto& [c, n] : entities) {
-      requiredPadding -= std::count(location->GetName().begin(), location->GetName().end(), c) * n;
-    }
     if (location->IsCategory(Category::cShop)) {
       // Shop items have short location names, but come with an additional price attribute.
       requiredPadding -= PRICE_ATTRIBUTE;
@@ -399,7 +393,7 @@ static void WriteAllLocations(tinyxml2::XMLDocument& spoilerLog) {
 bool SpoilerLog_Write() {
   WriteIngameSpoilerLog();
 
-  auto spoilerLog = tinyxml2::XMLDocument();
+  auto spoilerLog = tinyxml2::XMLDocument(false);
   spoilerLog.InsertEndChild(spoilerLog.NewDeclaration());
 
   auto rootNode = spoilerLog.NewElement("spoiler-log");
@@ -438,7 +432,7 @@ void PlacementLog_Clear() {
 }
 
 bool PlacementLog_Write() {
-  auto placementLog = tinyxml2::XMLDocument();
+  auto placementLog = tinyxml2::XMLDocument(false);
   placementLog.InsertEndChild(placementLog.NewDeclaration());
 
   auto rootNode = placementLog.NewElement("placement-log");


### PR DESCRIPTION
This pull request is a follow-up on #206 and disables the entity processing, effectively removing the `&apos;` from the preset and spoiler log files.

#### Additional notes:

* This change does not influence whether or not an actual preset file can be read: Both escaped and unescaped variants are recognized correctly, making this change backward compatible.
* Locations, items and settings etc. _should not use_ the `&` character in their name. While the tinyxml library can correctly handle unescaped `&` characters, the XML file itself is actually invalid (as per the XML standard), making other libraries possibly fail on reading the file correctly.
* Locations, items and settings etc. **must not use** the `<` and `"` characters in their name. They render the XML file syntactically invalid, making it impossible to be read. These characters can easily be avoided in names, so this should not be an actual problem.
* Sidenote: Using any of the characters named above in the placement log is actually fine, as CDATA disabled the need to escape characters. The only harmful sequence in the placement log is `]]>` (the CDATA ending tag).