### PR TITLE
Exclude irrelevant carpenters from spoiler log when Gerudo Fortress is Fast

### DIFF
--- a/source/spoiler_log.cpp
+++ b/source/spoiler_log.cpp
@@ -149,7 +149,8 @@ static void WriteIngameSpoilerLog() {
             continue;
         }
         // Gerudo Fortress
-        else if (Settings::GerudoFortress.Is(GERUDOFORTRESS_OPEN) && (loc->IsCategory(Category::cVanillaGFSmallKey) || loc->GetHintKey() == GF_GERUDO_TOKEN)) {
+        else if ((Settings::GerudoFortress.Is(GERUDOFORTRESS_OPEN) && (loc->IsCategory(Category::cVanillaGFSmallKey) || loc->GetHintKey() == GF_GERUDO_TOKEN)) ||
+            (Settings::GerudoFortress.Is(GERUDOFORTRESS_FAST) && loc->IsCategory(Category::cVanillaGFSmallKey) && loc->GetHintKey() != GF_NORTH_F1_CARPENTER)) {
             continue;
         }
     }


### PR DESCRIPTION
I thought with Fast that the other carpenters would still be in the pool but since they always have Recovery Hearts, which effectively is junk, they can be excluded.

Sorry if it feels like I'm spamming these pull requests, but _now_ everything should be covered.
