### PR TITLE
Properly return false on Here() function when there's no logical access

### DIFF
--- a/source/location_access.hpp
+++ b/source/location_access.hpp
@@ -192,9 +192,9 @@ public:
       Logic::IsChild = Child();
       Logic::IsAdult = Adult();
 
-      //update helpers and check condition
+      //update helpers and check condition as well as having at least child or adult access
       Logic::UpdateHelpers();
-      bool hereVal = condition();
+      bool hereVal = condition() && (Logic::IsAdult || Logic::IsChild);
 
       //set back age variables
       Logic::IsChild = pastChild;


### PR DESCRIPTION
The `Here()` function was not returning false on the condition that the specified area was not logically accessible yet. This adds an additional check to the return statement verifying that at least one age has access to the area. Shoutouts to Nessy for pinpointing the problem quickly. 