### PR TITLE
Center menu titles, plus minor fixes

### DIFF
--- a/code/src/giants_knife.c
+++ b/code/src/giants_knife.c
@@ -1,5 +1,6 @@
 #include "z3D/z3D.h"
 #include "settings.h"
+#include "giants_knife.h"
 
 u16 GK_SetDurability(void) {
     switch (gSettingsContext.gkDurability) {

--- a/code/src/giants_knife.h
+++ b/code/src/giants_knife.h
@@ -1,0 +1,3 @@
+#include "z3D/z3D.h"
+
+u16 GK_SetDurability(void);

--- a/code/src/savefile.c
+++ b/code/src/savefile.c
@@ -1,6 +1,7 @@
 #include "z3D/z3D.h"
 #include "settings.h"
 #include "item_effect.h"
+#include "giants_knife.h"
 #include "savefile.h"
 #include "3ds/types.h"
 
@@ -393,11 +394,11 @@ void SaveFile_SetStartingInventory(void) {
         gSaveContext.childEquips.buttonItems[0] = ITEM_SWORD_KOKIRI;
     }
 
-    if (gSettingsContext.startingBiggoronSword == 2) {
+    if (gSettingsContext.startingBiggoronSword == STARTINGBGS_BIGGORON_SWORD) {
         gSaveContext.bgsFlag = 1;
         gSaveContext.bgsHitsLeft = 1;
     }
-    if (gSettingsContext.startingBiggoronSword == 1){
+    if (gSettingsContext.startingBiggoronSword == STARTINGBGS_GIANTS_KNIFE){
         gSaveContext.bgsFlag = 0;
         gSaveContext.bgsHitsLeft = GK_SetDurability();
     }

--- a/source/menu.cpp
+++ b/source/menu.cpp
@@ -291,7 +291,7 @@ void UpdateGenerateMenu(u32 kDown) {
 }
 
 void PrintMainMenu() {
-  printf("\x1b[0;%dHMain Settings Menu", (BOTTOM_WIDTH/2) - 9);
+  printf("\x1b[0;%dHMain Settings", 1+(BOTTOM_WIDTH-13)/2);
 
   for (u8 i = 0; i < MAX_MAINMENU_SETTINGS_ON_SCREEN; i++) {
     if (i >= Settings::mainMenu.size()) break;
@@ -340,7 +340,7 @@ void PrintOptionSubMenu() {
   }
 
   //print menu name
-  printf("\x1b[0;%dH%s", (BOTTOM_WIDTH/2) - (currentMenu->name.length()/2), currentMenu->name.c_str());
+  printf("\x1b[0;%dH%s", 1+(BOTTOM_WIDTH-currentMenu->name.length())/2, currentMenu->name.c_str());
 
   //keep count of hidden settings to not make blank spaces appear in the list
   hiddenSettings = 0;
@@ -375,7 +375,7 @@ void PrintOptionSubMenu() {
 }
 
 void PrintSubMenu() {
-  printf("\x1b[0;%dH%s Menu", (BOTTOM_WIDTH/2) - 9, currentMenu->name.c_str());
+  printf("\x1b[0;%dH%s", 1+(BOTTOM_WIDTH-currentMenu->name.length())/2, currentMenu->name.c_str());
 
   for (u8 i = 0; i < MAX_SUBMENU_SETTINGS_ON_SCREEN; i++) {
     if (i >= currentMenu->itemsList->size()) break;
@@ -400,9 +400,9 @@ void PrintPresetsMenu() {
   }
 
   if(currentMenu->mode == LOAD_PRESET) {
-    printf("\x1b[0;%dHSelect a Preset to Load", (BOTTOM_WIDTH/2) - 7);
+    printf("\x1b[0;%dHSelect a Preset to Load", 1+(BOTTOM_WIDTH-23)/2);
   } else if (currentMenu->mode == DELETE_PRESET) {
-    printf("\x1b[0;%dHSelect a Preset to Delete", (BOTTOM_WIDTH/2) - 7);
+    printf("\x1b[0;%dHSelect a Preset to Delete", 1+(BOTTOM_WIDTH-25)/2);
   }
 
   for (u8 i = 0; i < MAX_SUBMENU_SETTINGS_ON_SCREEN; i++) {
@@ -425,7 +425,7 @@ void PrintGenerateMenu() {
 
   consoleSelect(&bottomScreen);
 
-  printf("\x1b[3;%dHHow will you play?", (BOTTOM_WIDTH/2) - 8);
+  printf("\x1b[3;%dHHow will you play?", 1+(BOTTOM_WIDTH-18)/2);
   std::vector<std::string> playOptions = {"3ds Console", "Citra Emulator"};
 
   for (u8 i = 0; i < playOptions.size(); i++) {

--- a/source/settings.cpp
+++ b/source/settings.cpp
@@ -1534,8 +1534,8 @@ namespace Settings {
 
     // Open Settings
     if (RandomizeOpen) {
-      // Skip Logic and RandomizeOpen Options to ensure proper logic
-      for (size_t i = 2; i < openOptions.size(); i++) {
+      // Skip RandomizeOpen Option
+      for (size_t i = 1; i < openOptions.size(); i++) {
         //hide options
         openOptions[i]->Hide();
 
@@ -1548,7 +1548,7 @@ namespace Settings {
       RandomGanonsTrials.SetSelectedIndex(ON);
     }
     else {
-      for (size_t i = 2; i < openOptions.size(); i++) {
+      for (size_t i = 1; i < openOptions.size(); i++) {
         openOptions[i]->Unhide();
       }
     }


### PR DESCRIPTION
I also removed the " Menu" part of the menu title strings to keep all titles consistent.

Minor fixes:
- Include Open Forest in RandomizeOpen.
- Reuse the StartingBiggoronSwordSetting enums.
- Add giants_knife.h to silence build warnings.
