### PR TITLE
Clear PendingJunkPool in GenerateItemPool()

### DIFF
--- a/source/item_pool.cpp
+++ b/source/item_pool.cpp
@@ -602,6 +602,7 @@ static void SetMinimalItemPool() {
 void GenerateItemPool() {
 
   ItemPool.clear();
+  PendingJunkPool.clear();
 
   //Initialize ice trap models to always major items
   IceTrapModels = {
@@ -1090,6 +1091,7 @@ void GenerateItemPool() {
       if (junkSet) break;
     }
   }
+  PendingJunkPool.clear();
 }
 
 void AddJunk() {

--- a/source/settings.cpp
+++ b/source/settings.cpp
@@ -396,7 +396,7 @@ namespace Settings {
   Option StartingShardOfAgony     = Option::U8  ("  Shard of Agony",       {"None",             "Shard of Agony"},                                          {""});
   Option StartingHealth           = Option::U8  ("  Health",               healthOptions,                                                                   {""});
   Option StartingMagicMeter       = Option::U8  ("  Magic Meter",          {"None",             "Single Magic",     "Double Magic"},                        {""});
-  Option StartingDoubleDefense    = Option::U8  ("  Double Defense",       {"None",             "Double Defence"},                                          {""});
+  Option StartingDoubleDefense    = Option::U8  ("  Double Defense",       {"None",             "Double Defense"},                                          {""});
   Option StartingQuestToggle      = Option::U8  ("Quest Items",            {"All Off",          "All On",           "Choose"},                              {""});
   Option StartingKokiriEmerald    = Option::U8  ("  Kokiri's Emerald",     {"None",             "Kokiri's Emer."},                                          {""});
   Option StartingGoronRuby        = Option::U8  ("  Goron's Ruby",         {"None",             "Goron's Ruby"},                                            {""});


### PR DESCRIPTION
Items added to PendingJunkPool in previous fill attempts could carry over into further fill attempts and even further seed generation. This clears the vector at the start of GenerateItemPool() as well as after all the items within it are put into ItemPool.

(It is likely only one of these is required but it seemed safer to include both)