### PR TITLE
Get difficulty options from vector function to avoid accidental misnaming

### DIFF
--- a/source/entrance.hpp
+++ b/source/entrance.hpp
@@ -40,13 +40,13 @@ public:
     bool GetConditionsMet() const {
         if (Settings::Logic.Is(LOGIC_NONE) || Settings::Logic.Is(LOGIC_VANILLA)) {
             return true;
-        }
-        for (size_t i = 0; i <= Settings::Logic.Value<u8>(); i++) {
-            if (conditions_met[i] == NULL) {
-                continue;
-            }
-            if (conditions_met[i]()) {
+        } else if (Settings::Logic.Is(LOGIC_GLITCHLESS)) {
+            return conditions_met[0]();
+        } else if (Settings::Logic.Is(LOGIC_GLITCHED)) {
+            if (conditions_met[0]()) {
                 return true;
+            } else if (conditions_met[1] != NULL) {
+                return conditions_met[1]();
             }
         }
         return false;

--- a/source/location_access.hpp
+++ b/source/location_access.hpp
@@ -25,13 +25,13 @@ public:
     bool ConditionsMet() const {
         if (Settings::Logic.Is(LOGIC_NONE) || Settings::Logic.Is(LOGIC_VANILLA)) {
             return true;
-        }
-        for (size_t i = 0; i <= Settings::Logic.Value<u8>(); i++) {
-            if (conditions_met[i] == NULL) {
-                continue;
-            }
-            if (conditions_met[i]()) {
+        } else if (Settings::Logic.Is(LOGIC_GLITCHLESS)) {
+            return conditions_met[0]();
+        } else if (Settings::Logic.Is(LOGIC_GLITCHED)) {
+            if (conditions_met[0]()) {
                 return true;
+            } else if (conditions_met[1] != NULL) {
+                return conditions_met[1]();
             }
         }
         return false;
@@ -79,13 +79,13 @@ public:
     bool GetConditionsMet() const {
         if (Settings::Logic.Is(LOGIC_NONE) || Settings::Logic.Is(LOGIC_VANILLA)) {
             return true;
-        }
-        for (size_t i = 0; i <= Settings::Logic.Value<u8>(); i++) {
-            if (conditions_met[i] == NULL) {
-                continue;
-            }
-            if (conditions_met[i]()) {
+        } else if (Settings::Logic.Is(LOGIC_GLITCHLESS)) {
+            return conditions_met[0]();
+        } else if (Settings::Logic.Is(LOGIC_GLITCHED)) {
+            if (conditions_met[0]()) {
                 return true;
+            } else if (conditions_met[1] != NULL) {
+                return conditions_met[1]();
             }
         }
         return false;

--- a/source/settings.cpp
+++ b/source/settings.cpp
@@ -594,14 +594,29 @@ namespace Settings {
     &LogicSpiritTrialHookshot,
   };
 
-  Option GlitchISG = Option::U8("Infinite Sword Glitch", {"Disabled", "Novice"}, {GlitchISGDescDisabled, GlitchISGDescNovice});
-  Option GlitchHover = Option::U8("Bomb Hover", {"Disabled", "Novice", "Intermediate", "Advanced"}, {GlitchHoverDescDisabled, GlitchHoverDescNovice, GlitchHoverDescIntermediate, GlitchHoverDescAdvanced});
-  Option GlitchMegaflip = Option::U8("Megaflip", {"Disabled", "Novice", "Intermediate"}, {GlitchMegaflipDescDisabled, GlitchMegaflipDescNovice, GlitchMegaflipDescIntermediate});
-  Option GlitchHookshotClip = Option::U8("Hookshot Clip", {"Disabled", "Novice"}, {GlitchHookshotClipDescDisabled, GlitchHookshotClipDescNovice});
-  Option GlitchHookshotJump_Bonk = Option::U8("Hookshot Jump (Bonk)", {"Disabled", "Intermediate"}, {GlitchHookshotJump_BonkDescDisabled, GlitchHookshotJump_BonkDescIntermediate});
-  Option GlitchHookshotJump_Boots = Option::U8("Hookshot Jump (Boots)", {"Disabled", "Novice", "Intermediate"}, {GlitchHookshotJump_BootsDescDisabled, GlitchHookshotJump_BootsDescNovice, GlitchHookshotJump_BootsDescIntermediate});
-  Option GlitchLedgeClip = Option::U8("Ledge Clip", {"Disabled", "Novice", "Intermediate"}, {GlitchLedgeClipDescDisabled, GlitchLedgeClipDescNovice, GlitchLedgeClipDescIntermediate});
-  Option GlitchTripleSlashClip = Option::U8("Triple Slash Clip", {"Disabled", "Novice"}, {GlitchTripleSlashClipDescDisabled, GlitchTripleSlashClipDescNovice});
+  //Function to avoid accidentally naming the options wrong, as logic.cpp requires these exact names
+  std::vector<std::string> GlitchDifficultyOptions(u8 enabledDifficulties) {
+    static constexpr std::array glitchDifficulties{"Novice", "Intermediate", "Advanced", "Expert", "Hero"};
+
+    std::vector<std::string> selectableDifficulties;
+    selectableDifficulties.push_back("Disabled");
+    for (size_t i = 0; i < glitchDifficulties.size(); i++) {
+      if ((enabledDifficulties >> i) & 1) {
+        selectableDifficulties.push_back(glitchDifficulties[i]);
+      }
+    }
+
+    return selectableDifficulties;
+  }
+
+  Option GlitchISG                = Option::U8("Infinite Sword Glitch", GlitchDifficultyOptions(0b00001), {GlitchISGDescDisabled, GlitchISGDescNovice});
+  Option GlitchHover              = Option::U8("Bomb Hover",            GlitchDifficultyOptions(0b00111), {GlitchHoverDescDisabled, GlitchHoverDescNovice, GlitchHoverDescIntermediate, GlitchHoverDescAdvanced});
+  Option GlitchMegaflip           = Option::U8("Megaflip",              GlitchDifficultyOptions(0b00011), {GlitchMegaflipDescDisabled, GlitchMegaflipDescNovice, GlitchMegaflipDescIntermediate});
+  Option GlitchHookshotClip       = Option::U8("Hookshot Clip",         GlitchDifficultyOptions(0b00001), {GlitchHookshotClipDescDisabled, GlitchHookshotClipDescNovice});
+  Option GlitchHookshotJump_Bonk  = Option::U8("Hookshot Jump (Bonk)",  GlitchDifficultyOptions(0b00010), {GlitchHookshotJump_BonkDescDisabled, GlitchHookshotJump_BonkDescIntermediate});
+  Option GlitchHookshotJump_Boots = Option::U8("Hookshot Jump (Boots)", GlitchDifficultyOptions(0b00011), {GlitchHookshotJump_BootsDescDisabled, GlitchHookshotJump_BootsDescNovice, GlitchHookshotJump_BootsDescIntermediate});
+  Option GlitchLedgeClip          = Option::U8("Ledge Clip",            GlitchDifficultyOptions(0b00011), {GlitchLedgeClipDescDisabled, GlitchLedgeClipDescNovice, GlitchLedgeClipDescIntermediate});
+  Option GlitchTripleSlashClip    = Option::U8("Triple Slash Clip",     GlitchDifficultyOptions(0b00001), {GlitchTripleSlashClipDescDisabled, GlitchTripleSlashClipDescNovice});
   std::vector<Option*> glitchOptions = {
     &GlitchISG,
     &GlitchHover,


### PR DESCRIPTION
With this, when more glitches are added we only have to check that the `glitchDifficulties` array is the same as the vector in `setting_descriptions.cpp`.