### PR TITLE
Fixes an issue where reading a preset file may crash the app.

### DIFF
--- a/source/preset.cpp
+++ b/source/preset.cpp
@@ -162,22 +162,21 @@ bool LoadPreset(std::string_view presetName, OptionCategory category) {
       } else {
         // If the current setting and element don't match, then search
         // linearly from the beginning. This will get us back on track if the
-        // next setting and element line up with each other*/
+        // next setting and element line up with each other.
         curNode = rootNode->FirstChildElement();
-        bool settingFound = false;
         while (curNode != nullptr) {
           if (settingToFind == RemoveLineBreaks(curNode->Attribute("name"))) {
             setting->SetSelectedIndexByString(curNode->GetText());
             curNode = curNode->NextSiblingElement();
-            settingFound = true;
             break;
           }
           curNode = curNode->NextSiblingElement();
         }
-        //reset to the beginning if the setting wasn't found
-        if (!settingFound) {
-          curNode = rootNode->FirstChildElement();
-        }
+      }
+
+      // Reset to the beginning if we reached the end.
+      if (curNode == nullptr) {
+        curNode = rootNode->FirstChildElement();
       }
     }
   }


### PR DESCRIPTION
This pull request fixes an issue where reading a preset file crashes the app if we run out of setting nodes while searching for the correct one. This happened when a new setting was added to the app at the end of the list of settings.