### PR TITLE
Increase size of trickNameTable to fit trap name of Progressive Goron Sword

### DIFF
--- a/source/shops.cpp
+++ b/source/shops.cpp
@@ -13,7 +13,7 @@ using namespace Settings;
 
 std::vector<ItemAndPrice> NonShopItems = {};
 
-static std::array<std::array<Text, 3>, 0xD4> trickNameTable; //Table of trick names for ice traps
+static std::array<std::array<Text, 3>, 0xD5> trickNameTable; //Table of trick names for ice traps
 bool initTrickNames = false; //Indicates if trick ice trap names have been initialized yet
 
 //Set vanilla shop item locations before potentially shuffling


### PR DESCRIPTION
I somehow missed this, sorry!

Latest nightly can crash when Shopsanity is enabled, and this was probably the cause as Progressive Goron Sword has item id 0xD4.
Tried making 10 seeds with Shopsanity set to 4 with this increased size and all succeeded.