### PR TITLE
Skip Jabu opening cutscene, rework entrance cutscenes

### DIFF
--- a/code/oot.ld
+++ b/code/oot.ld
@@ -332,6 +332,10 @@ SECTIONS
 		*(.patch_ReadGossipStoneHints)
 	}
 
+	.patch_SkipJabuOpeningCutscene 0x1B583C : {
+		*(.patch_SkipJabuOpeningCutscene)
+	}
+
 	.patch_KingZoraSecondTunic 0x1B6A18 : {
 		*(.patch_KingZoraSecondTunic)
 	}

--- a/code/oot.ld
+++ b/code/oot.ld
@@ -1064,6 +1064,10 @@ SECTIONS
 		*(.patch_ExtendedObjectClear)
 	}
 
+	.patch_PlayEntranceCutscene 0x44F068 : {
+		*(.patch_PlayEntranceCutscene)
+	}
+
 	.patch_RequiemLocation 0x44F104 : {
 		*(.patch_RequiemLocation)
 	}

--- a/code/src/demo_kankyo.c
+++ b/code/src/demo_kankyo.c
@@ -5,7 +5,6 @@
 #define DemoKankyo_Update_addr 0x262EA4
 #define DemoKankyo_Update ((ActorFunc)DemoKankyo_Update_addr)
 
