### PR TITLE
Fix Lost Woods music playing after exiting Goron City in Overworld ER

### DIFF
--- a/code/src/entrance.c
+++ b/code/src/entrance.c
@@ -168,6 +168,15 @@ void Entrance_Init(void) {
             }
         }
     }
+
+    //Set the exit transition of GC Woods Warp -> Lost Woods to a lost woods transition.
+    //This works as an easy fix for the Overworld ER bug that continues to play the lost
+    //woods music into the next area, even if isn't the lost woods. A "proper" fix would
+    //probably be to stop playing the music on any transition though
+    for (s16 i = 0x4D6; i < 0x4DA; i++) {
+        gEntranceTable[i].field &= 0xFF00;
+        gEntranceTable[i].field |= 0x002C;
+    }
 }
 
 void Entrance_DeathInGanonBattle(void) {

--- a/code/src/entrance.c
+++ b/code/src/entrance.c
@@ -173,9 +173,11 @@ void Entrance_Init(void) {
     //This works as an easy fix for the Overworld ER bug that continues to play the lost
     //woods music into the next area, even if isn't the lost woods. A "proper" fix would
     //probably be to stop playing the music on any transition though
-    for (s16 i = 0x4D6; i < 0x4DA; i++) {
-        gEntranceTable[i].field &= 0xFF00;
-        gEntranceTable[i].field |= 0x002C;
+    if (gSettingsContext.shuffleOverworldEntrances == ON) {
+        for (s16 i = 0x4D6; i < 0x4DA; i++) {
+            gEntranceTable[i].field &= 0xFF00;
+            gEntranceTable[i].field |= 0x002C;
+        }
     }
 }
 


### PR DESCRIPTION
The Lost Woods music that plays near the GC Woods Warp -> Lost Woods exit would continue to play over the next areas music when Overworld Entrance Randomizer was enabled. This is fixed by setting the fadeout animation of the exit to be a Lost Woods fadeout.