### PR TITLE
More temporary music shuffle fixes

### DIFF
--- a/code/src/sfx.c
+++ b/code/src/sfx.c
@@ -7,12 +7,13 @@
 SFXData rSfxData = {0};
 
 u32 SetSFX(u32 original) {
-    if (!gExtSaveData.option_EnableSFX && IsInGame()) {
-        return SEQ_AUDIO_BLANK;
-    }
-
     u16 sfxID = original - SFX_BASE;
     SeqType type = rSfxData.rSeqTypesSFX[sfxID];
+
+    static const u16 GET_BOXITEM_ID = 1205; // Treat GET_BOXITEM as a fanfare
+    if (IsInGame() && ((!gExtSaveData.option_EnableSFX && sfxID != GET_BOXITEM_ID) || (!gExtSaveData.option_EnableBGM && sfxID == GET_BOXITEM_ID))) {
+        return SEQ_AUDIO_BLANK;
+    }
 
     // Check for invalid sound effect
     if (original < SFX_BASE || original > SFX_BASE + SFX_COUNT || type >= SEQTYPE_COUNT) {

--- a/source/music.cpp
+++ b/source/music.cpp
@@ -36,7 +36,7 @@ namespace Music {
         /* NA_BGM_OCA_WATER */          SEQ_OCARINA,
         /* NA_BGM_OCA_SOUL */           SEQ_OCARINA,
         /* NA_BGM_OCA_DARKNESS */       SEQ_OCARINA,
-        /* NA_BGM_MIDDLE_BOSS */        SEQ_NOSHUFFLE, // Temporarily unshuffled: Override keeps playing even after the fight is over
+        /* NA_BGM_MIDDLE_BOSS */        SEQ_BGM_ERROR,
         /* NA_BGM_S_ITEM_GET */         SEQ_FANFARE,
         /* NA_BGM_SHRINE_OF_TIME */     SEQ_BGM_WORLD,
         /* NA_BGM_EVENT_CLEAR */        SEQ_FANFARE,
@@ -88,7 +88,7 @@ namespace Music {
         /* NA_BGM_STAFF_3 */            SEQ_NOSHUFFLE,
         /* NA_BGM_STAFF_4 */            SEQ_NOSHUFFLE,
         /* NA_BGM_BOSS01 */             SEQ_BGM_BATTLE,
-        /* NA_BGM_MINI_GAME_2 */        SEQ_BGM_EVENT,
+        /* NA_BGM_MINI_GAME_2 */        SEQ_BGM_ERROR,
     };
 
     std::array<u32, SEQ_COUNT> seqOverridesMusic;

--- a/source/music.hpp
+++ b/source/music.hpp
@@ -16,6 +16,10 @@ namespace Music {
         SEQ_BGM_BATTLE = 1 << 2,
         SEQ_OCARINA    = 1 << 3,
         SEQ_FANFARE    = 1 << 4,
+        // A soundtrack in this category has the issue where if another soundtrack that isn't
+        // in this category overrides it, it will keep playing when it should be stopped.
+        // For example when beating a mini-boss or finishing the zora diving game.
+        SEQ_BGM_ERROR  = 1 << 5,
     };
 
     extern const std::array<SeqType, SEQ_COUNT> seqTypesMusic;

--- a/source/settings.cpp
+++ b/source/settings.cpp
@@ -2007,6 +2007,7 @@ namespace Settings {
         Music::ShuffleSequences(Music::SeqType::SEQ_BGM_BATTLE);
       } else if (ShuffleBGM.Is(2)) {
         Music::ShuffleSequences(Music::SeqType::SEQ_BGM_WORLD | Music::SeqType::SEQ_BGM_EVENT | Music::SeqType::SEQ_BGM_BATTLE);
+        Music::ShuffleSequences(Music::SeqType::SEQ_BGM_ERROR);
       }
 
       if (ShuffleFanfares.Is(2)) {


### PR DESCRIPTION
Shuffles the middle boss and minigame 2 music together as they have the same issue of continuing to play when they should be cancelled, but when replacing each other they get stopped correctly.
