### PR TITLE
Possible fix to sfx shuffle related unmapped reads

### DIFF
--- a/code/src/sfx.c
+++ b/code/src/sfx.c
@@ -9,10 +9,10 @@ SFXData rSfxData = {0};
 /// A custom modulus function has to be used because the following examples for some reason cause unmapped writes:
 /// [(sfxID + gGlobalContext->sceneNum) % rSfxData.rSeqMaxes[type]]
 /// [gRandInt % rSfxData.rSeqMaxes[type]]
-u16 CustomSFXModulus(u16 sfxOverflow, SeqType type_) {
+u16 CustomSFXModulus(u16 sfxOverflow, u16 mod) {
     u16 sfxResult = sfxOverflow;
-    while (sfxResult >= rSfxData.rSeqMaxes[type_]) {
-        sfxResult -= rSfxData.rSeqMaxes[type_];
+    while (sfxResult >= mod) {
+        sfxResult -= mod;
     }
     return sfxResult;
 }
@@ -32,17 +32,17 @@ u32 SetSFX(u32 original) {
 
     if (gSettingsContext.shuffleSFXCategorically) {
         if (gSettingsContext.shuffleSFX == SHUFFLESFX_SCENESPECIFIC) {
-            return rSfxData.rSFXOverrides_Types[type][CustomSFXModulus(sfxID + gGlobalContext->sceneNum, type)];
+            return rSfxData.rSFXOverrides_Types[type][CustomSFXModulus(sfxID + gGlobalContext->sceneNum, rSfxData.rSeqMaxes[type])];
         }
         else if (gSettingsContext.shuffleSFX == SHUFFLESFX_CHAOS) {
-            return rSfxData.rSFXOverrides_Types[type][CustomSFXModulus(sfxID + gRandInt, type)];
+            return rSfxData.rSFXOverrides_Types[type][CustomSFXModulus(sfxID + gRandInt, rSfxData.rSeqMaxes[type])];
         }
     } else {
         if (gSettingsContext.shuffleSFX == SHUFFLESFX_SCENESPECIFIC) {
-            return rSfxData.rSFXOverrides_AllTrimmed[(sfxID + gGlobalContext->sceneNum) % SFX_COUNT_TRIMMED];
+            return rSfxData.rSFXOverrides_AllTrimmed[CustomSFXModulus(sfxID + gGlobalContext->sceneNum, SFX_COUNT_TRIMMED)];
         }
         else if (gSettingsContext.shuffleSFX == SHUFFLESFX_CHAOS) {
-            return rSfxData.rSFXOverrides_AllTrimmed[(sfxID + gRandInt) % SFX_COUNT_TRIMMED];
+            return rSfxData.rSFXOverrides_AllTrimmed[CustomSFXModulus(sfxID + gRandInt, SFX_COUNT_TRIMMED)];
         }
     }
 


### PR DESCRIPTION
There is an issue where playing a shuffled sound effect sometimes gave unmapped reads which this may fix. I tested two seeds in multiple scenes, and they all worked.
The issue may have been that the assembly code went over the uncategorized code check first (it happened even with categorical shuffle turned on) where I had forgotten to change the modulus to the custom function. So even if this doesn't fix the issue completely, it at least fixes what I previously forgot to change.
