### PR TITLE
Fix Navi message and altar text coloring

### DIFF
--- a/code/src/lake_hylia_objects.c
+++ b/code/src/lake_hylia_objects.c
@@ -41,7 +41,7 @@ void BgSpot06Objects_rUpdate(Actor* thisx, GlobalContext* globalCtx) {
 
         // Spawn a Navi check spot
         if (!(gSaveContext.eventChkInf[4] & 0x0400)) { // Water Temple blue warp not cleared
-            Actor_Spawn(&globalCtx->actorCtx, globalCtx, 0x173, -896.0f, -1243.0f, 6953.0f, 0, 0, 0, 0x3DB2);
+            Actor_Spawn(&globalCtx->actorCtx, globalCtx, 0x173, -896.0f, -1243.0f, 6953.0f, 0, 0, 0, 0x3DB3);
         }
 
         actionCounter++;

--- a/source/custom_messages.cpp
+++ b/source/custom_messages.cpp
@@ -353,7 +353,7 @@ constexpr std::array DungeonColors = {
             UNSKIPPABLE()+INSTANT_TEXT_ON()+CENTER_TEXT()+"Water level control system."+NEWLINE()+CENTER_TEXT()+"Keep away!"+INSTANT_TEXT_OFF()+MESSAGE_END(),
             UNSKIPPABLE()+INSTANT_TEXT_ON()+CENTER_TEXT()+"Contrôle du niveau d'eau."+NEWLINE()+CENTER_TEXT()+"Ne pas toucher!"+INSTANT_TEXT_OFF()+MESSAGE_END(),
             UNSKIPPABLE()+INSTANT_TEXT_ON()+CENTER_TEXT()+"Control del nivel del agua."+NEWLINE()+CENTER_TEXT()+"¡No te acerques!"+INSTANT_TEXT_OFF()+MESSAGE_END());
-        CreateMessage(0x1B2, 0, 0, 3,
+        CreateMessage(0x1B3, 0, 0, 3,
             UNSKIPPABLE()+"This switch is rustier than you think."+WAIT_FOR_INPUT()+"Something must be wrong with the pipe"+NEWLINE()+"system in the Water Temple."+MESSAGE_END(),
             UNSKIPPABLE()+"Cet interrupteur est très rouillé."+WAIT_FOR_INPUT()+"Quelque chose ne va pas avec"+NEWLINE()+"la tuyauterie du Temple de l'Eau."+MESSAGE_END(),
             UNSKIPPABLE()+"El interruptor está más oxidado de lo que"+NEWLINE()+"aparenta."+WAIT_FOR_INPUT()+"Algo debe andar mal en el sistema de"+NEWLINE()+"cañerías del Templo del Agua."+MESSAGE_END());

--- a/source/hints.cpp
+++ b/source/hints.cpp
@@ -620,9 +620,9 @@ static void CreateAltarText() {
   //Child Altar Text
   Text childText = Hint(SPIRITUAL_STONE_TEXT_START).GetText()+"^"+
   //Spiritual Stones
-  (StartingKokiriEmerald.Value<u8>() ? Text{"","",""} : BuildDungeonRewardText(ITEM_KOKIRI_EMERALD, KOKIRI_EMERALD))+
-  (StartingGoronRuby.Value<u8>() ? Text{"","",""} : BuildDungeonRewardText(ITEM_GORON_RUBY,     GORON_RUBY))+
-  (StartingZoraSapphire.Value<u8>() ? Text{"","",""} : BuildDungeonRewardText(ITEM_ZORA_SAPPHIRE,  ZORA_SAPPHIRE))+
+  (StartingKokiriEmerald.Value<u8>() ? Text{"##","##","##"} : BuildDungeonRewardText(ITEM_KOKIRI_EMERALD, KOKIRI_EMERALD))+
+  (StartingGoronRuby.Value<u8>()     ? Text{"##","##","##"} : BuildDungeonRewardText(ITEM_GORON_RUBY,     GORON_RUBY))+
+  (StartingZoraSapphire.Value<u8>()  ? Text{"##","##","##"} : BuildDungeonRewardText(ITEM_ZORA_SAPPHIRE,  ZORA_SAPPHIRE))+
   //How to open Door of Time, the event trigger is necessary to read the altar multiple times
   BuildDoorOfTimeText()+EVENT_TRIGGER();
   CreateMessageFromTextObject(0x7040, 0, 2, 3, AddColorsAndFormat(childText, {QM_GREEN, QM_RED, QM_BLUE}));
@@ -630,12 +630,12 @@ static void CreateAltarText() {
   //Adult Altar Text
   Text adultText = Hint(ADULT_ALTAR_TEXT_START).GetText()+"^"+
   //Medallion Areas
-  (StartingLightMedallion.Value<u8>() ? Text{"","",""} : BuildDungeonRewardText(ITEM_MEDALLION_LIGHT,  LIGHT_MEDALLION))+
-  (StartingForestMedallion.Value<u8>() ? Text{"","",""} : BuildDungeonRewardText(ITEM_MEDALLION_FOREST, FOREST_MEDALLION))+
-  (StartingFireMedallion.Value<u8>() ? Text{"","",""} : BuildDungeonRewardText(ITEM_MEDALLION_FIRE,   FIRE_MEDALLION))+
-  (StartingWaterMedallion.Value<u8>() ? Text{"","",""} : BuildDungeonRewardText(ITEM_MEDALLION_WATER,  WATER_MEDALLION))+
-  (StartingSpiritMedallion.Value<u8>() ? Text{"","",""} : BuildDungeonRewardText(ITEM_MEDALLION_SPIRIT, SPIRIT_MEDALLION))+
-  (StartingShadowMedallion.Value<u8>() ? Text{"","",""} : BuildDungeonRewardText(ITEM_MEDALLION_SHADOW, SHADOW_MEDALLION))+
+  (StartingLightMedallion.Value<u8>()  ? Text{"##","##","##"} : BuildDungeonRewardText(ITEM_MEDALLION_LIGHT,  LIGHT_MEDALLION))+
+  (StartingForestMedallion.Value<u8>() ? Text{"##","##","##"} : BuildDungeonRewardText(ITEM_MEDALLION_FOREST, FOREST_MEDALLION))+
+  (StartingFireMedallion.Value<u8>()   ? Text{"##","##","##"} : BuildDungeonRewardText(ITEM_MEDALLION_FIRE,   FIRE_MEDALLION))+
+  (StartingWaterMedallion.Value<u8>()  ? Text{"##","##","##"} : BuildDungeonRewardText(ITEM_MEDALLION_WATER,  WATER_MEDALLION))+
+  (StartingSpiritMedallion.Value<u8>() ? Text{"##","##","##"} : BuildDungeonRewardText(ITEM_MEDALLION_SPIRIT, SPIRIT_MEDALLION))+
+  (StartingShadowMedallion.Value<u8>() ? Text{"##","##","##"} : BuildDungeonRewardText(ITEM_MEDALLION_SHADOW, SHADOW_MEDALLION))+
 
   //Bridge requirement
   BuildBridgeReqsText()+


### PR DESCRIPTION
The Navi message for the Lake Hylia switch was accidentally overwriting another dialog. Now it uses a different text ID.

The medallion names in the ToT altar text could appear with the wrong colors if some of them were skipped due to being in the starting inventory. That is also fixed now.