### PR TITLE
Skip Twinrova quarreling cutscene and fix music bug

### DIFF
--- a/code/oot.ld
+++ b/code/oot.ld
@@ -312,6 +312,10 @@ SECTIONS
 		*(.patch_JabuJabuCutsceneOverride)
 	}
 
+	.patch_KotakeDontPlayBattleMusic 0x1A8218 : {
+		*(.patch_KotakeDontPlayBattleMusic)
+	}
+
 	.patch_GossipStoneAddSariaHint 0x1B398C : {
 		*(.patch_GossipStoneAddSariaHint)
 	}

--- a/code/oot.ld
+++ b/code/oot.ld
@@ -96,6 +96,10 @@ SECTIONS
 		*(.patch_BeanDaddyModifyPrice)
 	}
 
+	.patch_SkipTwinrovaQuarrelCutsceneOne 0x15273C : {
+		*(.patch_SkipTwinrovaQuarrelCutsceneOne)
+	}
+
 	.patch_FairyPickupHealAmount 0x15CA4C : {
 		*(.patch_FairyPickupHealAmount)
 	}
@@ -170,6 +174,10 @@ SECTIONS
 
 	.patch_SkipTimeTravelCutsceneOne 0x174DEC : {
 		*(.patch_SkipTimeTravelCutsceneOne)
+	}
+
+	.patch_SkipTwinrovaQuarrelCutsceneTwo 0x176110 : {
+		*(.patch_SkipTwinrovaQuarrelCutsceneTwo)
 	}
 
 	.patch_CarpenterBossDontNullExchangeItem 0x178BE4 : {

--- a/code/src/hooks.s
+++ b/code/src/hooks.s
@@ -1042,6 +1042,12 @@ hook_OverrideFogDuringGameplayInit:
     pop {r0-r12, lr}
     bx lr
 
+.global hook_SkipTwinrovaQuarrelCutscene
+hook_SkipTwinrovaQuarrelCutscene:
+    mov r0,#0x500
+    add r0,r0,#0x9
+    bx lr
+
 .section .loader
 .global hook_into_loader
 hook_into_loader:

--- a/code/src/patches.s
+++ b/code/src/patches.s
@@ -1632,6 +1632,11 @@ SaveMenuIgnoreOpen_patch:
 OverrideFogDuringGameplayInit_patch:
     bl hook_OverrideFogDuringGameplayInit
 
+.section .patch_KotakeDontPlayBattleMusic
+.global KotakeDontPlayBattleMusic_patch
+KotakeDontPlayBattleMusic_patch:
+    nop
+
 .section .patch_loader
 .global loader_patch
 

--- a/code/src/patches.s
+++ b/code/src/patches.s
@@ -1637,6 +1637,16 @@ OverrideFogDuringGameplayInit_patch:
 KotakeDontPlayBattleMusic_patch:
     nop
 
+.section .patch_SkipTwinrovaQuarrelCutsceneOne
+.global SkipTwinrovaQuarrelCutsceneOne_patch
+SkipTwinrovaQuarrelCutsceneOne_patch:
+    sub r1,r1,#0x500
+
+.section .patch_SkipTwinrovaQuarrelCutsceneTwo
+.global SkipTwinrovaQuarrelCutsceneTwo_patch
+SkipTwinrovaQuarrelCutsceneTwo_patch:
+    bl hook_SkipTwinrovaQuarrelCutscene
+
 .section .patch_loader
 .global loader_patch
 

--- a/code/src/twinrova.c
+++ b/code/src/twinrova.c
@@ -13,13 +13,11 @@
 #define Boss_Tw_Destroy_addr 0x1A88E8
 #define Boss_Tw_Destroy ((ActorFunc)Boss_Tw_Destroy_addr)
 
-#define SomeMusicFunction ((void (*)(u8 unk, u32 music))0x36EC40)
+#define PlayActorMusic ((void (*)(u8 unk, u32 music))0x36EC40)
 
 #define BOSS_BATTLE_BGM 0x1000589
-#define SPIRIT_TEMPLE_BGM 0x10005AC
 
 static u8 fightStarted = 0;
-static u8 musicSet = 0;
 static u8 appeared = 0;
 
 void Boss_Tw_rInit(Actor* thisx, GlobalContext* globalCtx) {
@@ -35,7 +33,7 @@ void Boss_Tw_rUpdate(Actor* thisx, GlobalContext* globalCtx) {
 
     if (!fightStarted && pos.x > -100 && pos.x < 100 && pos.y > 200 && pos.z > -100 && pos.z < 100) {
         fightStarted = 1;
-        SomeMusicFunction(0, BOSS_BATTLE_BGM);
+        PlayActorMusic(0, BOSS_BATTLE_BGM);
     }
 
     if (fightStarted) {
@@ -48,10 +46,6 @@ void Boss_Tw_rUpdate(Actor* thisx, GlobalContext* globalCtx) {
         } else if (!appeared) {
             appeared = 1;
         }
-    } else if (!musicSet) {
-        SomeMusicFunction(0, SPIRIT_TEMPLE_BGM);
-        SomeMusicFunction(0, SPIRIT_TEMPLE_BGM); // one doesn't work for some reason
-        musicSet = 1;
     }
 }
 
@@ -63,7 +57,6 @@ void Boss_Tw_rDraw(Actor* thisx, GlobalContext* globalCtx) {
 void Boss_Tw_rDestroy(Actor* thisx, GlobalContext* globalCtx) {
     if (thisx->params == 0x0001) { // Koume. This check is needed because the elemental
         fightStarted = 0;          // attacks are different instances of the actor
-        musicSet = 0;
         appeared = 0;
     }
 

--- a/code/src/twinrova.c
+++ b/code/src/twinrova.c
@@ -22,9 +22,12 @@ static u8 appeared = 0;
 
 void Boss_Tw_rInit(Actor* thisx, GlobalContext* globalCtx) {
     Boss_Tw_Init(thisx, globalCtx);
-    thisx->scale.x = 0.0025f;
-    thisx->scale.y = 0.0025f;
-    thisx->scale.z = 0.0025f;
+    if (thisx->params == 0 || thisx->params == 1) {
+        // Kotake or Koume
+        thisx->scale.x = 0.0025f;
+        thisx->scale.y = 0.0025f;
+        thisx->scale.z = 0.0025f;
+    }
 }
 
 void Boss_Tw_rUpdate(Actor* thisx, GlobalContext* globalCtx) {


### PR DESCRIPTION
- After Twinrova is defeated, Kotake and Koume rise up as soon as they reappear, without wasting time arguing.
- The red and white light balls that appear after Twinrova splits are not mistakenly miniaturized anymore.
- Music doesn't restart when entering Twinrova's battle arena.