### PR TITLE
Only show a dungeon's reward when it's compass is acquired

### DIFF
--- a/code/include/z3D/z3D.h
+++ b/code/include/z3D/z3D.h
@@ -93,7 +93,7 @@ typedef struct {
     /* 0x00B6 */ u16          equipment; //bits: swords 0-3, shields 4-6, tunics 8-10, boots 12-14
     /* 0x00B8 */ u32          upgrades; //bits: quiver 0-2, bombs 3-5, strength 6-8, dive 9-11, wallet 12-13, seeds 14-16, sticks 17-19, nuts 20-22
     /* 0x00BC */ u32          questItems; //bits: medallions 0-5, warp songs 6-11, songs 12-17, stones 18-20, shard 21, token 22, skull 23, heart pieces 24-31
-    /* 0x00C0 */ u8           dungeonItems[20];
+    /* 0x00C0 */ u8           dungeonItems[20]; //bits: boss key 0, compass 1, map 2
     /* 0x00D4 */ s8           dungeonKeys[19];
     /* 0x00E7 */ char         unk_E7[0x0001]; //in oot: defenseHearts. seems not here.
     /* 0x00E8 */ s16          gsTokens;

--- a/code/src/gfx.c
+++ b/code/src/gfx.c
@@ -64,9 +64,11 @@ static void Gfx_DrawDungeonItems(void) {
 }
 
 static void Gfx_DrawDungeonRewards(void) {
+    Draw_DrawFormattedString(10, 10, COLOR_TITLE, "Dungeon Rewards:");
     for (u32 dungeonId = 0; dungeonId <= DUNGEON_SHADOW_TEMPLE; ++dungeonId) {
-        Draw_DrawFormattedString(10, 10 + (dungeonId * SPACING_Y), COLOR_WHITE, "%-30s - %s", DungeonNames[dungeonId], DungeonReward_GetName(dungeonId));
+        Draw_DrawFormattedString(10, 10 + SPACING_Y + (dungeonId * SPACING_Y), COLOR_WHITE, "%-30s - %s", DungeonNames[dungeonId], gSaveContext.dungeonItems[dungeonId] & (1 << 1) ? DungeonReward_GetName(dungeonId) : "???");
     }
+    Draw_DrawFormattedString(10, 10 + (SPACING_Y * 10), COLOR_WHITE, "Find the dungeon's compass to reveal it's reward!");
     Gfx_DrawChangeMenuPrompt();
     Draw_FlushFramebuffer();
 }


### PR DESCRIPTION
~~**Based on #245, merge/close that first**~~

![image](https://user-images.githubusercontent.com/5352197/124041605-7a838d00-da07-11eb-8960-334d490cb8fb.png)
In OoTR this is an option, but I think it's good to keep the options low when possible and, again, I'm guessing that most are fine with this always enabled.

I also added that extra message, but maybe that's too much?