### PR TITLE
Bug fixes and adjustments

### DIFF
--- a/code/oot.ld
+++ b/code/oot.ld
@@ -456,20 +456,12 @@ SECTIONS
 		*(.patch_BombchuBowlingStaticReward)
 	}
 
-	.patch_SkipSongReplayForTimeBlocksOne 0x207FD8 : {
-		*(.patch_SkipSongReplayForTimeBlocksOne)
+	.patch_SkipSongReplays_TimeBlocksFix 0x208004 : {
+		*(.patch_SkipSongReplays_TimeBlocksFix)
 	}
 
-	.patch_SkipSongReplayForTimeBlocksTwo 0x207FF8 : {
-		*(.patch_SkipSongReplayForTimeBlocksTwo)
-	}
-
-	.patch_SkipSongReplayForTimeWarpBlocksOne 0x20803C : {
-		*(.patch_SkipSongReplayForTimeWarpBlocksOne)
-	}
-
-	.patch_SkipSongReplayForTimeWarpBlocksTwo 0x20805C : {
-		*(.patch_SkipSongReplayForTimeWarpBlocksTwo)
+	.patch_SkipSongReplays_WarpBlocksFix 0x208068 : {
+		*(.patch_SkipSongReplays_WarpBlocksFix)
 	}
 
 	.patch_ShopItemDontSetAnimSpeedOne 0x2101BC : {

--- a/code/src/actor.c
+++ b/code/src/actor.c
@@ -36,6 +36,7 @@
 #include "item_override.h"
 #include "songs_visual_effects.h"
 #include "shooting_gallery_man.h"
+#include "malon.h"
 
 #define OBJECT_GI_KEY 170
 #define OBJECT_GI_BOSSKEY 185
@@ -89,6 +90,8 @@ void Actor_Init() {
     gActorOverlayTable[0xDC].initInfo->update = Boss_Tw_rUpdate;
     gActorOverlayTable[0xDC].initInfo->draw = Boss_Tw_rDraw;
     gActorOverlayTable[0xDC].initInfo->destroy = Boss_Tw_rDestroy;
+
+    gActorOverlayTable[0xE7].initInfo->init = EnMa1_rInit;
 
     gActorOverlayTable[0xF1].initInfo->init = ItemOcarina_rInit;
     gActorOverlayTable[0xF1].initInfo->destroy = ItemOcarina_rDestroy;

--- a/code/src/actor.c
+++ b/code/src/actor.c
@@ -37,6 +37,7 @@
 #include "songs_visual_effects.h"
 #include "shooting_gallery_man.h"
 #include "malon.h"
+#include "jabu.h"
 
 #define OBJECT_GI_KEY 170
 #define OBJECT_GI_BOSSKEY 185
@@ -90,6 +91,8 @@ void Actor_Init() {
     gActorOverlayTable[0xDC].initInfo->update = Boss_Tw_rUpdate;
     gActorOverlayTable[0xDC].initInfo->draw = Boss_Tw_rDraw;
     gActorOverlayTable[0xDC].initInfo->destroy = Boss_Tw_rDestroy;
+
+    gActorOverlayTable[0xE6].initInfo->init = BgBdanSwitch_rInit;
 
     gActorOverlayTable[0xE7].initInfo->init = EnMa1_rInit;
 

--- a/code/src/hooks.s
+++ b/code/src/hooks.s
@@ -968,6 +968,30 @@ hook_TurboTextSignalNPC:
     movne r4,#0x1
     bx lr
 
+.global hook_SkipSongReplays_TimeBlocksFix
+hook_SkipSongReplays_TimeBlocksFix:
+    bne 0x208008
+    push  {r0-r12, lr}
+    bl Settings_GetSongReplaysOption
+    cmp r0,#0x0
+    pop {r0-r12, lr}
+    moveq r1,#0x6E
+    movne r1,#0x10
+    cmp r0,r0
+    b 0x208008
+
+.global hook_SkipSongReplays_WarpBlocksFix
+hook_SkipSongReplays_WarpBlocksFix:
+    bne 0x20806C
+    push  {r0-r12, lr}
+    bl Settings_GetSongReplaysOption
+    cmp r0,#0x0
+    pop {r0-r12, lr}
+    moveq r1,#0x6E
+    movne r1,#0x10
+    cmp r0,r0
+    b 0x20806C
+
 .global hook_CarpenterBossSetTradedSawFlag
 hook_CarpenterBossSetTradedSawFlag:
     push {r0-r12, lr}

--- a/code/src/hooks.s
+++ b/code/src/hooks.s
@@ -968,32 +968,6 @@ hook_TurboTextSignalNPC:
     movne r4,#0x1
     bx lr
 
-.global hook_SkipSongReplayForTimeBlocksOne
-hook_SkipSongReplayForTimeBlocksOne:
-    add r1,r1,#0x2B00
-    push {r0-r12, lr}
-    bl Settings_GetSongReplaysOption
-    cmp r0,#0x0
-    pop {r0-r12, lr}
-    beq 0x207FDC
-    push {r0,r1}
-    sub r1,r1,#0x70
-    ldrb r0,[r1]
-    cmp r0,#23
-    pop {r0,r1}
-    bne 0x208030
-    b 0x207FDC
-
-.global hook_SkipSongReplayForTimeBlocksTwo
-hook_SkipSongReplayForTimeBlocksTwo:
-    push {r0-r12, lr}
-    bl Settings_GetSongReplaysOption
-    cmp r0,#0x0
-    pop {r0-r12, lr}
-    bne 0x208028
-    add r0,r0,#0x100
-    b 0x207FFC
-
 .global hook_CarpenterBossSetTradedSawFlag
 hook_CarpenterBossSetTradedSawFlag:
     push {r0-r12, lr}
@@ -1009,32 +983,6 @@ hook_KingZoraSetTradedPrescriptionFlag:
     pop {r0-r12, lr}
     mov r2,#0x24
     b 0x1C52A4
-
-.global hook_SkipSongReplayForTimeWarpBlocksOne
-hook_SkipSongReplayForTimeWarpBlocksOne:
-    add r1,r1,#0x2B00
-    push {r0-r12, lr}
-    bl Settings_GetSongReplaysOption
-    cmp r0,#0x0
-    pop {r0-r12, lr}
-    beq 0x208040
-    push {r0,r1}
-    sub r1,r1,#0x70
-    ldrb r0,[r1]
-    cmp r0,#23
-    pop {r0,r1}
-    bne 0x208094
-    b 0x208040
-
-.global hook_SkipSongReplayForTimeWarpBlocksTwo
-hook_SkipSongReplayForTimeWarpBlocksTwo:
-    push {r0-r12, lr}
-    bl Settings_GetSongReplaysOption
-    cmp r0,#0x0
-    pop {r0-r12, lr}
-    bne 0x20808C
-    add r0,r0,#0x100
-    b 0x208060
 
 .global hook_SyatekiManReminder
 hook_SyatekiManReminder:

--- a/code/src/jabu.c
+++ b/code/src/jabu.c
@@ -1,5 +1,9 @@
 #include "z3D/z3D.h"
+#include "settings.h"
 #include "entrance.h"
+
+#define BgBdanSwitch_Init_addr 0x276508
+#define BgBdanSwitch_Init ((ActorFunc)BgBdanSwitch_Init_addr)
 
 void Jabu_SkipOpeningCutscene(void) {
     gGlobalContext->nextEntranceIndex = Entrance_OverrideNextIndex(0x0028);
@@ -11,4 +15,15 @@ void Jabu_SkipOpeningCutscene(void) {
 // By default it would appear only after beating the dungeon
 s32 ObjKibako_CheckRuto(void) {
     return gSaveContext.infTable[0x14] & 0x20;
+}
+
+void BgBdanSwitch_rInit(Actor* thisx, GlobalContext* globalCtx) {
+    // In MQ Jabu, spawn a box if Ruto isn't available in the basement room
+    if((gSaveContext.infTable[0x14] & 0x20 || gSaveContext.eventChkInf[3] & 0x0080) &&
+        gSettingsContext.jabuJabusBellyDungeonMode == DUNGEONMODE_MQ && globalCtx->sceneNum == 2 &&
+        thisx->room == 3 && ((thisx->params & 0x000F) == 0)
+      ) {
+        Actor_Spawn(&globalCtx->actorCtx, globalCtx, 0x110, 222.0f, -1113.0f, -3270.0f, 0, 0, 0, 0);
+    }
+    BgBdanSwitch_Init(thisx, globalCtx);
 }

--- a/code/src/jabu.h
+++ b/code/src/jabu.h
@@ -1,0 +1,8 @@
+#ifndef _JABU_OBJECTS_H_
+#define _JABU_OBJECTS_H_
+
+#include "z3D/z3D.h"
+
+void BgBdanSwitch_rInit(Actor* thisx, GlobalContext* globalCtx);
+
+#endif //_JABU_OBJECTS_H_

--- a/code/src/malon.c
+++ b/code/src/malon.c
@@ -1,0 +1,11 @@
+#include "malon.h"
+
+#define EnMa1_Init_addr 0x18C334
+#define EnMa1_Init ((ActorFunc)EnMa1_Init_addr)
+
+void EnMa1_rInit(Actor* thisx, GlobalContext* globalCtx) {
+    if (gSaveContext.eventChkInf[0x1] & 0x0001) { //If Talon has fled the castle...
+        gSaveContext.eventChkInf[0x1] |= 0x0040;  //...set "Invited to Sing With Child Malon" flag
+    }
+    EnMa1_Init(thisx, globalCtx);
+}

--- a/code/src/malon.h
+++ b/code/src/malon.h
@@ -1,0 +1,8 @@
+#ifndef _MALON_H_
+#define _MALON_H_
+
+#include "z3D/z3D.h"
+
+void EnMa1_rInit(Actor* thisx, GlobalContext* globalCtx);
+
+#endif //_MALON_H_

--- a/code/src/patches.s
+++ b/code/src/patches.s
@@ -1456,7 +1456,7 @@ TurboTextSignalNPC_patch:
 .section .patch_SkipSongReplays_TimeBlocksFix
 .global SkipSongReplays_TimeBlocksFix_patch
 SkipSongReplays_TimeBlocksFix_patch:
-    moveq r1,#0x1
+    b hook_SkipSongReplays_TimeBlocksFix
 
 .section .patch_ItemsMenuNumSprites
 .global ItemsMenuNumSprites_patch
@@ -1560,7 +1560,7 @@ CheckForPocketCuccoHatchKankyo_patch:
 .section .patch_SkipSongReplays_WarpBlocksFix
 .global SkipSongReplays_WarpBlocksFix_patch
 SkipSongReplays_WarpBlocksFix_patch:
-    moveq r1,#0x1
+    b hook_SkipSongReplays_WarpBlocksFix
 
 .section .patch_PlaySound
 .global PlaySound_patch

--- a/code/src/patches.s
+++ b/code/src/patches.s
@@ -1453,15 +1453,10 @@ TurboTextClose_patch:
 TurboTextSignalNPC_patch:
     bl hook_TurboTextSignalNPC
 
-.section .patch_SkipSongReplayForTimeBlocksOne
-.global SkipSongReplayForTimeBlocksOne_patch
-SkipSongReplayForTimeBlocksOne_patch:
-    b hook_SkipSongReplayForTimeBlocksOne
-
-.section .patch_SkipSongReplayForTimeBlocksTwo
-.global SkipSongReplayForTimeBlocksTwo_patch
-SkipSongReplayForTimeBlocksTwo_patch:
-    b hook_SkipSongReplayForTimeBlocksTwo
+.section .patch_SkipSongReplays_TimeBlocksFix
+.global SkipSongReplays_TimeBlocksFix_patch
+SkipSongReplays_TimeBlocksFix_patch:
+    moveq r1,#0x1
 
 .section .patch_ItemsMenuNumSprites
 .global ItemsMenuNumSprites_patch
@@ -1562,15 +1557,10 @@ CheckForPocketCuccoHatchGameplayInit_patch:
 CheckForPocketCuccoHatchKankyo_patch:
     bl SaveFile_CheckForPocketCuccoHatch
 
-.section .patch_SkipSongReplayForTimeWarpBlocksOne
-.global SkipSongReplayForTimeWarpBlocksOne_patch
-SkipSongReplayForTimeWarpBlocksOne_patch:
-    b hook_SkipSongReplayForTimeWarpBlocksOne
-
-.section .patch_SkipSongReplayForTimeWarpBlocksTwo
-.global SkipSongReplayForTimeWarpBlocksTwo_patch
-SkipSongReplayForTimeWarpBlocksTwo_patch:
-    b hook_SkipSongReplayForTimeWarpBlocksTwo
+.section .patch_SkipSongReplays_WarpBlocksFix
+.global SkipSongReplays_WarpBlocksFix_patch
+SkipSongReplays_WarpBlocksFix_patch:
+    moveq r1,#0x1
 
 .section .patch_PlaySound
 .global PlaySound_patch

--- a/source/hint_list.cpp
+++ b/source/hint_list.cpp
@@ -156,7 +156,7 @@ void HintTable_Init() {
                      }, {
                        //ambiguous text
                        Text{"some boots", /*french*/"une paire de bottes", /*spanish*/"un par de botas"},
-                       Text{"a feature of the Water Temple", /*french*/"une particularité du temple de l’eau", /*spanish*/"algo particular del Templo del Agua"},
+                       Text{"a feature of the Water Temple", /*french*/"une particularité du temple de l'eau", /*spanish*/"algo particular del Templo del Agua"},
                        Text{"something heavy", /*french*/"une chose pesante", /*spanish*/"algo de lo más pesado"},
                      },
                        //clear text
@@ -259,7 +259,7 @@ void HintTable_Init() {
                        Text{"a red ball",  /*french*/"une explosion de flammes", /*spanish*/"una roja esfera"},
                      }, {
                        //ambiguous text
-                       Text{"a Great Fairy’s power", /*french*/"le pouvoir d’une grande fée", /*spanish*/"el poder de una Gran Hada"},
+                       Text{"a Great Fairy's power", /*french*/"le pouvoir d'une grande fée", /*spanish*/"el poder de una Gran Hada"},
                      },
                        //clear text
                        Text{"Din's Fire", /*french*/"le feu de Din", /*spanish*/"el Fuego de Din"}
@@ -272,7 +272,7 @@ void HintTable_Init() {
                        Text{"a green ball",      /*french*/"une boule verte",        /*spanish*/"una verde esfera"},
                      }, {
                        //ambiguous text
-                       Text{"a Great Fairy’s power", /*french*/"le pouvoir d’une grande fée", /*spanish*/"el poder de una Gran Hada"},
+                       Text{"a Great Fairy's power", /*french*/"le pouvoir d'une grande fée", /*spanish*/"el poder de una Gran Hada"},
                      },
                        //clear text
                        Text{"Farore's Wind", /*french*/"le vent de Farore", /*spanish*/"el Viento de Farore"}
@@ -285,7 +285,7 @@ void HintTable_Init() {
                        Text{"a blue barrier",      /*french*/"une toison bleu",      /*spanish*/"una barrera azul"},
                      }, {
                        //ambiguous text
-                       Text{"a Great Fairy’s power", /*french*/"le pouvoir d’une grande fée", /*spanish*/"el poder de una Gran Hada"},
+                       Text{"a Great Fairy's power", /*french*/"le pouvoir d'une grande fée", /*spanish*/"el poder de una Gran Hada"},
                      },
                        //clear text
                        Text{"Nayru's Love", /*french*/"l'amour de Nayru", /*spanish*/"el Amor de Nayru"}
@@ -372,7 +372,7 @@ void HintTable_Init() {
                        Text{"strengthened love", /*french*/"un amour coriace",              /*spanish*/"un amor fortalecido"},
                      }, {
                        //ambiguous text
-                       Text{"a Great Fairy’s power", /*french*/"le pouvoir d’une grande fée", /*spanish*/"el poder de una Gran Hada"},
+                       Text{"a Great Fairy's power", /*french*/"le pouvoir d'une grande fée", /*spanish*/"el poder de una Gran Hada"},
                        Text{"something heart-shaped", /*french*/"une chose en forme de cœur", /*spanish*/"algo con forma de corazón"},
                      },
                        //clear text
@@ -401,7 +401,7 @@ void HintTable_Init() {
                        Text{"a fowl youth",        /*french*/"une omelette crue",      /*spanish*/"una dulce juventud"},
                      }, {
                        //ambiguous text
-                       Text{"a trade quest item", /*french*/"un objet de quête d’échanges", /*spanish*/"un objeto de una misión secundaria"},
+                       Text{"a trade quest item", /*french*/"un objet de quête d'échanges", /*spanish*/"un objeto de una misión secundaria"},
                        Text{"an egg", /*french*/"un oeuf", /*spanish*/"un huevo"},
                      },
                        //clear text
@@ -413,7 +413,7 @@ void HintTable_Init() {
                        Text{"a little clucker", /*french*/"un petit glousseur", /*spanish*/"un pollito chiquito"},
                      }, {
                        //ambiguous text
-                       Text{"a trade quest item", /*french*/"un objet de quête d’échanges", /*spanish*/"un objeto de una misión secundaria"},
+                       Text{"a trade quest item", /*french*/"un objet de quête d'échanges", /*spanish*/"un objeto de una misión secundaria"},
                      },
                        //clear text
                        Text{"the Pocket Cucco", /*french*/"le Cocotte de poche", /*spanish*/"el cuco de bolsillo"}
@@ -424,7 +424,7 @@ void HintTable_Init() {
                        Text{"a cerulean capon", /*french*/"un paon azur", /*spanish*/"un cerúleo capón"},
                      }, {
                        //ambiguous text
-                       Text{"a trade quest item", /*french*/"un objet de quête d’échanges", /*spanish*/"un objeto de una misión secundaria"},
+                       Text{"a trade quest item", /*french*/"un objet de quête d'échanges", /*spanish*/"un objeto de una misión secundaria"},
                      },
                        //clear text
                        Text{"Cojiro", /*french*/"le p'tit poulet", /*spanish*/"a Cojiro"}
@@ -435,7 +435,7 @@ void HintTable_Init() {
                        Text{"a powder ingredient", /*french*/"un ingrédient à poudre", /*spanish*/"un oloroso ingrediente"},
                      }, {
                        //ambiguous text
-                       Text{"a trade quest item", /*french*/"un objet de quête d’échanges", /*spanish*/"un objeto de una misión secundaria"},
+                       Text{"a trade quest item", /*french*/"un objet de quête d'échanges", /*spanish*/"un objeto de una misión secundaria"},
                      },
                        //clear text
                        Text{"an Odd Mushroom", /*french*/"un champignon suspect", /*spanish*/"un champiñón extraño"}
@@ -448,7 +448,7 @@ void HintTable_Init() {
                        //ambiguous text
                        Text{"something that contains medicine", /*french*/"une chose médicamenteuse", /*spanish*/"algo que contenga medicina"},
                        Text{"something with a strange smell", /*french*/"une chose qui sent bizarre", /*spanish*/"algo con un olor extraño"},
-                       Text{"a trade quest item", /*french*/"un objet de quête d’échanges", /*spanish*/"un objeto de una misión secundaria"},
+                       Text{"a trade quest item", /*french*/"un objet de quête d'échanges", /*spanish*/"un objeto de una misión secundaria"},
                      },
                        //clear text
                        Text{"an Odd Poultice", /*french*/"une mixture suspecte", /*spanish*/"una medicina rara"}
@@ -459,7 +459,7 @@ void HintTable_Init() {
                        Text{"a tree killer", /*french*/"un coupeur d'arbres", /*spanish*/"un destructor de árboles"},
                      }, {
                        //ambiguous text
-                       Text{"a trade quest item", /*french*/"un objet de quête d’échanges", /*spanish*/"un objeto de una misión secundaria"},
+                       Text{"a trade quest item", /*french*/"un objet de quête d'échanges", /*spanish*/"un objeto de una misión secundaria"},
                      },
                        //clear text
                        Text{"the Poacher's Saw", /*french*/"la scie du chasseur", /*spanish*/"la sierra del furtivo"}
@@ -470,7 +470,7 @@ void HintTable_Init() {
                        Text{"a shattered slicer", /*french*/"une arme cassée", /*spanish*/"una rebanadora rota"},
                      }, {
                        //ambiguous text
-                       Text{"a trade quest item", /*french*/"un objet de quête d’échanges", /*spanish*/"un objeto de una misión secundaria"},
+                       Text{"a trade quest item", /*french*/"un objet de quête d'échanges", /*spanish*/"un objeto de una misión secundaria"},
                        Text{"a sword", /*french*/"une épée", /*spanish*/"una espada"},
                      },
                        //clear text
@@ -483,7 +483,7 @@ void HintTable_Init() {
                        Text{"a doctor's note", /*french*/"un papier médical",  /*spanish*/"unas notas del doctor"},
                      }, {
                        //ambiguous text
-                       Text{"a trade quest item", /*french*/"un objet de quête d’échanges", /*spanish*/"un objeto de una misión secundaria"},
+                       Text{"a trade quest item", /*french*/"un objet de quête d'échanges", /*spanish*/"un objeto de una misión secundaria"},
                      },
                        //clear text
                        Text{"the Prescription", /*french*/"une ordonnance", /*spanish*/"la receta"}
@@ -494,7 +494,7 @@ void HintTable_Init() {
                        Text{"a perceiving polliwog", /*french*/"un amphibien", /*spanish*/"un variopinto batracio"},
                      }, {
                        //ambiguous text
-                       Text{"a trade quest item", /*french*/"un objet de quête d’échanges", /*spanish*/"un objeto de una misión secundaria"},
+                       Text{"a trade quest item", /*french*/"un objet de quête d'échanges", /*spanish*/"un objeto de una misión secundaria"},
                      },
                        //clear text
                        Text{"the Eyeball Frog", /*french*/"le crapaud-qui-louche", /*spanish*/"la rana de ojos saltones"}
@@ -505,7 +505,7 @@ void HintTable_Init() {
                        Text{"a vision vial", /*french*/"une solution oculaire", /*spanish*/"un remedio para la vista"},
                      }, {
                        //ambiguous text
-                       Text{"a trade quest item", /*french*/"un objet de quête d’échanges", /*spanish*/"un objeto de una misión secundaria"},
+                       Text{"a trade quest item", /*french*/"un objet de quête d'échanges", /*spanish*/"un objeto de una misión secundaria"},
                      },
                        //clear text
                        Text{"the Eyedrops", /*french*/"une phiole de super gouttes", /*spanish*/"las supergotas oculares"}
@@ -516,7 +516,7 @@ void HintTable_Init() {
                        Text{"a three day wait", /*french*/"un rendez-vous dans trois jours", /*spanish*/"unos tres días de espera"},
                      }, {
                        //ambiguous text
-                       Text{"a trade quest item", /*french*/"un objet de quête d’échanges", /*spanish*/"un objeto de una misión secundaria"},
+                       Text{"a trade quest item", /*french*/"un objet de quête d'échanges", /*spanish*/"un objeto de una misión secundaria"},
                      },
                        //clear text
                        Text{"the Claim Check", /*french*/"un certificat", /*spanish*/"el recibo"}
@@ -555,7 +555,7 @@ void HintTable_Init() {
                        Text{"a blast bag",            /*french*/"un estomac de Dodongo", /*spanish*/"un zurrón de estallidos"},
                      }, {
                        //ambiguous text
-                       Text{"explosives", /*french*/"un paquet d’explosifs", /*spanish*/"un montón de explosivos"},
+                       Text{"explosives", /*french*/"un paquet d'explosifs", /*spanish*/"un montón de explosivos"},
                        Text{"something that can remove boulders", /*french*/"une chose qui enlève les rochers", /*spanish*/"algo que pueda quitar rocas"},
                      },
                        //clear text
@@ -644,7 +644,7 @@ void HintTable_Init() {
                        Text{"a green rectangle",  /*french*/"un rectangle vert",    /*spanish*/"una verduzca barra"},
                      }, {
                        //ambiguous text
-                       Text{"a Great Fairy’s power", /*french*/"le pouvoir d’une grande fée", /*spanish*/"el poder de una Gran Hada"},
+                       Text{"a Great Fairy's power", /*french*/"le pouvoir d'une grande fée", /*spanish*/"el poder de una Gran Hada"},
                      },
                        //clear text
                        Text{"a Magic Meter", /*french*/"une jauge de magie", /*spanish*/"un aumento de poder mágico"}
@@ -672,7 +672,7 @@ void HintTable_Init() {
                      }, {
                        //ambiguous text
                        Text{"a prize of the House of Skulltulas", /*french*/"un prix de la maison des Skulltulas", /*spanish*/"un obsequio de la Casa Skulltula"},
-                       Text{"explosives", /*french*/"un paquet d’explosifs", /*spanish*/"un montón de explosivos"},
+                       Text{"explosives", /*french*/"un paquet d'explosifs", /*spanish*/"un montón de explosivos"},
                      },
                        //clear text
                        Text{"Bombchus", /*french*/"un paquet de Bombchus", /*spanish*/"unos bombchus"}
@@ -1004,7 +1004,7 @@ void HintTable_Init() {
                         Text{"a dungeon map", /*french*/"une carte", /*spanish*/"un mapa"},
                       },
                         //clear text
-                        Text{"the Deku Tree Map", /*french*/"la carte de l’arbre Mojo", /*spanish*/"el mapa del Gran Árbol Deku"}
+                        Text{"the Deku Tree Map", /*french*/"la carte de l'arbre Mojo", /*spanish*/"el mapa del Gran Árbol Deku"}
      );
     hintTable[DODONGOS_CAVERN_MAP] = HintText::Item({
                         //obscure text
@@ -1015,7 +1015,7 @@ void HintTable_Init() {
                         Text{"a dungeon map", /*french*/"une carte", /*spanish*/"un mapa"},
                       },
                         //clear text
-                        Text{"the Dodongo’s Cavern Map", /*french*/"la carte de la caverne Dodongo", /*spanish*/"el mapa de la Cueva de los Dodongos"}
+                        Text{"the Dodongo's Cavern Map", /*french*/"la carte de la caverne Dodongo", /*spanish*/"el mapa de la Cueva de los Dodongos"}
      );
     hintTable[JABU_JABUS_BELLY_MAP] = HintText::Item({
                         //obscure text
@@ -1026,7 +1026,7 @@ void HintTable_Init() {
                         Text{"a dungeon map", /*french*/"une carte", /*spanish*/"un mapa"},
                       },
                         //clear text
-                        Text{"the Jabu-Jabu’s Belly Map", /*french*/"la carte de Jabu-Jabu", /*spanish*/"el mapa de la Tripa de Jabu-Jabu"}
+                        Text{"the Jabu-Jabu's Belly Map", /*french*/"la carte de Jabu-Jabu", /*spanish*/"el mapa de la Tripa de Jabu-Jabu"}
      );
     hintTable[FOREST_TEMPLE_MAP] = HintText::Item({
                         //obscure text
@@ -1059,7 +1059,7 @@ void HintTable_Init() {
                         Text{"a dungeon map", /*french*/"une carte", /*spanish*/"un mapa"},
                       },
                         //clear text
-                        Text{"the Water Temple Map", /*french*/"la carte du temple de l’eau", /*spanish*/"el mapa del Templo del Agua"}
+                        Text{"the Water Temple Map", /*french*/"la carte du temple de l'eau", /*spanish*/"el mapa del Templo del Agua"}
      );
     hintTable[SPIRIT_TEMPLE_MAP] = HintText::Item({
                         //obscure text
@@ -1070,7 +1070,7 @@ void HintTable_Init() {
                         Text{"a dungeon map", /*french*/"une carte", /*spanish*/"un mapa"},
                       },
                         //clear text
-                        Text{"the Spirit Temple Map", /*french*/"la carte du temple de l’esprit", /*spanish*/"el mapa del Templo del Espíritu"}
+                        Text{"the Spirit Temple Map", /*french*/"la carte du temple de l'esprit", /*spanish*/"el mapa del Templo del Espíritu"}
      );
     hintTable[SHADOW_TEMPLE_MAP] = HintText::Item({
                         //obscure text
@@ -1081,7 +1081,7 @@ void HintTable_Init() {
                         Text{"a dungeon map", /*french*/"une carte", /*spanish*/"un mapa"},
                       },
                         //clear text
-                        Text{"the Shadow Temple Map", /*french*/"la carte du temple de l’ombre", /*spanish*/"el mapa del Templo de las Sombras"}
+                        Text{"the Shadow Temple Map", /*french*/"la carte du temple de l'ombre", /*spanish*/"el mapa del Templo de las Sombras"}
      );
     hintTable[BOTTOM_OF_THE_WELL_MAP] = HintText::Item({
                         //obscure text
@@ -1114,7 +1114,7 @@ void HintTable_Init() {
                         Text{"a compass", /*french*/"une boussole", /*spanish*/"una brújula"},
                       },
                         //clear text
-                        Text{"the Deku Tree Compass", /*french*/"la boussole de l’arbre Mojo", /*spanish*/"la brújula del Gran Árbol Deku"}
+                        Text{"the Deku Tree Compass", /*french*/"la boussole de l'arbre Mojo", /*spanish*/"la brújula del Gran Árbol Deku"}
      );
     hintTable[DODONGOS_CAVERN_COMPASS] = HintText::Item({
                         //obscure text
@@ -1125,7 +1125,7 @@ void HintTable_Init() {
                         Text{"a compass", /*french*/"une boussole", /*spanish*/"una brújula"},
                       },
                         //clear text
-                        Text{"the Dodongo’s Cavern Compass", /*french*/"la boussole de la caverne Dodongo", /*spanish*/"la brújula de la Cueva de los Dodongos"}
+                        Text{"the Dodongo's Cavern Compass", /*french*/"la boussole de la caverne Dodongo", /*spanish*/"la brújula de la Cueva de los Dodongos"}
      );
     hintTable[JABU_JABUS_BELLY_COMPASS] = HintText::Item({
                         //obscure text
@@ -1136,7 +1136,7 @@ void HintTable_Init() {
                         Text{"a compass", /*french*/"une boussole", /*spanish*/"una brújula"},
                       },
                         //clear text
-                        Text{"the Jabu-Jabu’s Belly Compass", /*french*/"la boussole de Jabu-Jabu", /*spanish*/"la brújula de la Tripa de Jabu-Jabu"}
+                        Text{"the Jabu-Jabu's Belly Compass", /*french*/"la boussole de Jabu-Jabu", /*spanish*/"la brújula de la Tripa de Jabu-Jabu"}
      );
     hintTable[FOREST_TEMPLE_COMPASS] = HintText::Item({
                         //obscure text
@@ -1169,7 +1169,7 @@ void HintTable_Init() {
                         Text{"a compass", /*french*/"une boussole", /*spanish*/"una brújula"},
                       },
                         //clear text
-                        Text{"the Water Temple Compass", /*french*/"la boussole du temple de l’eau", /*spanish*/"la brújula del Templo del Agua"}
+                        Text{"the Water Temple Compass", /*french*/"la boussole du temple de l'eau", /*spanish*/"la brújula del Templo del Agua"}
      );
     hintTable[SPIRIT_TEMPLE_COMPASS] = HintText::Item({
                         //obscure text
@@ -1180,7 +1180,7 @@ void HintTable_Init() {
                         Text{"a compass", /*french*/"une boussole", /*spanish*/"una brújula"},
                       },
                         //clear text
-                        Text{"the Spirit Temple Compass", /*french*/"la boussole du temple de l’esprit", /*spanish*/"la brújula del Templo del Espíritu"}
+                        Text{"the Spirit Temple Compass", /*french*/"la boussole du temple de l'esprit", /*spanish*/"la brújula del Templo del Espíritu"}
      );
     hintTable[SHADOW_TEMPLE_COMPASS] = HintText::Item({
                         //obscure text
@@ -1191,7 +1191,7 @@ void HintTable_Init() {
                         Text{"a compass", /*french*/"une boussole", /*spanish*/"una brújula"},
                       },
                         //clear text
-                        Text{"the Shadow Temple Compass", /*french*/"la boussole du temple de l’ombre", /*spanish*/"la brújula del Templo de las Sombras"}
+                        Text{"the Shadow Temple Compass", /*french*/"la boussole du temple de l'ombre", /*spanish*/"la brújula del Templo de las Sombras"}
      );
     hintTable[BOTTOM_OF_THE_WELL_COMPASS] = HintText::Item({
                         //obscure text
@@ -1246,7 +1246,7 @@ void HintTable_Init() {
                         Text{"a boss key", /*french*/"une clé d'or", /*spanish*/"una gran llave"},
                       },
                         //clear text
-                        Text{"the Water Temple Boss Key", /*french*/"la clé d'or du temple de l’eau", /*spanish*/"la gran llave del Templo del Agua"}
+                        Text{"the Water Temple Boss Key", /*french*/"la clé d'or du temple de l'eau", /*spanish*/"la gran llave del Templo del Agua"}
      );
     hintTable[SPIRIT_TEMPLE_BOSS_KEY] = HintText::Item({
                         //obscure text
@@ -1257,7 +1257,7 @@ void HintTable_Init() {
                         Text{"a boss key", /*french*/"une clé d'or", /*spanish*/"una gran llave"},
                       },
                         //clear text
-                        Text{"the Spirit Temple Boss Key", /*french*/"la clé d'or du temple de l’esprit", /*spanish*/"la gran llave del Templo del Espíritu"}
+                        Text{"the Spirit Temple Boss Key", /*french*/"la clé d'or du temple de l'esprit", /*spanish*/"la gran llave del Templo del Espíritu"}
      );
     hintTable[SHADOW_TEMPLE_BOSS_KEY] = HintText::Item({
                         //obscure text
@@ -1268,7 +1268,7 @@ void HintTable_Init() {
                         Text{"a boss key", /*french*/"une clé d'or", /*spanish*/"una gran llave"},
                       },
                         //clear text
-                        Text{"the Shadow Temple Boss Key", /*french*/"la clé d'or du temple de l’ombre", /*spanish*/"la gran llave del Templo de las Sombras"}
+                        Text{"the Shadow Temple Boss Key", /*french*/"la clé d'or du temple de l'ombre", /*spanish*/"la gran llave del Templo de las Sombras"}
      );
     hintTable[GANONS_CASTLE_BOSS_KEY] = HintText::Item({
                         //obscure text
@@ -1279,7 +1279,7 @@ void HintTable_Init() {
                         Text{"a boss key", /*french*/"une clé d'or", /*spanish*/"una gran llave"},
                       },
                         //clear text
-                        Text{"the Ganon’s Castle Boss Key", /*french*/"la clé d'or du château de Ganon", /*spanish*/"la gran llave del Castillo de Ganon"}
+                        Text{"the Ganon's Castle Boss Key", /*french*/"la clé d'or du château de Ganon", /*spanish*/"la gran llave del Castillo de Ganon"}
      );
     hintTable[FOREST_TEMPLE_SMALL_KEY] = HintText::Item({
                         //obscure text
@@ -1318,7 +1318,7 @@ void HintTable_Init() {
                         Text{"a small key", /*french*/"une petite clé", /*spanish*/"una llave pequeña"},
                       },
                         //clear text
-                        Text{"a Water Temple Small Key", /*french*/"une petite clé du temple de l’eau", /*spanish*/"una llave pequeña del Templo del Agua"}
+                        Text{"a Water Temple Small Key", /*french*/"une petite clé du temple de l'eau", /*spanish*/"una llave pequeña del Templo del Agua"}
      );
     hintTable[SPIRIT_TEMPLE_SMALL_KEY] = HintText::Item({
                         //obscure text
@@ -1331,7 +1331,7 @@ void HintTable_Init() {
                         Text{"a small key", /*french*/"une petite clé", /*spanish*/"una llave pequeña"},
                       },
                         //clear text
-                        Text{"a Spirit Temple Small Key", /*french*/"une petite clé du temple de l’esprit", /*spanish*/"una llave pequeña del Templo del Espíritu"}
+                        Text{"a Spirit Temple Small Key", /*french*/"une petite clé du temple de l'esprit", /*spanish*/"una llave pequeña del Templo del Espíritu"}
      );
     hintTable[SHADOW_TEMPLE_SMALL_KEY] = HintText::Item({
                         //obscure text
@@ -1344,7 +1344,7 @@ void HintTable_Init() {
                         Text{"a small key", /*french*/"une petite clé", /*spanish*/"una llave pequeña"},
                       },
                         //clear text
-                        Text{"a Shadow Temple Small Key", /*french*/"une petite clé du temple de l’ombre", /*spanish*/"una llave pequeña del Templo de las Sombras"}
+                        Text{"a Shadow Temple Small Key", /*french*/"une petite clé du temple de l'ombre", /*spanish*/"una llave pequeña del Templo de las Sombras"}
      );
     hintTable[GERUDO_TRAINING_GROUNDS_SMALL_KEY] = HintText::Item({
                         //obscure text
@@ -1396,7 +1396,7 @@ void HintTable_Init() {
                         Text{"a small key", /*french*/"une petite clé", /*spanish*/"una llave pequeña"},
                       },
                         //clear text
-                        Text{"a Ganon’s Castle Small Key", /*french*/"une petite clé du château de Ganon", /*spanish*/"una llave pequeña del Castillo de Ganon"}
+                        Text{"a Ganon's Castle Small Key", /*french*/"une petite clé du château de Ganon", /*spanish*/"una llave pequeña del Castillo de Ganon"}
      );
 
     hintTable[KOKIRI_EMERALD] = HintText::Item({
@@ -1616,7 +1616,7 @@ void HintTable_Init() {
                        Text{"frosty fun",           /*french*/"une engelure",               /*spanish*/"una gélida diversión"},
                      }, {
                        //ambiguous text
-                       Text{"a Great Fairy’s power", /*french*/"le pouvoir d’une grande fée", /*spanish*/"el poder de una Gran Hada"},
+                       Text{"a Great Fairy's power", /*french*/"le pouvoir d'une grande fée", /*spanish*/"el poder de una Gran Hada"},
                        Text{"a magic arrow", /*french*/"une flèche magique", /*spanish*/"una flecha mágica"},
                        Text{"a medallion", /*french*/"un médaillon", /*spanish*/"un medallón"},
                        Text{"a spiritual stone", /*french*/"une pierre spirituelle", /*spanish*/"una piedra espiritual"},
@@ -1634,7 +1634,7 @@ void HintTable_Init() {
                        Text{"a few blast balls", /*french*/"une poignée de boules bleues", /*spanish*/"un par de estallidos"},
                      }, {
                        //ambiguous text
-                       Text{"explosives", /*french*/"un paquet d’explosifs", /*spanish*/"un montón de explosivos"},
+                       Text{"explosives", /*french*/"un paquet d'explosifs", /*spanish*/"un montón de explosivos"},
                      },
                        //clear text
                        Text{"Bombs (5 pieces)", /*french*/"une demi-dizaine de bombes", /*spanish*/"unas (5) bombas"}
@@ -1646,7 +1646,7 @@ void HintTable_Init() {
                        Text{"some blast balls", /*french*/"un paquet de boules bleues", /*spanish*/"unos cuantos estallidos"},
                      }, {
                        //ambiguous text
-                       Text{"explosives", /*french*/"un paquet d’explosifs", /*spanish*/"un montón de explosivos"},
+                       Text{"explosives", /*french*/"un paquet d'explosifs", /*spanish*/"un montón de explosivos"},
                      },
                        //clear text
                        Text{"Bombs (10 pieces)", /*french*/"une dizaine de bombes", /*spanish*/"unas (10) bombas"}
@@ -1658,7 +1658,7 @@ void HintTable_Init() {
                        Text{"plenty of blast balls", /*french*/"une abondance de boules bleues", /*spanish*/"bastantes estallidos"},
                      }, {
                        //ambiguous text
-                       Text{"explosives", /*french*/"un paquet d’explosifs", /*spanish*/"un montón de explosivos"},
+                       Text{"explosives", /*french*/"un paquet d'explosifs", /*spanish*/"un montón de explosivos"},
                      },
                        //clear text
                        Text{"Bombs (20 pieces)", /*french*/"une vingtaine de bombes", /*spanish*/"unas (20) bombas"}
@@ -1673,7 +1673,7 @@ void HintTable_Init() {
                      }, {
                        //ambiguous text
                        Text{"a prize of the House of Skulltulas", /*french*/"un prix de la maison des Skulltulas", /*spanish*/"un obsequio de la Casa Skulltula"},
-                       Text{"explosives", /*french*/"un paquet d’explosifs", /*spanish*/"un montón de explosivos"},
+                       Text{"explosives", /*french*/"un paquet d'explosifs", /*spanish*/"un montón de explosivos"},
                      },
                        //clear text
                        Text{"Bombchus (5 pieces)", /*french*/"une demi-dizaine de Bombchus", /*spanish*/"unos (5) bombchus"}
@@ -1688,7 +1688,7 @@ void HintTable_Init() {
                      }, {
                        //ambiguous text
                        Text{"a prize of the House of Skulltulas", /*french*/"un prix de la maison des Skulltulas", /*spanish*/"un obsequio de la Casa Skulltula"},
-                       Text{"explosives", /*french*/"un paquet d’explosifs", /*spanish*/"un montón de explosivos"},
+                       Text{"explosives", /*french*/"un paquet d'explosifs", /*spanish*/"un montón de explosivos"},
                      },
                        //clear text
                        Text{"Bombchus (10 pieces)", /*french*/"une dizaine de Bombchus", /*spanish*/"unos (10) bombchus"}
@@ -1703,7 +1703,7 @@ void HintTable_Init() {
                      }, {
                        //ambiguous text
                        Text{"a prize of the House of Skulltulas", /*french*/"un prix de la maison des Skulltulas", /*spanish*/"un obsequio de la Casa Skulltula"},
-                       Text{"explosives", /*french*/"un paquet d’explosifs", /*spanish*/"un montón de explosivos"},
+                       Text{"explosives", /*french*/"un paquet d'explosifs", /*spanish*/"un montón de explosivos"},
                      },
                        //clear text
                        Text{"Bombchus (20 pieces)", /*french*/"une vingtaine de Bombchus", /*spanish*/"unos (20) bombchus"}


### PR DESCRIPTION
- Malon's song can be obtained without talking to her 3 times beforehand.
- In MQ Jabu, a wooden box appears in the basement after Ruto disappears from the dungeon, so that the Boomerang room can still be accessed afterwards. This resolves issue #426

https://user-images.githubusercontent.com/82058772/143149472-a9856eea-dcb0-4196-9402-6977dde0b3c7.mp4

- Time Blocks had an issue where you could make them disappear while standing on them. I realized the patches I had made for them were overly complicated, so I replaced them with a simpler one and this bug disappeared :)

https://user-images.githubusercontent.com/82058772/143149508-0f7dd515-ff04-4676-85c7-24bf84c8fec0.mp4

- The ambiguous hints were using the wrong character for the apostrophes, which appeared as an asterisk in-game. Now they use the correct one.