### PR TITLE
Always allow upgrade scrub locations to be excluded

### DIFF
--- a/source/category.hpp
+++ b/source/category.hpp
@@ -1,6 +1,7 @@
 #pragma once
 
 enum class Category {
+    cNull,
     cKokiriForest,
     cForest,
     cGrotto,

--- a/source/item_location.cpp
+++ b/source/item_location.cpp
@@ -1459,10 +1459,10 @@ void PlaceItemInLocation(LocationKey locKey, ItemKey item, bool applyEffectImmed
   loc->SetPlacedItem(item);
 }
 
-std::vector<LocationKey> GetLocations(const std::vector<LocationKey>& locationPool, Category category) {
+std::vector<LocationKey> GetLocations(const std::vector<LocationKey>& locationPool, Category categoryInclude, Category categoryExclude /*= Category::cNull*/) {
   std::vector<LocationKey> locationsInCategory;
   for (LocationKey locKey : locationPool) {
-    if (Location(locKey)->IsCategory(category)) {
+    if (Location(locKey)->IsCategory(categoryInclude) && !Location(locKey)->IsCategory(categoryExclude)) {
       locationsInCategory.push_back(locKey);
     }
   }

--- a/source/item_location.hpp
+++ b/source/item_location.hpp
@@ -388,7 +388,7 @@ extern u16 itemsPlaced;
 
 void GenerateLocationPool();
 void PlaceItemInLocation(LocationKey loc, ItemKey item, bool applyEffectImmediately = false);
-std::vector<LocationKey> GetLocations(const std::vector<LocationKey>& locationPool, Category category);
+std::vector<LocationKey> GetLocations(const std::vector<LocationKey>& locationPool, Category categoryInclude, Category categoryExclude = Category::cNull);
 void LocationReset();
 void ItemReset();
 void HintReset();

--- a/source/settings.cpp
+++ b/source/settings.cpp
@@ -940,7 +940,7 @@ namespace Settings {
     }
 
     //Force Include scrubs if Scrubsanity is Off
-    std::vector<LocationKey> scrubLocations = GetLocations(everyPossibleLocation, Category::cDekuScrub);
+    std::vector<LocationKey> scrubLocations = GetLocations(everyPossibleLocation, Category::cDekuScrub, Category::cDekuScrubUpgrades);
     if (Scrubsanity.Is(OFF)) {
       IncludeAndHide(scrubLocations);
     } else {


### PR DESCRIPTION
Now players have the option to completely ignore all scrubs if they want.