### PR TITLE
Bug fixes: sun's song and lake switch

### DIFF
--- a/code/src/lake_hylia_objects.c
+++ b/code/src/lake_hylia_objects.c
@@ -28,13 +28,13 @@ void BgSpot06Objects_rUpdate(Actor* thisx, GlobalContext* globalCtx) {
             switchParams = 0x3E81; // Frozen rusty switch, same flag as above. It's glitched and can't be pressed, which is perfect
         }
 
-        // Spawn a floor switch
-        floorSwitch = Actor_Spawn(&globalCtx->actorCtx, globalCtx, 0x12A, -896.0f, -1243.0f, 6953.0f, 0, 0, 0, switchParams);
-
         // if Lake Hylia's water is lowered, set the temp_switch flag
         if (!(gSaveContext.eventChkInf[6] & 0x0200)) {
             globalCtx->actorCtx.flags.tempSwch |= (0x40 << 24);
         }
+
+        // Spawn a floor switch
+        floorSwitch = Actor_Spawn(&globalCtx->actorCtx, globalCtx, 0x12A, -896.0f, -1243.0f, 6953.0f, 0, 0, 0, switchParams);
 
         // Spawn a sign
         Actor_Spawn(&globalCtx->actorCtx, globalCtx, 0x141, -970.0f, -1242.0f, 6954.0f, 0, 0, 0, 0x0046);

--- a/code/src/songs_visual_effects.c
+++ b/code/src/songs_visual_effects.c
@@ -61,10 +61,16 @@ void OceffWipe4_rUpdate(Actor* thisx, GlobalContext* globalCtx) {
 
 // Sun's Song
 void OceffSpot_rUpdate(Actor* thisx, GlobalContext* globalCtx) {
-    if (gSettingsContext.skipSongReplays != SONGREPLAYS_DONT_SKIP) {
+    if (gSettingsContext.skipSongReplays == SONGREPLAYS_DONT_SKIP) {
+        OceffSpot_Update(thisx, globalCtx);
+    }
+    // Wait for a bit before calling OceffSpot_End, otherwise Link and the music staff spots could start waiting
+    // for the Sun's Song light after it's been killed already, causing softlocks and non-functional song switches in MQ Spirit
+    else if ((gSettingsContext.skipSongReplays == SONGREPLAYS_SKIP_KEEP_SFX && gGlobalContext->msgMode == 0) ||
+             (gSettingsContext.skipSongReplays == SONGREPLAYS_SKIP_NO_SFX && ((PLAYER->stateFlags1 >> 24) & 0x30) != 0x30)
+            ) {
         OceffSpot_End(thisx, globalCtx);
     }
-    OceffSpot_Update(thisx, globalCtx);
 }
 
 // Song of Storms


### PR DESCRIPTION
This should fix some problems with Sun's Song and Skip Song Replays:
- the 5 songs puzzle in MQ Spirit being incompletable
- ZR frogs refusing to recognize the song with the "No SFX" option
- softlocks happening when playing the song with the "Keep SFX" option
- fog glitches when playing the song in Water Temple and then going underwater

I also moved a line for the Lake Hylia switch to make it properly appear pressed when the water is low