### PR TITLE
Another attempt at making Medigoron sell the right item

### DIFF
--- a/code/oot.ld
+++ b/code/oot.ld
@@ -72,8 +72,8 @@ SECTIONS
 		*(.patch_OwlMagicCheck)
 	}
 
-	.patch_MedigoronItemOverride 0x14D95C : {
-		*(.patch_MedigoronItemOverride)
+	.patch_MedigoronItemOverrideOne 0x14D95C : {
+		*(.patch_MedigoronItemOverrideOne)
 	}
 
 	.patch_BeanDaddyPurchase 0x14EDA8 : {
@@ -130,6 +130,14 @@ SECTIONS
 
 	.patch_DampeCheckCollectibleFlag 0x169F88 : {
 		*(.patch_DampeCheckCollectibleFlag)
+	}
+
+	.patch_MedigoronSetRewardFlag 0x16C918 : {
+		*(.patch_MedigoronSetRewardFlag)
+	}
+
+	.patch_MedigoronItemOverrideTwo 0x16C9BC : {
+		*(.patch_MedigoronItemOverrideTwo)
 	}
 
 	.patch_KingZoraIgnoreSapphire 0x1736B8 : {

--- a/code/src/hooks.s
+++ b/code/src/hooks.s
@@ -646,13 +646,29 @@ hook_MedigoronCheckFlagTwo:
 childLink:
     b 0x1302F0
 
-.global hook_MedigoronItemOverride
-hook_MedigoronItemOverride:
+.global hook_MedigoronSetRewardFlag
+hook_MedigoronSetRewardFlag:
+    mvn r0,#0xc7
+    push {r0-r12, lr}
+    bl EnGm_SetRewardFlag
+    pop {r0-r12, lr}
+    b 0x16C91C
+
+.global hook_MedigoronItemOverrideOne
+hook_MedigoronItemOverrideOne:
     push {r0-r1, r3-r12, lr}
     bl EnGm_ItemOverride
     cpy r2,r0
     pop {r0-r1, r3-r12, lr}
     b 0x14D960
+
+.global hook_MedigoronItemOverrideTwo
+hook_MedigoronItemOverrideTwo:
+    push {r0-r1, r3-r12, lr}
+    bl EnGm_ItemOverride
+    cpy r2,r0
+    pop {r0-r1, r3-r12, lr}
+    b 0x16C9C0
 
 .global hook_MedigoronGetCustomText
 hook_MedigoronGetCustomText:

--- a/code/src/medigoron.c
+++ b/code/src/medigoron.c
@@ -5,7 +5,7 @@ s32 EnGm_CheckRewardFlag(void) {
     // 0: blt, skip equipment check
     // 1: beq, goto text id 304D, no item offer
     // 2: continue like normal
-    if ((gSettingsContext.shuffleMerchants != SHUFFLEMERCHANTS_OFF && (gSaveContext.eventChkInf[3] & 0x20) == 0)) {
+    if (gSettingsContext.shuffleMerchants != SHUFFLEMERCHANTS_OFF && (gSaveContext.eventChkInf[3] & 0x20) == 0) {
         return 0;
     }
     else if (gSettingsContext.progressiveGoronSword && ((gSaveContext.equipment >> 2) & 0x1) == 0) {
@@ -14,15 +14,18 @@ s32 EnGm_CheckRewardFlag(void) {
     return 2;
 }
 
+s32 EnGm_SetRewardFlag(void) {
+    gSaveContext.eventChkInf[3] |= 0x20;
+}
+
 s32 EnGm_UseCustomText(void) {
     return (gSettingsContext.shuffleMerchants == SHUFFLEMERCHANTS_HINTS && (gSaveContext.eventChkInf[3] & 0x20) == 0);
 }
 
 s32 EnGm_ItemOverride(void) {
-    if (!gSettingsContext.shuffleMerchants || gSaveContext.eventChkInf[3] & 0x20) {
+    if (gSettingsContext.shuffleMerchants == SHUFFLEMERCHANTS_OFF || gSaveContext.eventChkInf[3] & 0x20) {
         return GI_SWORD_KNIFE;
     } else {
-        gSaveContext.eventChkInf[3] |= 0x20;
         return GI_MASK_GORON;
     }
 }

--- a/code/src/patches.s
+++ b/code/src/patches.s
@@ -1317,16 +1317,26 @@ MedigoronCheckFlagOne_patch:
 MedigoronCheckFlagTwo_patch:
     b hook_MedigoronCheckFlagTwo
 
+.section .patch_MedigoronSetRewardFlag
+.global MedigoronSetRewardFlag_patch
+MedigoronSetRewardFlag_patch:
+    b hook_MedigoronSetRewardFlag
+
 .section .patch_MedigoronGetCustomText
 .global MedigoronGetCustomText_patch
 MedigoronGetCustomText_patch:
     b hook_MedigoronGetCustomText
     nop
 
-.section .patch_MedigoronItemOverride
-.global MedigoronItemOverride_patch
-MedigoronItemOverride_patch:
-    b hook_MedigoronItemOverride
+.section .patch_MedigoronItemOverrideOne
+.global MedigoronItemOverrideOne_patch
+MedigoronItemOverrideOne_patch:
+    b hook_MedigoronItemOverrideOne
+
+.section .patch_MedigoronItemOverrideTwo
+.global MedigoronItemOverrideTwo_patch
+MedigoronItemOverrideTwo_patch:
+    b hook_MedigoronItemOverrideTwo
 
 .section .patch_CarpetSalesmanCheckFlagOne
 .global CarpetSalesmanCheckFlagOne_patch


### PR DESCRIPTION
- Patch Medigoron's 2nd GiveItem
- Set the reward flag separately so it doesn't make the 2nd GiveItem a Giant's Knife when the first one fails

Please check so I got this right! I placed the SetRewardFlag where I thought the code would go _after_ the item has been given.
It seems like ice traps causes the 2nd GiveItem to be used, and buying those at least works now.
