### PR TITLE
Add percent counter in item tracker, check got magic container

### DIFF
--- a/code/src/gfx.c
+++ b/code/src/gfx.c
@@ -137,7 +137,7 @@ static void Gfx_DrawSpoilerAllItems(void) {
         Draw_DrawFormattedString(10, 10, COLOR_TITLE, "All Item Locations (%d - %d) / %d",
             firstItem, lastItem, gSpoilerData.ItemLocationsCount);
         if (!gSettingsContext.ingameSpoilers) {
-            Draw_DrawFormattedString(SCREEN_BOT_WIDTH - 10 - (SPACING_X * 6), 10, itemPercent == 100 ? COLOR_GREEN : COLOR_WHITE, "%.1f%%", itemPercent);
+            Draw_DrawFormattedString(SCREEN_BOT_WIDTH - 10 - (SPACING_X * 6), 10, itemPercent == 100 ? COLOR_GREEN : COLOR_WHITE, "%5.1f%%", itemPercent);
         }
 
         for (u32 item = 0; item < MAX_ITEM_LINES; ++item) {
@@ -180,13 +180,15 @@ static s16 Gfx_Scroll(s16 current, s16 scrollDelta, u16 itemCount) {
 static void Gfx_ShowMenu(void) {
     u32 pressed = 0;
 
-    float itemsChecked = 0;
-    for (u16 i = 0; i < gSpoilerData.ItemLocationsCount; i++) {
-        if (SpoilerData_GetIsItemLocationCollected(i)) {
-            itemsChecked++;
+    if (!gSettingsContext.ingameSpoilers) {
+        float itemsChecked = 0;
+        for (u16 i = 0; i < gSpoilerData.ItemLocationsCount; i++) {
+            if (SpoilerData_GetIsItemLocationCollected(i)) {
+                itemsChecked++;
+            }
         }
+        itemPercent = (itemsChecked / gSpoilerData.ItemLocationsCount) * 100;
     }
-    itemPercent = (itemsChecked / gSpoilerData.ItemLocationsCount) * 100;
 
     Draw_ClearFramebuffer();
     Draw_FlushFramebuffer();

--- a/code/src/gfx.c
+++ b/code/src/gfx.c
@@ -17,6 +17,7 @@ static u8 currentSphere = 0;
 static s16 spoilerScroll = 0;
 static s16 allItemsScroll = 0;
 static s32 curMenuIdx = 0;
+static float itemPercent = 0;
 
 #define UP_ARROW_CHR 24
 #define DOWN_ARROW_CHR 25
@@ -135,6 +136,9 @@ static void Gfx_DrawSpoilerAllItems(void) {
         if (lastItem > gSpoilerData.ItemLocationsCount) { lastItem = gSpoilerData.ItemLocationsCount; }
         Draw_DrawFormattedString(10, 10, COLOR_TITLE, "All Item Locations (%d - %d) / %d",
             firstItem, lastItem, gSpoilerData.ItemLocationsCount);
+        if (!gSettingsContext.ingameSpoilers) {
+            Draw_DrawFormattedString(SCREEN_BOT_WIDTH - 10 - (SPACING_X * 6), 10, itemPercent == 100 ? COLOR_GREEN : COLOR_WHITE, "%.1f%%", itemPercent);
+        }
 
         for (u32 item = 0; item < MAX_ITEM_LINES; ++item) {
             u32 locIndex = item + allItemsScroll;
@@ -175,6 +179,14 @@ static s16 Gfx_Scroll(s16 current, s16 scrollDelta, u16 itemCount) {
 
 static void Gfx_ShowMenu(void) {
     u32 pressed = 0;
+
+    float itemsChecked = 0;
+    for (u16 i = 0; i < gSpoilerData.ItemLocationsCount; i++) {
+        if (SpoilerData_GetIsItemLocationCollected(i)) {
+            itemsChecked++;
+        }
+    }
+    itemPercent = (itemsChecked / gSpoilerData.ItemLocationsCount) * 100;
 
     Draw_ClearFramebuffer();
     Draw_FlushFramebuffer();

--- a/code/src/savefile.c
+++ b/code/src/savefile.c
@@ -38,6 +38,7 @@ void SaveFile_Init() {
     gSaveContext.infTable   [0x0] |= 0x01;   //greeted by Saria
     gSaveContext.infTable  [0x11] |= 0x0400; //Met Darunia in Fire Temple
     gSaveContext.infTable  [0x14] |= 0x000E; //Ruto in Jabu can be escorted immediately
+    gSaveContext.infTable  [0x19] |= 0x0100; //Got Magic Container
     gSaveContext.eventChkInf[0x3] |= 0x0800; //began Nabooru Battle
     gSaveContext.eventChkInf[0x7] |= 0x01FF; //began boss battles
     gSaveContext.eventChkInf[0x9] |= 0x0010; //Spoke to Nabooru as child

--- a/source/spoiler_log.cpp
+++ b/source/spoiler_log.cpp
@@ -122,7 +122,7 @@ static void WriteIngameSpoilerLog() {
     // Exclude uncheckable/repeatable locations from ingame tracker
     if (!Settings::IngameSpoilers) {
         // General
-        if (loc->IsExcluded() || loc->GetPlacedItem().GetItemType() == ITEMTYPE_DROP) {
+        if (loc->IsExcluded() || loc->GetHintKey() == NONE) {
             continue;
         }
         // Shops

--- a/source/spoiler_log.cpp
+++ b/source/spoiler_log.cpp
@@ -148,6 +148,10 @@ static void WriteIngameSpoilerLog() {
         else if (Settings::ShuffleMerchants.Is(SHUFFLEMERCHANTS_OFF) && loc->IsCategory(Category::cMerchant)) {
             continue;
         }
+        // Gerudo Fortress
+        else if (Settings::GerudoFortress.Is(GERUDOFORTRESS_OPEN) && (loc->IsCategory(Category::cVanillaGFSmallKey) || loc->GetHintKey() == GF_GERUDO_TOKEN)) {
+            continue;
+        }
     }
 
     auto locName = loc->GetName();


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/5352197/125191821-af33e780-e244-11eb-8184-45cf654f9ff3.png)
Will turn green when all locations are checked, so skip checking Ganon.

Also skip the message you get when first picking up a magic refill.
