### PR TITLE
Fix Quick Text and Song Replays issues

### DIFF
--- a/code/oot.ld
+++ b/code/oot.ld
@@ -608,6 +608,10 @@ SECTIONS
 		*(.patch_BiggoronDayCheck)
 	}
 
+	.patch_TurboTextSignalNPC 0x3469F4 : {
+		*(.patch_TurboTextSignalNPC)
+	}
+
 	.patch_FairyReviveHealAmount 0x34AF48 : {
 		*(.patch_FairyReviveHealAmount)
 	}
@@ -964,8 +968,12 @@ SECTIONS
 		*(.patch_EnableFW)
 	}
 
-	.patch_TurboText 0x480928 : {
-		*(.patch_TurboText)
+	.patch_TurboTextAdvance 0x480928 : {
+		*(.patch_TurboTextAdvance)
+	}
+
+	.patch_TurboTextClose 0x488214 : {
+		*(.patch_TurboTextClose)
 	}
 
 	.patch_SwapFaroresWind 0x49186C : {

--- a/code/oot.ld
+++ b/code/oot.ld
@@ -384,6 +384,14 @@ SECTIONS
 		*(.patch_BombchuBowlingStaticReward)
 	}
 
+	.patch_SkipSongReplayForTimeBlocksOne 0x207FD8 : {
+		*(.patch_SkipSongReplayForTimeBlocksOne)
+	}
+
+	.patch_SkipSongReplayForTimeBlocksTwo 0x207FF8 : {
+		*(.patch_SkipSongReplayForTimeBlocksTwo)
+	}
+
 	.patch_ShopItemDontSetAnimSpeedOne 0x2101BC : {
 		*(.patch_ShopItemDontSetAnimSpeedOne)
 	}

--- a/code/src/hooks.s
+++ b/code/src/hooks.s
@@ -762,6 +762,32 @@ hook_TurboText:
     cmpeq r0,#0x0
     bx lr
 
+.global hook_SkipSongReplayForTimeBlocksOne
+hook_SkipSongReplayForTimeBlocksOne:
+    add r1,r1,#0x2B00
+    push {r0-r12, lr}
+    bl Settings_GetSongReplaysOption
+    cmp r0,#0x0
+    pop {r0-r12, lr}
+    beq 0x207FDC
+    push {r0,r1}
+    sub r1,r1,#0x70
+    ldrb r0,[r1]
+    cmp r0,#23
+    pop {r0,r1}
+    bne 0x208030
+    b 0x207FDC
+
+.global hook_SkipSongReplayForTimeBlocksTwo
+hook_SkipSongReplayForTimeBlocksTwo:
+    push {r0-r12, lr}
+    bl Settings_GetSongReplaysOption
+    cmp r0,#0x0
+    pop {r0-r12, lr}
+    bne 0x208028
+    add r0,r0,#0x100
+    b 0x207FFC
+
 .section .loader
 .global hook_into_loader
 hook_into_loader:

--- a/code/src/hooks.s
+++ b/code/src/hooks.s
@@ -753,13 +753,32 @@ hook_InstantTextRemoveOff:
     ldr r0,[r5,#0x0]
     b 0x2E06CC
 
-.global hook_TurboText
-hook_TurboText:
+.global hook_TurboTextAdvance
+hook_TurboTextAdvance:
     push {r0-r12, lr}
     bl Settings_IsTurboText
     cmp r0,#0x0
     pop {r0-r12, lr}
     cmpeq r0,#0x0
+    bx lr
+
+.global hook_TurboTextClose
+hook_TurboTextClose:
+    push {r0-r12, lr}
+    bl Settings_IsTurboText
+    cmp r0,#0x0
+    pop {r0-r12, lr}
+    cmpeq r0,#0x0
+    bx lr
+
+.global hook_TurboTextSignalNPC
+hook_TurboTextSignalNPC:
+    movne r4,#0x1
+    push {r0-r12, lr}
+    bl Settings_IsTurboText
+    cmp r0,#0x0
+    pop {r0-r12, lr}
+    movne r4,#0x1
     bx lr
 
 .global hook_SkipSongReplayForTimeBlocksOne

--- a/code/src/patches.s
+++ b/code/src/patches.s
@@ -1362,10 +1362,20 @@ InstantTextBoxBreak_patch:
 InstantTextRemoveOff_patch:
     b hook_InstantTextRemoveOff
 
-.section .patch_TurboText
-.global TurboText_patch
-TurboText_patch:
-    bl hook_TurboText
+.section .patch_TurboTextAdvance
+.global TurboTextAdvance_patch
+TurboTextAdvance_patch:
+    bl hook_TurboTextAdvance
+
+.section .patch_TurboTextClose
+.global TurboTextClose_patch
+TurboTextClose_patch:
+    bl hook_TurboTextClose
+
+.section .patch_TurboTextSignalNPC
+.global TurboTextSignalNPC_patch
+TurboTextSignalNPC_patch:
+    bl hook_TurboTextSignalNPC
 
 .section .patch_SkipSongReplayForTimeBlocksOne
 .global SkipSongReplayForTimeBlocksOne_patch

--- a/code/src/patches.s
+++ b/code/src/patches.s
@@ -1367,6 +1367,16 @@ InstantTextRemoveOff_patch:
 TurboText_patch:
     bl hook_TurboText
 
+.section .patch_SkipSongReplayForTimeBlocksOne
+.global SkipSongReplayForTimeBlocksOne_patch
+SkipSongReplayForTimeBlocksOne_patch:
+    b hook_SkipSongReplayForTimeBlocksOne
+
+.section .patch_SkipSongReplayForTimeBlocksTwo
+.global SkipSongReplayForTimeBlocksTwo_patch
+SkipSongReplayForTimeBlocksTwo_patch:
+    b hook_SkipSongReplayForTimeBlocksTwo
+
 .section .patch_loader
 .global loader_patch
 

--- a/code/src/settings.c
+++ b/code/src/settings.c
@@ -100,6 +100,10 @@ u32 Settings_GetQuickTextOption() {
     return gSettingsContext.quickText;
 }
 
+u32 Settings_GetSongReplaysOption() {
+    return gSettingsContext.skipSongReplays;
+}
+
 u32 Settings_IsTurboText() {
     return (gSettingsContext.quickText >= QUICKTEXT_TURBO && rInputCtx.cur.b);
 }

--- a/source/setting_descriptions.cpp
+++ b/source/setting_descriptions.cpp
@@ -530,8 +530,8 @@ string_view quickTextDesc1            = "Every text box will be completable by p
                                         "at any point while it's scrolling.";              //
 string_view quickTextDesc2            = "Every text box will auto-complete instantly.\n"   //
                                         "No scrolling allowed!";                           //
-string_view quickTextDesc3            = "Holding B will advance text boxes automatically\n"//
-                                        "(but it won't close them).";                      //
+string_view quickTextDesc3            = "Holding B will advance and close text boxes\n"    //
+                                        "automatically, except for choice selections.";    //
 /*------------------------------                                                           //
 |       SKIP SONG REPLAYS      |                                                           //
 ------------------------------*/                                                           //


### PR DESCRIPTION
- Turbo Text can now close every text box instead of only advancing them, so the last issue that was left unsolved in my previous PR is now fixed.
- Skipping song replays was preventing SoT Blocks from appearing/disappearing. This is also fixed now.

Notes on the assembly code:
- _patch_TurboTextClose_ and _patch_TurboTextSignalNPC_: same as Advance, the first patch is for actually closing the text, while the second one is needed so that NPCs stop their "talking to Link" action and set the collection flags if they gave him an item.
- _patch_SkipSongReplayForTimeBlocksOne_: the blocks only check for SoT when the msgMode is 23 (used to skip the replay), so that they don't read a stale value for the last song played.
- _patch_SkipSongReplayForTimeBlocksTwo_: after checking for SoT, the blocks immediately appear/disappear, without waiting for a non-existent ocarina state