### PR TITLE
Fix ER glitches with Epona

### DIFF
--- a/code/include/z3D/z3D.h
+++ b/code/include/z3D/z3D.h
@@ -10,8 +10,9 @@
 // #include "hid.h"
 
 typedef struct {
-    /* 0x00 */ u8 buttonItems[5]; //B,Y,X,I,II
-    /* 0x05 */ u8 buttonSlots[4]; //Y,X,I,II
+    /* 0x00 */ u8  buttonItems[5]; //B,Y,X,I,II
+    /* 0x05 */ u8  buttonSlots[4]; //Y,X,I,II
+    /* 0x09 */ u8  unk_09;
     /* 0x0A */ u16 equipment;
 } ItemEquips; // size = 0x0C
 
@@ -415,10 +416,12 @@ typedef struct GlobalContext {
 _Static_assert(sizeof(GlobalContext) == 0x5F14, "Global Context size");
 
 typedef struct StaticContext {
-    /* 0x0000 */ char unk_0[0x0E72];
-    /* 0x0E72 */ u16 collisionDisplay;
+    /* 0x0000 */ char unk_0[0x0E60];
+    /* 0x0E60 */ u16  spawnOnEpona;
+    /* 0x0E62 */ char unk_E72[0x0010];
+    /* 0x0E72 */ u16  collisionDisplay;
     /* 0x0E74 */ char unk_E74[0x015C];
-    /* 0x0FD0 */ u16 renderGeometryDisable;
+    /* 0x0FD0 */ u16  renderGeometryDisable;
     /* 0x0FD2 */ char unk_FD2[0x0602];
 } StaticContext; //size 0x15D4
 // _Static_assert(sizeof(StaticContext) == 0x15D4, "Static Context size");

--- a/code/oot.ld
+++ b/code/oot.ld
@@ -1068,6 +1068,10 @@ SECTIONS
 		*(.patch_GetCustomMessageTextTwo)
 	}
 
+	.patch_GameplayDestroy 0x44E294 : {
+		*(.patch_GameplayDestroy)
+	}
+
 	.patch_ExtendedObjectClear 0x44E754 : {
 		*(.patch_ExtendedObjectClear)
 	}

--- a/code/src/entrance.c
+++ b/code/src/entrance.c
@@ -338,6 +338,18 @@ u8 EntranceCutscene_ShouldPlay(u8 flag) {
     return 0; //cutscene will not play
 }
 
+void Entrance_CheckEpona() {
+    s32 entrance = gSaveContext.entranceIndex;
+    s8 dest = gEntranceTable[entrance].scene;
+    //If Link is riding Epona but he's about to enter a scene where she can't spawn,
+    //unset the Epona flag to avoid Master glitch, and restore temp B.
+    if (gSettingsContext.shuffleOverworldEntrances && entrance != 0x496 && (PLAYER->stateFlags1 & 0x00800000) &&
+        dest != 81 && dest != 87 && dest != 90 && dest != 95 && dest != 99) {
+        gStaticContext.spawnOnEpona = 0;
+        gSaveContext.equips.buttonItems[0] = gSaveContext.buttonStatus[0]; //"temp B"
+    }
+}
+
 EntranceName entranceNames[] = {
     { 0x0000, "KF" /* > Deku Tree */ , ENTRANCE_GROUP_KOKIRI_FOREST },
     { 0x0209, "Deku Tree" /* > KF */ , ENTRANCE_GROUP_KOKIRI_FOREST },

--- a/code/src/hooks.s
+++ b/code/src/hooks.s
@@ -1102,6 +1102,14 @@ hook_SilenceNavi:
     cmp r0,r2
     bx lr
 
+.global hook_GameplayDestroy
+hook_GameplayDestroy:
+    cpy r4,r0
+    push {r0-r12, lr}
+    bl Entrance_CheckEpona
+    pop {r0-r12, lr}
+    bx lr
+
 .section .loader
 .global hook_into_loader
 hook_into_loader:

--- a/code/src/patches.s
+++ b/code/src/patches.s
@@ -1677,6 +1677,11 @@ SkipJabuOpeningCutscene_patch:
 SilenceNavi_patch:
     bl hook_SilenceNavi
 
+.section .patch_GameplayDestroy
+.global GameplayDestroy_patch
+GameplayDestroy_patch:
+    bl hook_GameplayDestroy
+
 .section .patch_loader
 .global loader_patch
 


### PR DESCRIPTION
This fixes the problems caused by entering a loading zone on Epona in Entrance Randomizer:
- if Epona can't appear at the destination, the flag to spawn on Epona is cleared. This basically patches out the Master glitch, so you don't accidentally softlock by spawning on Epona in weird locations, but the trick can still be intentionally performed by glitching into the Thieves' Hideout loading zone, like in the vanilla game.
- if the destination is underwater, the sword will now be restored to the B button correctly.