### PR TITLE
force the ocarina staff textbox to always close when suns song finishes

### DIFF
--- a/code/include/z3D/z3D.h
+++ b/code/include/z3D/z3D.h
@@ -557,6 +557,10 @@ typedef void (*Flags_SetEnv_proc)(GlobalContext* globalCtx, s16 flag);
 typedef void (*GiveItem_proc)(Actor* actor, GlobalContext* globalCtx, s32 getItemId, f32 xzRange, f32 yRange)
     __attribute__((pcs("aapcs-vfp")));
 #define GiveItem_addr 0x3724DC
-#define GiveItem ((GiveItem_proc)0x3724DC)
+#define GiveItem ((GiveItem_proc)GiveItem_addr)
+
+typedef void (*Message_CloseTextbox_proc)(GlobalContext* globalCtx);
+#define Message_CloseTextbox_addr 0x3725E0
+#define Message_CloseTextbox ((Message_CloseTextbox_proc)Message_CloseTextbox_addr)
 
 #endif //_Z3D_H_

--- a/code/oot.ld
+++ b/code/oot.ld
@@ -1156,6 +1156,10 @@ SECTIONS
 		*(.patch_InterfaceDrawDontSpoilTradeItems)
 	}
 
+	.patch_SunsSongEndCloseTextbox 0x45B514 : {
+		*(.patch_SunsSongEndCloseTextbox)
+	}
+
 	.patch_SetSunsSongRespawnFlag 0x45B660 : {
 		*(.patch_SetSunsSongRespawnFlag)
 	}

--- a/code/src/hooks.s
+++ b/code/src/hooks.s
@@ -661,6 +661,13 @@ hook_SetSunsSongRespawnFlag:
     cpy r0,r6
     bx lr
 
+.global hook_SunsSongEndCloseTextbox
+hook_SunsSongEndCloseTextbox:
+    push {r0-r12, lr}
+    bl Settings_SunsSongEndCloseTextbox
+    pop {r0-r12, lr}
+    b 0x45B518
+
 .global hook_SetVoidoutRespawnFlag
 hook_SetVoidoutRespawnFlag:
     push {r0-r12, lr}

--- a/code/src/patches.s
+++ b/code/src/patches.s
@@ -1312,6 +1312,11 @@ SetGameOverRespawnFlag_patch:
 SetSunsSongRespawnFlag_patch:
     bl hook_SetSunsSongRespawnFlag
 
+.section .patch_SunsSongEndCloseTextbox
+.global SunsSongsEndCloseTextbox_patch
+SunsSongsEndCloseTextbox_patch:
+    beq hook_SunsSongEndCloseTextbox
+
 .section .patch_SetVoidoutRespawnFlag
 .global SetVoidoutRespawnFlag_patch
 SetVoidoutRespawnFlag_patch:

--- a/code/src/settings.c
+++ b/code/src/settings.c
@@ -125,6 +125,11 @@ void Settings_SkipSongReplays() {
     }
 }
 
+void Settings_SunsSongEndCloseTextbox() {
+    Message_CloseTextbox(gGlobalContext);
+    gGlobalContext->unk_2B7E = 4; // msgCtx.ocarinaMode, exits the ocarina playing
+}
+
   const char hashIconNames[32][25] = {
     "Deku Stick",
     "Deku Nut",

--- a/source/music.cpp
+++ b/source/music.cpp
@@ -51,7 +51,7 @@ namespace Music {
         /* NA_BGM_OCA_SARIA */          SEQ_OCARINA,
         /* NA_BGM_OCA_EPONA */          SEQ_OCARINA,
         /* NA_BGM_OCA_ZELDA */          SEQ_OCARINA,
-        /* NA_BGM_OCA_SUNMOON */        SEQ_OCARINA,
+        /* NA_BGM_OCA_SUNMOON */        SEQ_NOSHUFFLE, /* Remove Sun's Song from the Ocarina pool for now due to bugs */
         /* NA_BGM_OCA_TIME */           SEQ_OCARINA,
         /* NA_BGM_OCA_STORM */          SEQ_OCARINA,
         /* NA_BGM_NAVI */               SEQ_BGM_EVENT,


### PR DESCRIPTION
This patch forces the ocarina staff textbox to close at the same that Links stop playing the ocarina when sun's song is played, under any conditions.

This fixes the bug where the textbox stays up for too long when ocarina song shuffle is turned on, but song replays are not skipped.

@HylianFreddy is normally the ocarina songs guy, so Ill let him glance at this before merging