### PR TITLE
Glitch Logic + Dungeon ER Bug Fix

### DIFF
--- a/source/location_access.cpp
+++ b/source/location_access.cpp
@@ -1325,8 +1325,6 @@ void AreaTable_Init() {
                   Entrance(KAKARIKO_VILLAGE,             {[]{return true;}}),
                   Entrance(GRAVEYARD_WARP_PAD_REGION,    {[]{return false;},
                                               /*Glitched*/[]{return CanDoGlitch(GlitchType::BombHover, GlitchDifficulty::NOVICE) || CanDoGlitch(GlitchType::HookshotJump_Bonk, GlitchDifficulty::INTERMEDIATE) || CanDoGlitch(GlitchType::HookshotJump_Boots, GlitchDifficulty::NOVICE);}}),
-                  Entrance(SHADOW_TEMPLE_ENTRYWAY,       {[]{return false;},
-                                              /*Glitched*/[]{return CanDoGlitch(GlitchType::HookshotJump_Bonk, GlitchDifficulty::INTERMEDIATE) || CanDoGlitch(GlitchType::HookshotJump_Boots, GlitchDifficulty::NOVICE);}}),
   });
 
   areaTable[GRAVEYARD_SHIELD_GRAVE] = Area("Graveyard Shield Grave", "", NONE, NO_DAY_NIGHT_CYCLE, {}, {
@@ -1383,7 +1381,8 @@ void AreaTable_Init() {
                 }, {
                   //Exits
                   Entrance(THE_GRAVEYARD,             {[]{return true;}}),
-                  Entrance(SHADOW_TEMPLE_ENTRYWAY,    {[]{return CanUse(DINS_FIRE) || (LogicShadowFireArrowEntry && CanUse(FIRE_ARROWS));}}),
+                  Entrance(SHADOW_TEMPLE_ENTRYWAY,    {[]{return CanUse(DINS_FIRE) || (LogicShadowFireArrowEntry && CanUse(FIRE_ARROWS));},
+                                           /*Glitched*/[]{return (CanDoGlitch(GlitchType::HookshotJump_Bonk, GlitchDifficulty::INTERMEDIATE) || CanDoGlitch(GlitchType::HookshotJump_Boots, GlitchDifficulty::NOVICE)) && CanTakeDamage;}}),
   });
 
   areaTable[KAK_BEHIND_GATE] = Area("Kak Behind Gate", "Kakariko Village", NONE, NO_DAY_NIGHT_CYCLE, {}, {}, {


### PR DESCRIPTION
ER only updates the logic for dungeon entrances from the region they are in, but glitch logic added an entrance to ShT from GY's main area which wasn't updated and could create softlocks. The simple way to fix this is to apply the glitch logic to the original entrance since you can always return to the lower area from the warp pad and the same glitches are used to reach the warp pad from the lower area.