### PR TITLE
Fix MQ chest locations showing up on vanilla dungeon maps and vice versa

### DIFF
--- a/code/src/hooks.s
+++ b/code/src/hooks.s
@@ -519,6 +519,14 @@ hook_CheckDekuTreeClear:
 hook_CheckCurrentDungeonMode:
     push {r0-r12, lr}
     bl Dungeon_GetCurrentDungeonMode
+    cmp r0,#0x1
+    pop {r0-r12, lr}
+    bx lr
+
+.global hook_DungeonCheckJabuMQBox
+hook_DungeonCheckJabuMQBox:
+    push {r0-r12, lr}
+    bl Dungeon_GetCurrentDungeonMode
     cmp r0,#0x0
     pop {r0-r12, lr}
     bx lr

--- a/code/src/patches.s
+++ b/code/src/patches.s
@@ -1096,7 +1096,7 @@ DoorOfTimeOpenCutscene_patch:
 .section .patch_DungeonCheckJabuMQBox
 .global DungeonCheckJabuMQBox_patch
 DungeonCheckJabuMQBox_patch:
-    bl hook_CheckCurrentDungeonMode
+    bl hook_DungeonCheckJabuMQBox
     nop
 
 .section .patch_JabuSwitchRutoCheck


### PR DESCRIPTION
The hook to check for the the current dungeon mode was being used by the patches for both the Jabu MQ boxes and the chest locations on the map, but needed to be split up for both to work properly.