### PR TITLE
Add in-game "Silence Navi" option

### DIFF
--- a/code/oot.ld
+++ b/code/oot.ld
@@ -540,6 +540,10 @@ SECTIONS
 		*(.patch_CanPlayBombchuBowlingOne)
 	}
 
+	.patch_SilenceNavi 0x26807C : {
+		*(.patch_SilenceNavi)
+	}
+
 	.patch_CheckGerudoToken_269884 0x269884 : {
 		*(.patch_CheckGerudoToken_269884)
 	}

--- a/code/src/gfx_options.c
+++ b/code/src/gfx_options.c
@@ -13,7 +13,7 @@ typedef struct {
 } Option;
 
 s8 selectedOption;
-Option options[2];
+Option options[3];
 
 void InitOptions(void) {
     // BGM
@@ -29,6 +29,13 @@ void InitOptions(void) {
     strcpy(options[1].alternatives[1], "On");
     strcpy(options[1].description, "Toggles the sound effects.");
     options[1].optionPointer = &gExtSaveData.option_EnableSFX;
+
+    // Silence Navi
+    strcpy(options[2].name, "Silence Navi");
+    strcpy(options[2].alternatives[0], "Off");
+    strcpy(options[2].alternatives[1], "On");
+    strcpy(options[2].description, "Prevents Navi from alerting you about advice.");
+    options[2].optionPointer = &gExtSaveData.option_SilenceNavi;
 }
 
 void Gfx_DrawOptions(void) {

--- a/code/src/hooks.s
+++ b/code/src/hooks.s
@@ -1092,6 +1092,16 @@ hook_SkipJabuOpeningCutscene:
     pop {r0-r12, lr}
     bx lr
 
+.global hook_SilenceNavi
+hook_SilenceNavi:
+    push {r0-r12, lr}
+    bl IsNaviSilenced
+    cmp r0,#0x1
+    pop {r0-r12, lr}
+    beq 0x26808C
+    cmp r0,r2
+    bx lr
+
 .section .loader
 .global hook_into_loader
 hook_into_loader:

--- a/code/src/navi.c
+++ b/code/src/navi.c
@@ -1,0 +1,6 @@
+#include "../include/z3D/z3D.h"
+#include "savefile.h"
+
+u8 IsNaviSilenced(void) {
+    return gExtSaveData.option_SilenceNavi;
+}

--- a/code/src/patches.s
+++ b/code/src/patches.s
@@ -1672,6 +1672,11 @@ PlayEntranceCutscene_patch:
 SkipJabuOpeningCutscene_patch:
     bl hook_SkipJabuOpeningCutscene
 
+.section .patch_SilenceNavi
+.global SilenceNavi_patch
+SilenceNavi_patch:
+    bl hook_SilenceNavi
+
 .section .patch_loader
 .global loader_patch
 

--- a/code/src/savefile.c
+++ b/code/src/savefile.c
@@ -566,8 +566,10 @@ void SaveFile_InitExtSaveData(u32 saveNumber) {
     gExtSaveData.playtimeSeconds = 0;
     memset(&gExtSaveData.scenesDiscovered, 0, sizeof(gExtSaveData.scenesDiscovered));
     memset(&gExtSaveData.entrancesDiscovered, 0, sizeof(gExtSaveData.entrancesDiscovered));
+    // Ingame Options
     gExtSaveData.option_EnableBGM = 1;
     gExtSaveData.option_EnableSFX = 1;
+    gExtSaveData.option_SilenceNavi = 0;
 }
 
 void SaveFile_LoadExtSaveData(u32 saveNumber) {

--- a/code/src/savefile.h
+++ b/code/src/savefile.h
@@ -24,7 +24,7 @@ void SaveFile_LoadExtSaveData(u32 saveNumber);
 void SaveFile_SaveExtSaveData(u32 saveNumber);
 
 // Increment the version number whenever the ExtSaveData structure is changed
-#define EXTSAVEDATA_VERSION 4
+#define EXTSAVEDATA_VERSION 5
 
 typedef struct {
     u32 version;            // Needs to always be the first field of the structure
@@ -45,6 +45,7 @@ typedef struct {
     // Ingame Options, all need to be s8
     s8 option_EnableBGM;
     s8 option_EnableSFX;
+    s8 option_SilenceNavi;
 } ExtSaveData;
 
 #ifdef DECLARE_EXTSAVEDATA


### PR DESCRIPTION
Prevents Navi from alerting the player with advice by halting the increase of the navi timer. If Navi has yet to give advice, the timer will also be set back to 0. Disabling the option will make the message re-appear after 15 seconds. 
If the option is enabled after Navi has alerted the player but is awaiting input to say the message, the alert will simply disappear. 
It's set to `Off` by default.
