### PR TITLE
Make sure Starting Age is set correctly when Closed Forest is randomly chosen

### DIFF
--- a/source/settings.cpp
+++ b/source/settings.cpp
@@ -1799,6 +1799,10 @@ namespace Settings {
         if (selectOptions) {
           worldOptions[i]->SetSelectedIndex(Random(0,worldOptions[i]->GetOptionCount()));
         }
+        // Sanity Check Closed Forest
+        if (OpenForest.Is(OPENFOREST_CLOSED)) {
+          StartingAge.SetSelectedIndex(AGE_CHILD);
+        }
       }
     }
     else {


### PR DESCRIPTION
There was no sanity check on starting age for when Closed Forest was randomly chosen. This PR fixes that and checks the setting after both have potentially been randomized.