### PR TITLE
Build Tool: Update Unistore Content

### DIFF
--- a/.github/workflows/create_nightly.yml
+++ b/.github/workflows/create_nightly.yml
@@ -97,7 +97,7 @@ jobs:
               },
               {
                 "info": {
-                  "title": "OoT3D Randomizer Niightly <NIGHTLY_1>",
+                  "title": "OoT3D Randomizer Nightly <NIGHTLY_1>",
                   "author": "OoT3DR Team",
                   "description": "A randomizer patch for OoT3D to be used with Luma for Nintendo 3DS",
                   "category": [
@@ -141,7 +141,7 @@ jobs:
               },
               {
                 "info": {
-                  "title": "OoT3D Randomizer Niightly <NIGHTLY_2>",
+                  "title": "OoT3D Randomizer Nightly <NIGHTLY_2>",
                   "author": "OoT3DR Team",
                   "description": "A randomizer patch for OoT3D to be used with Luma for Nintendo 3DS",
                   "category": [
@@ -185,7 +185,7 @@ jobs:
               },
               {
                 "info": {
-                  "title": "OoT3D Randomizer Niightly <NIGHTLY_3>",
+                  "title": "OoT3D Randomizer Nightly <NIGHTLY_3>",
                   "author": "OoT3DR Team",
                   "description": "A randomizer patch for OoT3D to be used with Luma for Nintendo 3DS",
                   "category": [
@@ -229,7 +229,7 @@ jobs:
               },
               {
                 "info": {
-                  "title": "OoT3D Randomizer Niightly <NIGHTLY_4>",
+                  "title": "OoT3D Randomizer Nightly <NIGHTLY_4>",
                   "author": "OoT3DR Team",
                   "description": "A randomizer patch for OoT3D to be used with Luma for Nintendo 3DS",
                   "category": [
@@ -273,7 +273,7 @@ jobs:
               },
               {
                 "info": {
-                  "title": "OoT3D Randomizer Niightly <NIGHTLY_5>",
+                  "title": "OoT3D Randomizer Nightly <NIGHTLY_5>",
                   "author": "OoT3DR Team",
                   "description": "A randomizer patch for OoT3D to be used with Luma for Nintendo 3DS",
                   "category": [

--- a/.github/workflows/create_nightly.yml
+++ b/.github/workflows/create_nightly.yml
@@ -53,7 +53,7 @@ jobs:
             "storeContent": [
               {
                 "info": {
-                  "title": "OoT3D Randomizer Current Version",
+                  "title": "OoT3D Randomizer <VERSION_STABLE>",
                   "author": "OoT3DR Team",
                   "description": "A randomizer patch for OoT3D to be used with Luma for Nintendo 3DS",
                   "category": [
@@ -97,7 +97,7 @@ jobs:
               },
               {
                 "info": {
-                  "title": "OoT3D Randomizer Current Version",
+                  "title": "OoT3D Randomizer Niightly <NIGHTLY_1>",
                   "author": "OoT3DR Team",
                   "description": "A randomizer patch for OoT3D to be used with Luma for Nintendo 3DS",
                   "category": [
@@ -106,7 +106,7 @@ jobs:
                   "console": [
                     "3DS"
                   ],
-                  "icon_index": 2,
+                  "icon_index": 1,
                   "sheet_index": 0,
                   "last_updated": "<NIGHTLY_1_CREATED> at <NIGHTLY_1_TIME> (UTC)",
                   "license": "MIT",
@@ -141,7 +141,7 @@ jobs:
               },
               {
                 "info": {
-                  "title": "OoT3D Randomizer Current Version",
+                  "title": "OoT3D Randomizer Niightly <NIGHTLY_2>",
                   "author": "OoT3DR Team",
                   "description": "A randomizer patch for OoT3D to be used with Luma for Nintendo 3DS",
                   "category": [
@@ -150,7 +150,7 @@ jobs:
                   "console": [
                     "3DS"
                   ],
-                  "icon_index": 2,
+                  "icon_index": 1,
                   "sheet_index": 0,
                   "last_updated": "<NIGHTLY_2_CREATED> at <NIGHTLY_2_TIME> (UTC)",
                   "license": "MIT",
@@ -185,7 +185,7 @@ jobs:
               },
               {
                 "info": {
-                  "title": "OoT3D Randomizer Current Version",
+                  "title": "OoT3D Randomizer Niightly <NIGHTLY_3>",
                   "author": "OoT3DR Team",
                   "description": "A randomizer patch for OoT3D to be used with Luma for Nintendo 3DS",
                   "category": [
@@ -194,7 +194,7 @@ jobs:
                   "console": [
                     "3DS"
                   ],
-                  "icon_index": 2,
+                  "icon_index": 1,
                   "sheet_index": 0,
                   "last_updated": "<NIGHTLY_3_CREATED> at <NIGHTLY_3_TIME> (UTC)",
                   "license": "MIT",
@@ -229,7 +229,7 @@ jobs:
               },
               {
                 "info": {
-                  "title": "OoT3D Randomizer Current Version",
+                  "title": "OoT3D Randomizer Niightly <NIGHTLY_4>",
                   "author": "OoT3DR Team",
                   "description": "A randomizer patch for OoT3D to be used with Luma for Nintendo 3DS",
                   "category": [
@@ -238,7 +238,7 @@ jobs:
                   "console": [
                     "3DS"
                   ],
-                  "icon_index": 2,
+                  "icon_index": 1,
                   "sheet_index": 0,
                   "last_updated": "<NIGHTLY_4_CREATED> at <NIGHTLY_4_TIME> (UTC)",
                   "license": "MIT",
@@ -273,7 +273,7 @@ jobs:
               },
               {
                 "info": {
-                  "title": "OoT3D Randomizer Current Version",
+                  "title": "OoT3D Randomizer Niightly <NIGHTLY_5>",
                   "author": "OoT3DR Team",
                   "description": "A randomizer patch for OoT3D to be used with Luma for Nintendo 3DS",
                   "category": [
@@ -282,7 +282,7 @@ jobs:
                   "console": [
                     "3DS"
                   ],
-                  "icon_index": 2,
+                  "icon_index": 1,
                   "sheet_index": 0,
                   "last_updated": "<NIGHTLY_5_CREATED> at <NIGHTLY_5_TIME> (UTC)",
                   "license": "MIT",


### PR DESCRIPTION
Change release and nightly titles to respective versions.

Update the icon index to reference dev builds instead of everything showing a regular full release icon.