### PR TITLE
Strip & from hints in the XML spoiler log

### DIFF
--- a/source/spoiler_log.cpp
+++ b/source/spoiler_log.cpp
@@ -426,7 +426,11 @@ static void WriteHints(tinyxml2::XMLDocument& spoilerLog) {
 
     auto node = parentNode->InsertNewChildElement("hint");
     node->SetAttribute("location", location->GetName().c_str());
-    node->SetText(location->GetPlacedItemName().GetEnglish().c_str());
+
+    auto text = location->GetPlacedItemName().GetEnglish();
+    std::replace(text.begin(), text.end(), '&', ' ');
+    std::replace(text.begin(), text.end(), '^', ' ');
+    node->SetText(text.c_str());
   }
 
   spoilerLog.RootElement()->InsertEndChild(parentNode);


### PR DESCRIPTION
This pull request removes the `&` (line break for the ingame text box) character from the hint texts (replacing it with a space) for the XML spoiler log, as the unescaped & breaks the XML document. 

Additionally, I replaced the `^` (box break) with a space as well for better readability.

