### PR TITLE
Two minor fixes

### DIFF
--- a/code/oot.ld
+++ b/code/oot.ld
@@ -1237,7 +1237,7 @@ SECTIONS
 	}
 
 	.patch_ReturnFWSetupGrottoInfo 0x496B88 : {
-		*(.patch_PlayerFWSetupGrottoInfo)
+		*(.patch_ReturnFWSetupGrottoInfo)
 	}
 
 	.patch_SetVoidoutRespawnFlag 0x496C70 : {

--- a/source/hint_list.cpp
+++ b/source/hint_list.cpp
@@ -2107,7 +2107,7 @@ void HintTable_Init() {
 
     hintTable[HF_GS_COW_GROTTO] = HintText::Sometimes({
                        //obscure text
-                       Text{"a #spider behind webs# in a grotto holds", /*french*/"l'#araignée derrière une toile# dans une grotte donne", /*spanish*/"una #Skulltula tras la telaraña de una cueva otorga"},
+                       Text{"a #spider behind webs# in a grotto holds", /*french*/"l'#araignée derrière une toile# dans une grotte donne", /*spanish*/"una #Skulltula tras la telaraña# de una cueva otorga"},
   });
 
     hintTable[HF_COW_GROTTO_COW] = HintText::Sometimes({


### PR DESCRIPTION
This PR fixes two typos:
- The ReturnFWSetupGrottoInfo patch in oot.ld had a typo in it and was presumably never running. Although this patch will only ever run if the player uses Grotto Entrance Shuffle and Enables FW anywhere (or uses RI to set FW after leaving a grotto).
- There was a missing `#` in the spanish translation for the Hyrule Field Cow Grotto GS hint text.