### PR TITLE
All Locations Reachable toggle

### DIFF
--- a/source/fill.hpp
+++ b/source/fill.hpp
@@ -18,5 +18,4 @@ enum class SearchMode {
 void VanillaFill();
 int Fill();
 
-std::vector<LocationKey> GetAccessibleLocations(const std::vector<LocationKey>& allowedLocations,
-                                                  SearchMode mode = SearchMode::ReachabilitySearch);
+std::vector<LocationKey> GetAccessibleLocations(const std::vector<LocationKey>& allowedLocations, SearchMode mode = SearchMode::ReachabilitySearch);

--- a/source/hints.cpp
+++ b/source/hints.cpp
@@ -741,6 +741,12 @@ void CreateAllHints() {
     }
   }
 
+  //If any gossip stones failed to have a hint placed on them for some reason, place a junk hint as a failsafe.
+  for (LocationKey gossipStone : FilterFromPool(gossipStoneLocations, [](const LocationKey loc){return Location(loc)->GetPlacedItemKey() == NONE;})) {
+    const HintText junkHint = RandomElement(GetHintCategory(HintCategory::Junk));
+    AddHint(junkHint.GetText(), gossipStone, {QM_PINK});
+  }
+
   //Getting gossip stone locations temporarily sets one location to not be reachable.
   //Call the function one last time to get rid of false positives on locations not
   //being reachable.

--- a/source/setting_descriptions.cpp
+++ b/source/setting_descriptions.cpp
@@ -588,6 +588,14 @@ string_view damageMultiDesc           = "Changes the amount of damage taken.\n" 
 string_view startingTimeDesc          = "Change up Link's sleep routine.";                 //
                                                                                            //
 /*------------------------------                                                           //
+|   ALL LOCATIONS REACHABLE    |                                                           //
+------------------------------*/                                                           //
+string_view locationsReachableDesc    = "When this options is enabled, the randomizer will\n"
+                                        "guarantee that every item is obtainable and every\n"
+                                        "location is reachable. When disabled, only\n"     //
+                                        "required items and locations to beat the game\n"  //
+                                        "will be guaranteed reachable.";                   //
+/*------------------------------                                                           //
 |     NIGHT GS EXPECT SUNS     |                                                           //
 ------------------------------*/                                                           //
 string_view nightGSDesc               = "GS Tokens that can only be obtained during the\n" //

--- a/source/setting_descriptions.hpp
+++ b/source/setting_descriptions.hpp
@@ -199,6 +199,7 @@ extern string_view damageMultiDesc;
 
 extern string_view startingTimeDesc;
 
+extern string_view locationsReachableDesc;
 extern string_view nightGSDesc;
 
 extern string_view chestAnimDesc;

--- a/source/settings.cpp
+++ b/source/settings.cpp
@@ -406,10 +406,12 @@ namespace Settings {
     &StartingSkulltulaToken,
   };
 
-  Option Logic             = Option::U8  ("Logic",                  {"Glitchless", "No Logic", "Vanilla"}, {logicGlitchless, logicNoLogic, logicVanilla});
-  Option NightGSExpectSuns = Option::Bool("Night GSs Expect Sun's", {"Off", "On"},                         {nightGSDesc});
+  Option Logic              = Option::U8  ("Logic",                   {"Glitchless", "No Logic", "Vanilla"}, {logicGlitchless, logicNoLogic, logicVanilla});
+  Option LocationsReachable = Option::Bool("All Locations Reachable", {"Off", "On"},                         {locationsReachableDesc}); 
+  Option NightGSExpectSuns  = Option::Bool("Night GSs Expect Sun's",  {"Off", "On"},                         {nightGSDesc});
   std::vector<Option *> logicOptions = {
     &Logic,
+    &LocationsReachable,
     &NightGSExpectSuns,
   };
 
@@ -995,6 +997,8 @@ namespace Settings {
 
     ItemPoolValue.SetSelectedIndex(ITEMPOOL_BALANCED);
     IceTrapValue.SetSelectedIndex(ICETRAPS_NORMAL);
+
+    LocationsReachable.SetSelectedIndex(1); //All Locations Reachable On
 
     SetDefaultCosmetics();
   }

--- a/source/settings.hpp
+++ b/source/settings.hpp
@@ -402,6 +402,7 @@ namespace Settings {
 
   //Logic Settings
   extern Option Logic;
+  extern Option LocationsReachable;
   extern Option NightGSExpectSuns;
 
   //Trick Settings

--- a/source/spoiler_log.cpp
+++ b/source/spoiler_log.cpp
@@ -247,7 +247,9 @@ static void WriteLocation(
     node->SetAttribute("price", price);
   }
   if (!location->IsAddedToPool()) {
-    node->SetAttribute("not-added", true);
+    #ifdef ENABLE_DEBUG  
+      node->SetAttribute("not-added", true);
+    #endif
   }
 }
 


### PR DESCRIPTION
Finally using this branch for what I originally made it for before I got distracted with menu stuff.

Adds a new toggle which is left on by default, All Locations Reachable. If this toggle is disabled, then while a path to the end of the game will be guaranteed, not all locations will be guaranteed. This can create situations such as megaton hammer on volvagia, or zelda's lullaby on a great fairy location, if these items are not necessary to defeat Ganon.

The way this basically works is that, when the Assumed Fill algo is running, every time an item is placed the game is checked to be beatable. (Yes, this is slow.) If it is beatable, then the remaining major items are placed with Random Fill instead of Assumed Fill, so they will be placed without logic and can thus be placed in unobtainable locations.

Since this will lead to some locations being unreachable, the `not-added` property on a location in the spoiler was changed to be debug only. Previously this would only happen from an error, so it made sense to display it to the user.

Finally, a failsafe was added for gossip stones so that any gossip stones with no hint will get a junk hint placed on them, since ALR off can lead to some gossip stones being unreachable in logic. This inadvertently puts a bandaid on the issue of gossip stones mysteriously having no hints placed on them even with normal logic, but of course doesn't actually fix the underlying issue.