### PR TITLE
Make Link able to receive items when surfacing from water

### DIFF
--- a/code/include/z3D/z3D.h
+++ b/code/include/z3D/z3D.h
@@ -563,4 +563,8 @@ typedef void (*Message_CloseTextbox_proc)(GlobalContext* globalCtx);
 #define Message_CloseTextbox_addr 0x3725E0
 #define Message_CloseTextbox ((Message_CloseTextbox_proc)Message_CloseTextbox_addr)
 
+typedef void (*SetupItemInWater_proc)(Player* player, GlobalContext* globalCtx);
+#define SetupItemInWater_addr 0x354894
+#define SetupItemInWater ((SetupItemInWater_proc)SetupItemInWater_addr)
+
 #endif //_Z3D_H_

--- a/code/src/common.c
+++ b/code/src/common.c
@@ -45,3 +45,9 @@ u8 IsInGame(void) {
     return mode == 0 ||
         (mode == 1 && entr != 0x0629 && entr != 0x0147 && entr != 0x00A0 && entr != 0x008D);
 }
+
+void DebugPrintNumber(const char* message, int num) {
+    char buf[128];
+    int length = snprintf(buf, 128, message, num);
+    svcOutputDebugString(buf, length);
+}

--- a/code/src/common.h
+++ b/code/src/common.h
@@ -2,6 +2,8 @@
 #define _COMMON_H_
 
 #include "../include/z3D/z3D.h"
+#include "../include/3ds/svc.h"
+#include "../include/lib/printf.h"
 
 #define ARRAY_SIZE(x) (sizeof(x) / sizeof(x[0]))
 
@@ -11,5 +13,6 @@ u32 Hash(u32);
 u8  Bias(u32);
 
 u8 IsInGame(void);
+void DebugPrintNumber(const char *, int);
 
 #endif //_COMMON_H_

--- a/code/src/item_override.c
+++ b/code/src/item_override.c
@@ -7,11 +7,15 @@
 #include "objects.h"
 #include "entrance.h"
 #include "savefile.h"
+#include "common.h"
 #include <stddef.h>
 
 #include "z3D/z3D.h"
 #include "z3D/actors/z_en_box.h"
 #include "z3D/actors/z_en_item00.h"
+
+#define READY_ON_LAND 1
+#define READY_IN_WATER 2
 
 static ItemOverride rItemOverrides[640] = { 0 };
 static s32 rItemOverrides_Count = 0;
@@ -239,7 +243,7 @@ void ItemOverride_AfterItemReceived(void) {
     ItemOverride_Clear();
 }
 
-static u32 ItemOverride_PlayerIsReady(void) {
+static u32 ItemOverride_PlayerIsReadyOnLand(void) {
     if ((PLAYER->stateFlags1 & 0xFCAC2485) == 0 && (PLAYER->actor.bgCheckFlags & 0x0001) &&
         (PLAYER->stateFlags2 & 0x000C0000) == 0 && PLAYER->actor.draw != NULL &&
         gGlobalContext->actorCtx.titleCtx.delayTimer == 0 && gGlobalContext->actorCtx.titleCtx.durationTimer == 0 &&
@@ -259,25 +263,35 @@ static u32 ItemOverride_PlayerIsReady(void) {
 }
 
 static u32 ItemOverride_PlayerIsReadyInWater(void) {
-  if ((PLAYER->stateFlags1 & 0xF4AC2085) == 0 /*&& (PLAYER->actor.bgCheckFlags & 0x0001)*/ &&
-      (PLAYER->stateFlags2 & 0x000C0000) == 0 && PLAYER->actor.draw != NULL &&
-      gGlobalContext->actorCtx.titleCtx.delayTimer == 0 && gGlobalContext->actorCtx.titleCtx.durationTimer == 0 &&
-      gGlobalContext->actorCtx.titleCtx.alpha == 0 &&
-      (PLAYER->stateFlags1 & 0x08000000) != 0 && // Player is Swimming
-      (PLAYER->stateFlags2 & 0x400) != 0 && // Player is underwater
-      (PLAYER->stateFlags1 & 0x400) == 0 // Player is not already receiving an item when surfacing
-      // && (z64_event_state_1 & 0x20) == 0 //TODO
-      // && (z64_game.camera_2 == 0) //TODO
-  ) {
-      rSatisfiedPendingFramesWater++;
-  } else {
-      rSatisfiedPendingFramesWater = 0;
-  }
-  if (rSatisfiedPendingFramesWater >= 2) {
-      rSatisfiedPendingFramesWater = 0;
-      return 1;
-  }
-  return 0;
+    if ((PLAYER->stateFlags1 & 0xF4AC2085) == 0 /*&& (PLAYER->actor.bgCheckFlags & 0x0001)*/ &&
+        (PLAYER->stateFlags2 & 0x000C0000) == 0 && PLAYER->actor.draw != NULL &&
+        gGlobalContext->actorCtx.titleCtx.delayTimer == 0 && gGlobalContext->actorCtx.titleCtx.durationTimer == 0 &&
+        gGlobalContext->actorCtx.titleCtx.alpha == 0 &&
+        (PLAYER->stateFlags1 & 0x08000000) != 0 && // Player is Swimming
+        (PLAYER->stateFlags2 & 0x400) != 0 && // Player is underwater
+        (PLAYER->stateFlags1 & 0x400) == 0 // Player is not already receiving an item when surfacing
+        // && (z64_event_state_1 & 0x20) == 0 //TODO
+        // && (z64_game.camera_2 == 0) //TODO
+    ) {
+        rSatisfiedPendingFramesWater++;
+    } else {
+        rSatisfiedPendingFramesWater = 0;
+    }
+    if (rSatisfiedPendingFramesWater >= 2) {
+        rSatisfiedPendingFramesWater = 0;
+        return 1;
+    }
+    return 0;
+}
+
+static u32 ItemOverride_PlayerIsReady(void) {
+    if (ItemOverride_PlayerIsReadyOnLand()) {
+        return READY_ON_LAND;
+    }
+    if (ItemOverride_PlayerIsReadyInWater()) {
+        return READY_IN_WATER;
+    }
+    return 0;
 }
 
 static void ItemOverride_TryPendingItem(void) {
@@ -302,21 +316,19 @@ void ItemOverride_Update(void) {
     ItemOverride_CheckZeldasLetter();
     IceTrap_Update();
     CustomModel_Update();
-    if (ItemOverride_PlayerIsReady()) {
+    u8 readyStatus = ItemOverride_PlayerIsReady();
+    if (readyStatus) {
         ItemOverride_PopIceTrap();
         if (IceTrap_IsPending()) {
             IceTrap_Give();
         } else {
             ItemOverride_TryPendingItem();
+            if (readyStatus == READY_IN_WATER) {
+                SetupItemInWater(PLAYER, gGlobalContext);
+                rDummyActor->parent = NULL;
+                ItemOverride_PopPendingOverride();
+            }
         }
-    } else if (ItemOverride_PlayerIsReadyInWater() && ItemOverride_IsAPendingOverride()) {
-        // Link receives an item when surfacing
-        PLAYER->stateFlags1 |= 0x400;
-        // Copied from decomp, puts Link into a cutscene state when floating up
-        // so players can't savewarp to miss the incoming override
-        PLAYER->stateFlags1 |= 0x20000800;
-        ItemOverride_TryPendingItem();
-        ItemOverride_PopPendingOverride();
     }
 }
 


### PR DESCRIPTION
Link will now receive delayed item overrides when surfacing from water if applicable. Currently this will only happen when exiting whichever dungeon leads to the Water Temple -> Lake Hylia entrance in dungeon entrance shuffle.