### PR TITLE
Fix entrance shuffle conflicts resulting from randomizing settings

### DIFF
--- a/source/settings.cpp
+++ b/source/settings.cpp
@@ -1814,6 +1814,14 @@ namespace Settings {
       }
     }
 
+    // Sanity Check Entrance Shuffling
+    if (!ShuffleEntrances) {
+      ShuffleDungeonEntrances.SetSelectedIndex(OFF);
+      ShuffleOverworldEntrances.SetSelectedIndex(OFF);
+      ShuffleInteriorEntrances.SetSelectedIndex(OFF);
+      ShuffleGrottoEntrances.SetSelectedIndex(OFF);
+    }
+
     // Shuffle Settings
     if (RandomizeShuffle) {
       // Still displays if previously locked


### PR DESCRIPTION
Entrance shuffle settings weren't being sanitized when Randomize Settings was selected in the world settings menu. This PR fixes this issue.