### PR TITLE
Fix how shuffled grottos handle respawns

### DIFF
--- a/code/oot.ld
+++ b/code/oot.ld
@@ -1212,10 +1212,6 @@ SECTIONS
 		*(.patch_SetBGMDayNight)
 	}
 
-	.patch_SetFWGrottoID 0x4911D4 : {
-		*(.patch_SetFWGrottoID)
-	}
-
 	.patch_SwapFaroresWind 0x49186C : {
 		*(.patch_SwapFaroresWind)
 	}
@@ -1237,11 +1233,11 @@ SECTIONS
 	}
 
 	.patch_ReturnFWSetupGrottoInfo 0x496B88 : {
-		*(.patch_PlayerFWSetupGrottoInfo)
+		*(.patch_ReturnFWSetupGrottoInfo)
 	}
 
-	.patch_SetVoidoutRespawnFlag 0x496C70 : {
-		*(.patch_SetVoidoutRespawnFlag)
+	.patch_SetSpecialVoidOutRespawnFlag 0x496C70 : {
+		*(.patch_SetSpecialVoidOutRespawnFlag)
 	}
 
 	.patch_GanonBattleDeathWarp 0x496C98 : {

--- a/code/src/hooks.s
+++ b/code/src/hooks.s
@@ -648,7 +648,7 @@ hook_SetGameOverEntrance:
 .global hook_SetGameOverRespawnFlag
 hook_SetGameOverRespawnFlag:
     push {r0-r12, lr}
-    bl Grotto_SetRespawnFlag
+    bl Grotto_ForceGrottoReturn
     pop {r0-r12, lr}
     cmp r8,#0x3
     bx lr
@@ -656,15 +656,15 @@ hook_SetGameOverRespawnFlag:
 .global hook_SetSunsSongRespawnFlag
 hook_SetSunsSongRespawnFlag:
     push {r0-r12, lr}
-    bl Grotto_SetRespawnFlag
+    bl Grotto_ForceGrottoReturn
     pop {r0-r12, lr}
     cpy r0,r6
     bx lr
 
-.global hook_SetVoidoutRespawnFlag
-hook_SetVoidoutRespawnFlag:
+.global hook_SetSpecialVoidOutRespawnFlag
+hook_SetSpecialVoidOutRespawnFlag:
     push {r0-r12, lr}
-    bl Grotto_SetRespawnFlagAndDamage
+    bl Grotto_ForceRegularVoidOut
     pop {r0-r12, lr}
     mov r1,#0x104
     bx lr
@@ -1179,14 +1179,6 @@ hook_ReturnFWSetupGrottoInfo:
     bl Grotto_SetupReturnInfoOnFWReturn
     pop {r0-r12, lr}
     add sp,sp,#0x8
-    bx lr
-
-.global hook_SetFWGrottoID
-hook_SetFWGrottoID:
-    push {r0-r12, lr}
-    bl Grotto_StoreGrottoIDOnFWSet
-    pop {r0-r12, lr}
-    add r1,r7,#0x400
     bx lr
 
 .section .loader

--- a/code/src/patches.s
+++ b/code/src/patches.s
@@ -1312,10 +1312,10 @@ SetGameOverRespawnFlag_patch:
 SetSunsSongRespawnFlag_patch:
     bl hook_SetSunsSongRespawnFlag
 
-.section .patch_SetVoidoutRespawnFlag
-.global SetVoidoutRespawnFlag_patch
-SetVoidoutRespawnFlag_patch:
-    bl hook_SetVoidoutRespawnFlag
+.section .patch_SetSpecialVoidOutRespawnFlag
+.global SetSpecialVoidOutRespawnFlag_patch
+SetSpecialVoidOutRespawnFlag_patch:
+    bl hook_SetSpecialVoidOutRespawnFlag
 
 .section .patch_SariasSongHintsOne
 .global SariasSongHintsOne_patch
@@ -1722,11 +1722,6 @@ OverrideGrottoActorEntrance_patch:
 .global ReturnFWSetupGrottoInfo_patch
 ReturnFWSetupGrottoInfo_patch:
     bl hook_ReturnFWSetupGrottoInfo
-
-.section .patch_SetFWGrottoID
-.global SetFWGrottoID_patch
-SetFWGrottoID_patch:
-    bl hook_SetFWGrottoID
 
 .section .patch_loader
 .global loader_patch

--- a/code/src/savefile.c
+++ b/code/src/savefile.c
@@ -571,8 +571,6 @@ void SaveFile_InitExtSaveData(u32 saveNumber) {
     gExtSaveData.version = EXTSAVEDATA_VERSION; // Do not change this line
     gExtSaveData.biggoronTrades = 0;
     memset(&gExtSaveData.fwStored, 0, sizeof(gExtSaveData.fwStored));
-    gExtSaveData.childFWgrottoID = 0xFF;
-    gExtSaveData.adultFWgrottoID = 0xFF;
     gExtSaveData.playtimeSeconds = 0;
     memset(&gExtSaveData.scenesDiscovered, 0, sizeof(gExtSaveData.scenesDiscovered));
     memset(&gExtSaveData.entrancesDiscovered, 0, sizeof(gExtSaveData.entrancesDiscovered));

--- a/code/src/savefile.h
+++ b/code/src/savefile.h
@@ -24,7 +24,7 @@ void SaveFile_LoadExtSaveData(u32 saveNumber);
 void SaveFile_SaveExtSaveData(u32 saveNumber);
 
 // Increment the version number whenever the ExtSaveData structure is changed
-#define EXTSAVEDATA_VERSION 7
+#define EXTSAVEDATA_VERSION 8
 
 typedef struct {
     u32 version;            // Needs to always be the first field of the structure
@@ -39,8 +39,6 @@ typedef struct {
         s32  tempSwchFlags;
         s32  tempCollectFlags;
     }   fwStored;
-    u8 adultFWgrottoID;
-    u8 childFWgrottoID;
     u32 playtimeSeconds;
     u32 scenesDiscovered[SAVEFILE_SCENES_DISCOVERED_IDX_COUNT];
     u32 entrancesDiscovered[SAVEFILE_ENTRANCES_DISCOVERED_IDX_COUNT];


### PR DESCRIPTION
This PR fixes a couple of minor glitches with temp flags for shuffled grotto entrances, and changes some things like how setting FW outside a grotto is managed.
The following is just a technical explanation.

When returning to FW, the RESPAWN_MODE_DOWN data (Entrance Point) is automatically set by FW, and the RESPAWN_MODE_RETURN (Grotto Return Point) can be copied from FW, so there is no need to set it dynamically.

In Grotto_SetupReturnInfo (which is now only used to set the Entrance Point), some things need adjustments:
- setting the respawnFlag doesn't do anything, because it gets reset immediately after (if it didn't then you'd get damaged everytime you exit a grotto, because type 1 is a void out);
- setting the playerParams just makes Link pop out of the ground even when voiding out, which shouldn't be the case in my opinion;
- setting the temp flags is almost useless (it doesn't affect the void respawn, because when you void out the game keeps the previous flags and ignores those stored in the Entrance Point), but we still need to set them because they can be copied to the FW Point. The current implementation applies the current flags to the Grotto Return Point, but that is wrong because it would just keep the ones from the scene the player is exiting from. Until mixed entrances and decoupled entrances are implemented, the flags can be taken from the Grotto Return Point. When those settings will be enabled, it will be better to just zero out these flags.

Sun's Song and Game Over have to use the Grotto Return Point, because their normal zoneout type is -2, which doesn't restore coordinates. But they should still keep the current temp flags, because that's the point of using type -2. With the current implementation, they instead restore the temp flags saved in the grotto return.

Special void out (type -1) is similar, but we can just force it to use the normal void out (type 1). After all, the only area with grottos that has special voids is DMT, which has no doors to set different entrance points (so changing them to regular voids doesn't affect anything). The other areas with special voids are Spirit Temple and Ice Cavern.