-#define DoT_Opening_Cutscene_Pointer ((void*)0x0893AD30)
 #define CsTimer (globalCtx->csCtx.frames)
 
 void DemoKankyo_rUpdate(Actor* thisx, GlobalContext* globalCtx) {
@@ -14,7 +13,7 @@ void DemoKankyo_rUpdate(Actor* thisx, GlobalContext* globalCtx) {
     // Warp Song particles
     if (thisx->params == 0x000F) {
         globalCtx->sceneLoadFlag = 0x14;
-        gGlobalContext->fadeOutTransition = 5;
+        globalCtx->fadeOutTransition = 5;
         switch (globalCtx->unk_2A91[0xEB]) { // text related variable
             case 0:
                 globalCtx->nextEntranceIndex = 0x0600; // Minuet
@@ -47,8 +46,8 @@ void DemoKankyo_rUpdate(Actor* thisx, GlobalContext* globalCtx) {
         }
     }
 
-    // Door of Time, the opening cutscene is playing (only regular one, not beta CS #03)
-    if (thisx->params == 0x000D && globalCtx->csCtx.segment == DoT_Opening_Cutscene_Pointer) {
+    // Door of Time, a non-numbered cutscene is playing (it can only be the Door opening cs)
+    if (thisx->params == 0x000D && gSaveContext.cutsceneIndex == 0xFFFD) {
         // skip the Spiritual Stones part of the cutscene
         if (CsTimer < 800) {
             CsTimer = 800;

--- a/code/src/entrance.c
+++ b/code/src/entrance.c
@@ -8,6 +8,10 @@ typedef void (*SetNextEntrance_proc)(struct GlobalContext* globalCtx, s16 entran
 #define SetNextEntrance_addr 0x3716F0
 #define SetNextEntrance ((SetNextEntrance_proc)SetNextEntrance_addr)
 
+typedef void (*SetEventChkInf_proc)(u32 flag);
+#define SetEventChkInf_addr 0x34CBF8
+#define SetEventChkInf ((SetEventChkInf_proc)SetEventChkInf_addr)
+
 #define dynamicExitList_addr 0x53C094
 #define dynamicExitList ((s16*)dynamicExitList_addr)
 
@@ -358,4 +362,15 @@ void EnableFW() {
             gSaveContext.buttonStatus[i] = 0;
         }
     }
+}
+
+u8 EntranceCutscene_ShouldPlay(u8 flag) {
+    if (gSaveContext.gameMode != 0 || flag == 0x18 || flag == 0xAD || (flag >= 0xBB && flag <= 0xBF)) {
+        if (flag == 0xC0) {
+            gSaveContext.eventChkInf[0x3] &= ~0x0800; // clear "began Nabooru battle"
+        }
+        return 1; // cutscene will play normally in DHWW, or always if it's freeing Epona or clearing a Trial
+    }
+    SetEventChkInf(flag);
+    return 0; //cutscene will not play
 }

--- a/code/src/hooks.s
+++ b/code/src/hooks.s
@@ -1065,6 +1065,17 @@ hook_FixItemsMenuSlotDuplication:
     add r10,r10,#0x1
     b 0x456B94
 
+.global hook_PlayEntranceCutscene
+hook_PlayEntranceCutscene:
+    bgt 0x44F0A4
+    push {r0-r12, lr}
+    ldrb r0,[r5,#0x3]
+    bl EntranceCutscene_ShouldPlay
+    cmp r0,#0x0
+    pop {r0-r12, lr}
+    beq 0x44F0A4
+    b 0x44F06C
+
 .global hook_SkipJabuOpeningCutscene
 hook_SkipJabuOpeningCutscene:
     ldrh r0,[r0,#0x0]

--- a/code/src/hooks.s
+++ b/code/src/hooks.s
@@ -1065,6 +1065,14 @@ hook_FixItemsMenuSlotDuplication:
     add r10,r10,#0x1
     b 0x456B94
 
+.global hook_SkipJabuOpeningCutscene
+hook_SkipJabuOpeningCutscene:
+    ldrh r0,[r0,#0x0]
+    push {r0-r12, lr}
+    bl Jabu_SkipOpeningCutscene
+    pop {r0-r12, lr}
+    bx lr
+
 .section .loader
 .global hook_into_loader
 hook_into_loader:

--- a/code/src/jabu.c
+++ b/code/src/jabu.c
@@ -1,0 +1,7 @@
+#include "z3D/z3D.h"
+
+void Jabu_SkipOpeningCutscene(void) {
+    gGlobalContext->nextEntranceIndex = 0x0028;
+    gGlobalContext->sceneLoadFlag = 0x14;
+    gGlobalContext->fadeOutTransition = 2;
+}

--- a/code/src/lake_hylia_objects.c
+++ b/code/src/lake_hylia_objects.c
@@ -63,6 +63,7 @@ void BgSpot06Objects_rUpdate(Actor* thisx, GlobalContext* globalCtx) {
             // TODO: remove this warp when the water will properly move
             globalCtx->nextEntranceIndex = 0x0604;
             globalCtx->sceneLoadFlag = 0x14;
+            globalCtx->fadeOutTransition = 5;
         }
     } else {
         if (thisx->params == 0x0002 && !(gSaveContext.eventChkInf[6] & 0x0200)) {
@@ -72,6 +73,7 @@ void BgSpot06Objects_rUpdate(Actor* thisx, GlobalContext* globalCtx) {
             // TODO: remove this warp when the water will properly move
             globalCtx->nextEntranceIndex = 0x0604;
             globalCtx->sceneLoadFlag = 0x14;
+            globalCtx->fadeOutTransition = 5;
         }
     }
     /*  //TODO: change shape of the water texture to cover the entire lake, then change collision context stuff to make

--- a/code/src/patches.s
+++ b/code/src/patches.s
@@ -1657,6 +1657,11 @@ SkipTwinrovaQuarrelCutsceneTwo_patch:
 FixItemsMenuSlotDuplication_patch:
     b hook_FixItemsMenuSlotDuplication
 
+.section .patch_PlayEntranceCutscene
+.global PlayEntranceCutscene_patch
+PlayEntranceCutscene_patch:
+    b hook_PlayEntranceCutscene
+
 .section .patch_SkipJabuOpeningCutscene
 .global SkipJabuOpeningCutscene_patch
 SkipJabuOpeningCutscene_patch:

--- a/code/src/patches.s
+++ b/code/src/patches.s
@@ -1657,6 +1657,11 @@ SkipTwinrovaQuarrelCutsceneTwo_patch:
 FixItemsMenuSlotDuplication_patch:
     b hook_FixItemsMenuSlotDuplication
 
+.section .patch_SkipJabuOpeningCutscene
+.global SkipJabuOpeningCutscene_patch
+SkipJabuOpeningCutscene_patch:
+    bl hook_SkipJabuOpeningCutscene
+
 .section .patch_loader
 .global loader_patch
 

--- a/code/src/savefile.c
+++ b/code/src/savefile.c
@@ -44,6 +44,7 @@ void SaveFile_Init(u32 fileBaseIndex) {
     gSaveContext.infTable  [0x11] |= 0x0400; //Met Darunia in Fire Temple
     gSaveContext.infTable  [0x14] |= 0x000E; //Ruto in Jabu can be escorted immediately
     gSaveContext.infTable  [0x19] |= 0x0100; //Picked up Magic Container
+    gSaveContext.infTable  [0x19] |= 0x0020; //Talked to owl in Lake Hylia
     gSaveContext.itemGetInf [0x1] |= 0x0008; //Picked up Deku Seeds
     gSaveContext.eventChkInf[0x3] |= 0x0800; //began Nabooru Battle
     gSaveContext.eventChkInf[0x7] |= 0x01FF; //began boss battles

--- a/code/src/savefile.c
+++ b/code/src/savefile.c
@@ -48,10 +48,11 @@ void SaveFile_Init(u32 fileBaseIndex) {
     gSaveContext.eventChkInf[0x3] |= 0x0800; //began Nabooru Battle
     gSaveContext.eventChkInf[0x7] |= 0x01FF; //began boss battles
     gSaveContext.eventChkInf[0x9] |= 0x0010; //Spoke to Nabooru as child
-    gSaveContext.eventChkInf[0xA] |= 0x017B; //entrance cutscenes (minus temple of time)
-    gSaveContext.eventChkInf[0xB] |= 0x07FF; //more entrance cutscenes
-    gSaveContext.eventChkInf[0xC] |= 0x0001; //Nabooru ordered to fight by Twinrova
-    gSaveContext.eventChkInf[0xC] |= 0x8000; //Forest Temple entrance cutscene (3ds only)
+    gSaveContext.eventChkInf[0xB] |= 0x0001; //Dodongo's Cavern intro
+  //gSaveContext.eventChkInf[0xA] |= 0x017B; //entrance cutscenes (minus temple of time)
+  //gSaveContext.eventChkInf[0xB] |= 0x07FF; //more entrance cutscenes
+  //gSaveContext.eventChkInf[0xC] |= 0x0001; //Nabooru ordered to fight by Twinrova
+  //gSaveContext.eventChkInf[0xC] |= 0x8000; //Forest Temple entrance cutscene (3ds only)
 
     gSaveContext.sceneFlags[5].swch |= 0x00010000; //remove Ruto cutscene in Water Temple
 
@@ -145,10 +146,6 @@ void SaveFile_Init(u32 fileBaseIndex) {
 
     if (gSettingsContext.fourPoesCutscene == SKIP) {
         gSaveContext.sceneFlags[3].swch |= 0x08000000; //Remove Poe cutscene in Forest Temple
-    }
-
-    if (gSettingsContext.templeOfTimeIntro == SKIP) {
-        gSaveContext.eventChkInf[0xA] |= 0x0080; //Remove Temple of Time intro cutscene
     }
 
     //Move mido away from the path to the Deku Tree in Open Forest

--- a/code/src/settings.h
+++ b/code/src/settings.h
@@ -377,7 +377,6 @@ typedef struct {
   u8 skipMinigamePhases;
   u8 freeScarecrow;
   u8 fourPoesCutscene;
-  u8 templeOfTimeIntro;
   u8 lakeHyliaOwl;
   u8 bigPoeTargetCount;
   u8 numRequiredCuccos;

--- a/source/setting_descriptions.cpp
+++ b/source/setting_descriptions.cpp
@@ -516,13 +516,6 @@ string_view fourPoesDesc              = "The cutscene with the 4 poes in Forest 
                                         "be skipped. If the cutscene is not skipped, it can"
                                         "be exploited to reach the basement early.";       //
 /*------------------------------                                                           //
-|     TEMPLE OF TIME INTRO     |                                                           //
-------------------------------*/                                                           //
-string_view templeOfTimeIntroDesc     = "The introduction cutscene to Temple of Time will\n"
-                                        "be skipped. This cutscene is helpful for\n"       //
-                                        "performing Door of Time Skip should the Door of\n"//
-                                        "Time be closed.";                                 //
-/*------------------------------                                                           //
 |        LAKE HYLIA OWL        |                                                           //
 ------------------------------*/                                                           //
 string_view lakeHyliaOwlDesc          = "The owl flight cutscene in Lake Hylia will be\n"  //

--- a/source/setting_descriptions.hpp
+++ b/source/setting_descriptions.hpp
@@ -174,8 +174,6 @@ extern string_view freeScarecrowDesc;
 
 extern string_view fourPoesDesc;
 
-extern string_view templeOfTimeIntroDesc;
-
 extern string_view lakeHyliaOwlDesc;
 
 extern string_view bigPoeTargetCountDesc;

--- a/source/settings.cpp
+++ b/source/settings.cpp
@@ -199,7 +199,6 @@ namespace Settings {
   Option SkipMinigamePhases  = Option::Bool("Minigames repetitions",  {"Don't Skip", "Skip"},                                                 {skipMinigamePhasesDesc});
   Option FreeScarecrow       = Option::Bool("Free Scarecrow",         {"Off", "On"},                                                          {freeScarecrowDesc});
   Option FourPoesCutscene    = Option::Bool("Four Poes Cutscene",     {"Don't Skip", "Skip"},                                                 {fourPoesDesc},                                                                                                   OptionCategory::Setting,    SKIP);
-  Option TempleOfTimeIntro   = Option::Bool("Temple of Time Intro",   {"Don't Skip", "Skip"},                                                 {templeOfTimeIntroDesc},                                                                                          OptionCategory::Setting,    SKIP);
   Option LakeHyliaOwl        = Option::Bool("Lake Hylia Owl",         {"Don't Skip", "Skip"},                                                 {lakeHyliaOwlDesc},                                                                                               OptionCategory::Setting,    SKIP);
   Option BigPoeTargetCount   = Option::U8  ("Big Poe Target Count",   {"1", "2", "3", "4", "5", "6", "7", "8", "9", "10"},                    {bigPoeTargetCountDesc});
   Option NumRequiredCuccos   = Option::U8  ("Cuccos to return",       {"0", "1", "2", "3", "4", "5", "6", "7"},                               {numRequiredCuccosDesc});
@@ -215,7 +214,6 @@ namespace Settings {
     &SkipMinigamePhases,
     &FreeScarecrow,
     &FourPoesCutscene,
-    &TempleOfTimeIntro,
     &LakeHyliaOwl,
     &BigPoeTargetCount,
     &NumRequiredCuccos,
@@ -936,7 +934,6 @@ namespace Settings {
     ctx.skipMinigamePhases   = (SkipMinigamePhases) ? 1 : 0;
     ctx.freeScarecrow        = (FreeScarecrow) ? 1 : 0;
     ctx.fourPoesCutscene     = (FourPoesCutscene) ? 1 : 0;
-    ctx.templeOfTimeIntro    = (TempleOfTimeIntro) ? 1 : 0;
     ctx.lakeHyliaOwl         = (LakeHyliaOwl) ? 1 : 0;
     ctx.bigPoeTargetCount    = BigPoeTargetCount.Value<u8>() + 1;
     ctx.numRequiredCuccos    = NumRequiredCuccos.Value<u8>();

--- a/source/settings.hpp
+++ b/source/settings.hpp
@@ -349,7 +349,6 @@ namespace Settings {
   extern Option SkipMinigamePhases;
   extern Option FreeScarecrow;
   extern Option FourPoesCutscene;
-  extern Option TempleOfTimeIntro;
   extern Option LakeHyliaOwl;
   extern Option BigPoeTargetCount;
   extern Option NumRequiredCuccos;


### PR DESCRIPTION
- The cutscene after feeding Jabu Jabu a fish is skipped
- The bug with the DoT opening cutscene not being skipped anymore is fixed. The spiritual stones also appear in the correct positions on the pedestal
- Most Entrance Cutscenes are changed to only play during Title Screen mode, so the option to skip the ToT intro has been removed and most of the relevant flags are not set anymore when creating a save file. The flags are still set when entering areas in normal gameplay, even without the cutscene playing.