### PR TITLE
Fix missing the item override for the song of time check

### DIFF
--- a/code/src/item_override.c
+++ b/code/src/item_override.c
@@ -269,7 +269,10 @@ static u32 ItemOverride_PlayerIsReadyInWater(void) {
         gGlobalContext->actorCtx.titleCtx.alpha == 0 &&
         (PLAYER->stateFlags1 & 0x08000000) != 0 && // Player is Swimming
         (PLAYER->stateFlags2 & 0x400) != 0 && // Player is underwater
-        (PLAYER->stateFlags1 & 0x400) == 0 // Player is not already receiving an item when surfacing
+        (PLAYER->stateFlags1 & 0x400) == 0 && // Player is not already receiving an item when surfacing
+        gGlobalContext->sceneLoadFlag == 0 && // Another scene isn't about to be loaded
+        rPendingOverrideQueue[0].key.type == OVR_TEMPLE // Must be an item received for completing a dungeon
+        // && Multiworld is off
         // && (z64_event_state_1 & 0x20) == 0 //TODO
         // && (z64_game.camera_2 == 0) //TODO
     ) {


### PR DESCRIPTION
Due to being able to receive items in water, the item override for the song of time check could get missed if players were mashing A too fast after receiving the Ocarina of Time check. The requirements for being ready in water are now stricter to make sure this can't happen.