### PR TITLE
Make Boomerang room accessible after Ruto disappears

### DIFF
--- a/code/include/z3D/z3D.h
+++ b/code/include/z3D/z3D.h
@@ -12,7 +12,6 @@
 typedef struct {
     /* 0x00 */ u8  buttonItems[5]; //B,Y,X,I,II
     /* 0x05 */ u8  buttonSlots[4]; //Y,X,I,II
-    /* 0x09 */ u8  unk_09;
     /* 0x0A */ u16 equipment;
 } ItemEquips; // size = 0x0C
 

--- a/code/oot.ld
+++ b/code/oot.ld
@@ -80,6 +80,10 @@ SECTIONS
 		*(.patch_SongOfStormsLocation)
 	}
 
+	.patch_JabuSwitchRutoCheck 0x143AC8 : {
+	  *(.patch_JabuSwitchRutoCheck)
+	}
+
 	.patch_OwlMagicCheck 0x144B44 : {
 		*(.patch_OwlMagicCheck)
 	}
@@ -494,6 +498,10 @@ SECTIONS
 
 	.patch_DungeonCheckJabuMQBox 0x21590C : {
 	  *(.patch_DungeonCheckJabuMQBox)
+	}
+
+	.patch_JabuBoxCheckRuto 0x215934 : {
+	  *(.patch_JabuBoxCheckRuto)
 	}
 
 	.patch_DekuTheaterMaskOfTruth 0x21CA30 : {

--- a/code/src/hooks.s
+++ b/code/src/hooks.s
@@ -519,7 +519,23 @@ hook_CheckDekuTreeClear:
 hook_CheckCurrentDungeonMode:
     push {r0-r12, lr}
     bl Dungeon_GetCurrentDungeonMode
-    cmp r0,#0x1
+    cmp r0,#0x0
+    pop {r0-r12, lr}
+    bx lr
+
+.global hook_JabuSwitchRutoCheck
+hook_JabuSwitchRutoCheck:
+    cmp r0,#0xA1
+    bxeq lr
+    cmp r0,#0x110
+    bx lr
+
+.global hook_JabuBoxCheckRuto
+hook_JabuBoxCheckRuto:
+    tst r0,#0x80
+    push {r0-r12, lr}
+    bleq ObjKibako_CheckRuto
+    cmpeq r0,#0x0
     pop {r0-r12, lr}
     bx lr
 

--- a/code/src/jabu.c
+++ b/code/src/jabu.c
@@ -5,3 +5,9 @@ void Jabu_SkipOpeningCutscene(void) {
     gGlobalContext->sceneLoadFlag = 0x14;
     gGlobalContext->fadeOutTransition = 2;
 }
+
+// Used to make the small crate appear after Ruto gets the sapphire
+// By default it would appear only after beating the dungeon
+s32 ObjKibako_CheckRuto(void) {
+    return gSaveContext.infTable[0x14] & 0x20;
+}

--- a/code/src/patches.s
+++ b/code/src/patches.s
@@ -1097,6 +1097,17 @@ DoorOfTimeOpenCutscene_patch:
 .global DungeonCheckJabuMQBox_patch
 DungeonCheckJabuMQBox_patch:
     bl hook_CheckCurrentDungeonMode
+    nop
+
+.section .patch_JabuSwitchRutoCheck
+.global JabuSwitchRutoCheck_patch
+JabuSwitchRutoCheck_patch:
+    bl hook_JabuSwitchRutoCheck
+
+.section .patch_JabuBoxCheckRuto
+.global JabuBoxCheckRuto_patch
+JabuBoxCheckRuto_patch:
+    bl hook_JabuBoxCheckRuto
 
 .section .patch_TalonGetCastleTextbox
 .global TalonGetCastleTextbox_patch

--- a/code/src/savefile.c
+++ b/code/src/savefile.c
@@ -43,7 +43,7 @@ void SaveFile_Init(u32 fileBaseIndex) {
     gSaveContext.cutsceneIndex = 0;          //no intro cutscene
     gSaveContext.infTable   [0x0] |= 0x01;   //greeted by Saria
     gSaveContext.infTable  [0x11] |= 0x0400; //Met Darunia in Fire Temple
-    gSaveContext.infTable  [0x14] |= 0x000E; //Ruto in Jabu can be escorted immediately
+    gSaveContext.infTable  [0x14] |= 0x0016; //Ruto in Jabu can be escorted immediately, skip cutscene entering Big Octo room
     gSaveContext.infTable  [0x19] |= 0x0100; //Picked up Magic Container
     gSaveContext.infTable  [0x19] |= 0x0020; //Talked to owl in Lake Hylia
     gSaveContext.itemGetInf [0x1] |= 0x0008; //Picked up Deku Seeds


### PR DESCRIPTION
The switch in the forked room that usually requires Ruto can now be pressed with the wooden box instead. The box only spawns after Ruto becomes unavailable, either by beating the dungeon or throwing her on the Big Octo platform.
Also, one additional flag is set on file creation to skip the small cutscene when Link enters the Big Octo room and Ruto tells him to throw her on the platform.


https://user-images.githubusercontent.com/82058772/140628898-9bd572c8-0ddb-4f77-9034-e8d1600e1633.mp4