### PR TITLE
Make random trap effects consistent within a seed

### DIFF
--- a/code/src/chest.c
+++ b/code/src/chest.c
@@ -147,11 +147,18 @@ u8 Chest_OverrideIceSmoke(Actor* thisx) {
 
     if (thisx != lastTrapChest && thisx->xzDistToPlayer < 50.0f) {
         lastTrapChest = thisx;
+
+        u32 salt = 0;
+        for (int i = 0; i < 4; i++) {
+            salt |= gSettingsContext.hashIndexes[i] << (i * 8);
+        }
+        u32 saltedHash = Hash(thisx->params ^ salt);
+
         u8 damageType = 0;
         if (gSettingsContext.randomTrapDmg == 1) { //basic
-            damageType = gRandInt % 6;
+            damageType = saltedHash % 6;
         } else if (gSettingsContext.randomTrapDmg == 2) { //advanced
-            damageType = gRandInt % 9;
+            damageType = saltedHash % 9;
         }
 
         if (damageType == 3) {
@@ -160,7 +167,7 @@ u8 Chest_OverrideIceSmoke(Actor* thisx) {
         PLAYER->getItemId = 0;
         PLAYER->stateFlags1 &= ~0x20000C00;
         PLAYER->actor.colChkInfo.damage = (gSettingsContext.mirrorWorld) ? 16 : 8;
-        if (damageType == 0 || ((damageType == 1 || damageType == 5) && gRandInt % 2)) { // For knockback
+        if (damageType == 0 || ((damageType == 1 || damageType == 5) && saltedHash % 2)) { // For knockback
             PLAYER->stateFlags1 |= 0x4000;                                               // Ledge Cancel
         }
         if (PLAYER->invincibilityTimer > 0) {
@@ -194,7 +201,7 @@ u8 Chest_OverrideIceSmoke(Actor* thisx) {
         }
         // Fire Trap
         else if(damageType == 8) {
-            FireDamage(&(PLAYER->actor), gGlobalContext, gRandInt % 2);
+            FireDamage(&(PLAYER->actor), gGlobalContext, saltedHash % 2);
             LinkDamage(gGlobalContext, PLAYER, 0, 0.0f, 0.0f, 0, 20);
             return 1;
         }

--- a/code/src/chest.c
+++ b/code/src/chest.c
@@ -147,18 +147,13 @@ u8 Chest_OverrideIceSmoke(Actor* thisx) {
 
     if (thisx != lastTrapChest && thisx->xzDistToPlayer < 50.0f) {
         lastTrapChest = thisx;
-
-        u32 salt = 0;
-        for (int i = 0; i < 4; i++) {
-            salt |= gSettingsContext.hashIndexes[i] << (i * 8);
-        }
-        u32 saltedHash = Hash(thisx->params ^ salt);
+        u32 pRandInt = Hash(thisx->params);
 
         u8 damageType = 0;
         if (gSettingsContext.randomTrapDmg == 1) { //basic
-            damageType = saltedHash % 6;
+            damageType = pRandInt % 6;
         } else if (gSettingsContext.randomTrapDmg == 2) { //advanced
-            damageType = saltedHash % 9;
+            damageType = pRandInt % 9;
         }
 
         if (damageType == 3) {
@@ -167,7 +162,7 @@ u8 Chest_OverrideIceSmoke(Actor* thisx) {
         PLAYER->getItemId = 0;
         PLAYER->stateFlags1 &= ~0x20000C00;
         PLAYER->actor.colChkInfo.damage = (gSettingsContext.mirrorWorld) ? 16 : 8;
-        if (damageType == 0 || ((damageType == 1 || damageType == 5) && saltedHash % 2)) { // For knockback
+        if (damageType == 0 || ((damageType == 1 || damageType == 5) && pRandInt % 2)) { // For knockback
             PLAYER->stateFlags1 |= 0x4000;                                               // Ledge Cancel
         }
         if (PLAYER->invincibilityTimer > 0) {
@@ -201,7 +196,7 @@ u8 Chest_OverrideIceSmoke(Actor* thisx) {
         }
         // Fire Trap
         else if(damageType == 8) {
-            FireDamage(&(PLAYER->actor), gGlobalContext, saltedHash % 2);
+            FireDamage(&(PLAYER->actor), gGlobalContext, pRandInt % 2);
             LinkDamage(gGlobalContext, PLAYER, 0, 0.0f, 0.0f, 0, 20);
             return 1;
         }

--- a/code/src/icetrap.c
+++ b/code/src/icetrap.c
@@ -24,13 +24,6 @@ u32 IceTrap_IsPending(void) {
 }
 
 void IceTrap_Push(u32 key) {
-    // TODO: Remove this once testing is finished
-    gSaveContext.ammo[SLOT_STICK]   = ((key >> 30) & 3) * 10 + ((key >> 27) & 7);
-    gSaveContext.ammo[SLOT_NUT]     = ((key >> 24) & 7) * 10 + ((key >> 21) & 7);
-    gSaveContext.ammo[SLOT_BOMB]    = ((key >> 18) & 7) * 10 + ((key >> 15) & 7);
-    gSaveContext.ammo[SLOT_BOMBCHU] = ((key >> 12) & 7) * 10 + ((key >>  9) & 7);
-    gSaveContext.rupees = ((key >> 6) & 7) * 100 + ((key >> 3) & 7) * 10 + (key & 7);
-
     source[pendingFreezes++] = key;
 }
 

--- a/code/src/icetrap.h
+++ b/code/src/icetrap.h
@@ -3,7 +3,7 @@
 
 #include "z3D/z3D.h"
 
-void IceTrap_Push(void);
+void IceTrap_Push(u32 key);
 void IceTrap_Give(void);
 u32 IceTrap_IsPending(void);
 void IceTrap_Update(void);

--- a/code/src/item_effect.c
+++ b/code/src/item_effect.c
@@ -106,7 +106,7 @@ void ItemEffect_GiveSong(SaveContext* saveCtx, s16 questBit, s16 arg2) {
 }
 
 void ItemEffect_IceTrap(SaveContext* saveCtx, s16 arg1, s16 arg2) {
-    IceTrap_Push(0); // TODO: Find a unique identifier for traps coming from this function, args seem to always be 0x7FFF and 0x8000
+    IceTrap_Push((u16)arg1 << 16 | (u16)arg2);
 }
 
 void ItemEffect_BeanPack(SaveContext* saveCtx, s16 arg1, s16 arg2) {

--- a/code/src/item_effect.c
+++ b/code/src/item_effect.c
@@ -106,7 +106,7 @@ void ItemEffect_GiveSong(SaveContext* saveCtx, s16 questBit, s16 arg2) {
 }
 
 void ItemEffect_IceTrap(SaveContext* saveCtx, s16 arg1, s16 arg2) {
-    IceTrap_Push();
+    IceTrap_Push(0); // TODO: Find a unique identifier for traps coming from this function, args seem to always be 0x7FFF and 0x8000
 }
 
 void ItemEffect_BeanPack(SaveContext* saveCtx, s16 arg1, s16 arg2) {

--- a/code/src/item_override.c
+++ b/code/src/item_override.c
@@ -199,7 +199,7 @@ static void ItemOverride_PopIceTrap(void) {
     ItemOverride_Key key = rPendingOverrideQueue[0].key;
     ItemOverride_Value value = rPendingOverrideQueue[0].value;
     if (value.itemId == 0x7C) {
-        IceTrap_Push();
+        IceTrap_Push(key.all);
         ItemOverride_PopPendingOverride();
         ItemOverride_AfterKeyReceived(key);
     }

--- a/code/src/item_override.c
+++ b/code/src/item_override.c
@@ -302,6 +302,9 @@ void ItemOverride_GetItem(Actor* fromActor, Player* player, s8 incomingItemId) {
             baseItemId = 0x7C;
         }
         fromActor->params = (fromActor->params & 0xF01F) | (baseItemId << 5);
+    } else if (override.value.itemId == 0x7C) {
+        rActiveItemRow->effectArg1 = override.key.all >> 16;
+        rActiveItemRow->effectArg2 = override.key.all & 0xFFFF;
     }
 
     player->getItemId = incomingNegative ? -baseItemId : baseItemId;
@@ -336,6 +339,10 @@ void ItemOverride_GetSkulltulaToken(Actor* tokenActor) {
 
     u16 resolvedItemId = ItemTable_ResolveUpgrades(itemId);
     ItemRow* itemRow = ItemTable_GetItemRow(resolvedItemId);
+    if (override.value.itemId == 0x7C) {
+        itemRow->effectArg1 = override.key.all >> 16;
+        itemRow->effectArg2 = override.key.all & 0xFFFF;
+    }
 
     ItemTable_CallEffect(itemRow);
 

--- a/code/src/settings.c
+++ b/code/src/settings.c
@@ -57,6 +57,18 @@ s32 Settings_ApplyDamageMultiplier(GlobalContext* globalCtx, s32 changeHealth) {
     return modifiedChangeHealth;
 }
 
+// From section 5 of https://www.cs.ubc.ca/~rbridson/docs/schechter-sca08-turbulence.pdf
+u32 Hash(u32 state) {
+    state ^= 0xDC3A653D;
+    state *= 0xE1C88647;
+    state ^= state >> 16;
+    state *= 0xE1C88647;
+    state ^= state >> 16;
+    state *= 0xE1C88647;
+
+    return state;
+}
+
   const char hashIconNames[32][25] = {
     "Deku Stick",
     "Deku Nut",

--- a/code/src/settings.c
+++ b/code/src/settings.c
@@ -59,6 +59,13 @@ s32 Settings_ApplyDamageMultiplier(GlobalContext* globalCtx, s32 changeHealth) {
 
 // From section 5 of https://www.cs.ubc.ca/~rbridson/docs/schechter-sca08-turbulence.pdf
 u32 Hash(u32 state) {
+    // Added salt based on the seed hash so traps in the same location in different seeds can have different effects
+    u32 salt = 0;
+    for (int i = 0; i < 5; i++) {
+        salt |= gSettingsContext.hashIndexes[i] << (i * 6);
+    }
+    state ^= salt;
+
     state ^= 0xDC3A653D;
     state *= 0xE1C88647;
     state ^= state >> 16;

--- a/code/src/settings.h
+++ b/code/src/settings.h
@@ -374,5 +374,6 @@ extern SettingsContext gSettingsContext;
 extern const char hashIconNames[32][25];
 
 s32 Settings_ApplyDamageMultiplier(GlobalContext*, s32);
+u32 Hash(u32 state);
 
 #endif


### PR DESCRIPTION
Since the different random trap types can take up different amounts of time and the randomisation was done using gRandInt the setting was unsuitable for races.
This replaces all uses of gRandInt for random traps with a hash function using override.key.all or thisx->params and the seed hash to produce pseudo-random numbers that are consistent when collecting the same ice trap location within a seed but suitably different between small changes of input.