### PR TITLE
Rehabilitate Mido

### DIFF
--- a/code/oot.ld
+++ b/code/oot.ld
@@ -108,7 +108,7 @@ SECTIONS
 		*(.patch_KingZoraCheckMovedFlag)
 	}
 
-	.patch_MidoCheckSpawn 0x16614C : {
+	.patch_MidoCheckSpawn 0x166154 : {
 		*(.patch_MidoCheckSpawn)
 	}
 

--- a/code/src/mido.c
+++ b/code/src/mido.c
@@ -3,40 +3,42 @@
 #include "settings.h"
 
 
-//Fixes it so that Mido only spawns in Kokiri forest while he's useful (i.e. until you show him sword and shield)
 //Done to fix vanilla weirdness where Mido despawns in forest after obtaining Zelda's letter
 u32 EnMd_ShouldSpawn(void) {
+    bool DekuTreeDead = (gSaveContext.eventChkInf[0] & 0x80); //"Obtained Kokiri Emerald & Deku Tree Dead"
+    bool ObtainedLetter = (gSaveContext.eventChkInf[4] & 0x1); //"Obtained Zelda's Letter"
     bool ShowedSword = (gSaveContext.eventChkInf[0] & 0x10); //"Showed Mido Sword & Shield"
+    //We want to make sure Mido stays outside until after showing him the sword
+    //To work like how vanilla does, he's also allowed to stay outside until you either get the letter or Deku Tree is dead
+    bool SpawnInForest = !(ShowedSword && (ObtainedLetter || DekuTreeDead));
     if (gGlobalContext->sceneNum == 0x55) { //Kokiri Forest, spawn if hasn't been showed sword and shield yet
-        if (!ShowedSword) {
+        if (SpawnInForest) {
             return 1;
         }
     }
 
     if (gGlobalContext->sceneNum == 0x28) { //Mido's house, spawn if not spawning in forest
-        if (ShowedSword && gSaveContext.linkAge == AGE_CHILD) {
+        if (!SpawnInForest && gSaveContext.linkAge == AGE_CHILD) {
             return 1;
         }
     }
 
-    if (gGlobalContext->sceneNum == 0x5B) { //Lost woods, spawn if not yet played Saria's
-        if(!EventCheck(0x0A)) {
-            return 1;
-        }
+    if (gGlobalContext->sceneNum == 0x5B) { //Lost woods, spawn always
+        return 1;
     }
 
     return 0;
 }
 
-//Fixes an issue where Mido prioritizes Mido telling you about the Deku tree's death over showing him sword and shield
+//Fixes an issue where Mido prioritizes telling you about the Deku tree's death over showing him sword and shield
 u16 EnMd_GetTextKokiriForest() {
 
     if (gSaveContext.eventChkInf[0] & 0x10) {
         return 0x1034;
     }
        //Has kokiri sword                         Has deku shield
-    if ((gSaveContext.equips.equipment & 0x1) && (gSaveContext.equips.equipment & 0x10)) { //Text to tell you you're cool for having a sword
-        return 0x1033;
+    if ((gSaveContext.equips.equipment & 0x1) && (gSaveContext.equips.equipment & 0x10)) {
+        return 0x1033; //Text to tell you you're cool for having a sword
     }
 
     if (gSaveContext.infTable[0] & 0x1000) {

--- a/code/src/settings.h
+++ b/code/src/settings.h
@@ -311,6 +311,7 @@ typedef struct {
   u8 bigPoeTargetCount;
   u8 numRequiredCuccos;
   u8 kingZoraSpeed;
+  u8 completeMaskQuest;
 
   u8 damageMultiplier;
   u8 startingTime;
@@ -321,7 +322,6 @@ typedef struct {
   u8 ingameSpoilers;
   u8 menuOpeningButton;
   u8 randomTrapDmg;
-  u8 completeMaskQuest;
 
   u8 faroresWindAnywhere;
   u8 stickAsAdult;

--- a/source/setting_descriptions.cpp
+++ b/source/setting_descriptions.cpp
@@ -518,6 +518,11 @@ string_view kingZoraSpeedVanilla      = "King Zora will move out of the way in 2
 string_view kingZoraSpeedRandom       = "King Zora will move out of the way in 1 to 128\n" //
                                         "shuffles, with lower numbers being more common";  //
 /*------------------------------                                                           //
+|      COMPLETE MASK QUEST     |                                                           //
+------------------------------*/                                                           //
+string_view completeMaskDesc          = "Once the happy mask shop is opened, all masks\n"  //
+                                        "will be available to be borrowed.";               //
+/*------------------------------                                                           //
 |     GOSSIP STONE HINTS       |                                                           //
 ------------------------------*/                                                           //
 string_view gossipStonesHintsDesc     = "Gossip Stones can be made to give hints about\n"  //
@@ -684,11 +689,6 @@ string_view basicTrapDmgDesc          = "All alternative traps will cause a smal
                                                                                            //
 string_view advancedTrapDmgDesc       = "Some chest traps will burn your Deku Shield or\n" //
                                         "cause a lot of damage (with one-hit protection)"; //
-/*------------------------------                                                           //
-|      COMPLETE MASK QUEST     |                                                           //
-------------------------------*/                                                           //
-string_view completeMaskDesc          = "Once the happy mask shop is opened, all masks\n"  //
-                                        "will be available to be borrowed.";               //
                                                                                            //--------------//
 /*------------------------------                                                                           //
 |  DETAILED LOGIC EXPLANATIONS |                                                                           //

--- a/source/settings.cpp
+++ b/source/settings.cpp
@@ -156,6 +156,7 @@ namespace Settings {
   Option BigPoeTargetCount   = Option::U8  ("Big Poe Target Count",   {"1", "2", "3", "4", "5", "6", "7", "8", "9", "10"},                    {bigPoeTargetCountDesc});
   Option NumRequiredCuccos   = Option::U8  ("Cuccos to return",       {"0", "1", "2", "3", "4", "5", "6", "7"},                               {numRequiredCuccosDesc});
   Option KingZoraSpeed       = Option::U8  ("King Zora Speed",        {"Fast", "Vanilla", "Random"},                                          {kingZoraSpeedFast, kingZoraSpeedVanilla, kingZoraSpeedRandom});
+  Option CompleteMaskQuest   = Option::Bool("Complete Mask Quest",    {"Off", "On"},                                                          {completeMaskDesc});
   std::vector<Option *> timesaverOptions = {
     &SkipChildStealth,
     &SkipTowerEscape,
@@ -167,6 +168,7 @@ namespace Settings {
     &BigPoeTargetCount,
     &NumRequiredCuccos,
     &KingZoraSpeed,
+    &CompleteMaskQuest,
   };
 
   //Misc Settings
@@ -182,7 +184,6 @@ namespace Settings {
   Option IngameSpoilers      = Option::Bool("Ingame Spoilers",        {"Hide", "Show"},                                                       {ingameSpoilersHideDesc, ingameSpoilersShowDesc });
   Option MenuOpeningButton   = Option::U8  ("Open Info Menu with",    {"Select","Start","D-Pad Up","D-Pad Down","D-Pad Right","D-Pad Left",}, {menuButtonDesc});
   Option RandomTrapDmg       = Option::U8  ("Random Trap Damage",     {"Off", "Basic", "Advanced"},                                           {randomTrapDmgDesc, basicTrapDmgDesc, advancedTrapDmgDesc});
-  Option CompleteMaskQuest   = Option::Bool("Complete Mask Quest",    {"Off", "On"},                                                          {completeMaskDesc});
   bool HasNightStart         = false;
   std::vector<Option *> miscOptions = {
     &GossipStoneHints,
@@ -197,7 +198,6 @@ namespace Settings {
     &IngameSpoilers,
     &MenuOpeningButton,
     &RandomTrapDmg,
-    &CompleteMaskQuest,
   };
 
   //Item Usability Settings
@@ -725,6 +725,7 @@ namespace Settings {
     ctx.bigPoeTargetCount    = BigPoeTargetCount.Value<u8>() + 1;
     ctx.numRequiredCuccos    = NumRequiredCuccos.Value<u8>();
     ctx.kingZoraSpeed        = KingZoraSpeed.Value<u8>();
+    ctx.completeMaskQuest    = CompleteMaskQuest ? 1 : 0;
 
     ctx.gossipStoneHints     = GossipStoneHints.Value<u8>();
     ctx.damageMultiplier     = DamageMultiplier.Value<u8>();
@@ -735,7 +736,6 @@ namespace Settings {
     ctx.ingameSpoilers       = (IngameSpoilers) ? 1 : 0;
     ctx.menuOpeningButton    = MenuOpeningButton.Value<u8>();
     ctx.randomTrapDmg        = RandomTrapDmg.Value<u8>();
-    ctx.completeMaskQuest    = CompleteMaskQuest ? 1 : 0;
 
     ctx.faroresWindAnywhere  = (FaroresWindAnywhere) ? 1 : 0;
     ctx.stickAsAdult         = (StickAsAdult) ? 1 : 0;

--- a/source/settings.hpp
+++ b/source/settings.hpp
@@ -303,6 +303,7 @@ namespace Settings {
   extern Option BigPoeTargetCount;
   extern Option NumRequiredCuccos;
   extern Option KingZoraSpeed;
+  extern Option CompleteMaskQuest;
 
   extern Option GossipStoneHints;
   extern Option ClearerHints;
@@ -317,7 +318,6 @@ namespace Settings {
   extern Option MenuOpeningButton;
   extern Option RandomTrapDmg;
   extern bool HasNightStart;
-  extern Option CompleteMaskQuest;
 
   extern Option StickAsAdult;
   extern Option BoomerangAsAdult;


### PR DESCRIPTION
Mido was sent to prison for a long time for his crimes against humanity. Surprisingly, Hylian prisons are more about rehabilitation than punishment. I believe he has truly come out of the experience as a changed man-child. No more blocking you when he shouldn't be, no more taking off guard duty when he needs to be on it, and no more destroying worlds. (But I swear to god if he has another trick up his sleeve I will just delete him from the game entirely, open forest and open woods will be the only options)

The crashes were being caused by my previous patch to check for his spawn overwriting 2 instructions which set up the save context, and future instructions the patch branched to expected the save context to be set up. It was fixed by just moving the patch forward 2 instructions.

This was also the cause of mysterious issues in my previous PRs where he was refusing to stay moved in both forest and woods after moving him. This allowed 2 things:
1. He now will stay outside in Forest, after showing him sword and shield, until the Deku Tree is dead or Zelda's letter is found, similarly to Vanilla. After being locked up for so long, he's earned some extra time to enjoy being outside.
2. It's no longer necessary to despawn him in Woods after playing Saria's for him. No need to yeet a well-behaved boy out of existence.

Oh also, Charade suggested that Complete Mask Quest should be moved into the Timesavers menu and he's 100% right so I threw that in here.