### PR TITLE
Various Bug Fixes

### DIFF
--- a/code/oot.ld
+++ b/code/oot.ld
@@ -148,10 +148,6 @@ SECTIONS
 		*(.patch_SariasSongCheckFlag)
 	}
 
-	.patch_DampeCheckCollectibleFlag 0x169F88 : {
-		*(.patch_DampeCheckCollectibleFlag)
-	}
-
 	.patch_GrogCheckForShouldDespawn 0x16485C : {
 		*(.patch_GrogCheckForShouldDespawn)
 	}

--- a/code/oot.ld
+++ b/code/oot.ld
@@ -644,6 +644,10 @@ SECTIONS
 		*(.patch_NoSilverGauntletsCutsceneWarp)
 	}
 
+	.patch_FishingIgnoreTempBOne 0x2C3A10 : {
+		*(.patch_FishingIgnoreTempBOne)
+	}
+
 	.patch_DoorOfTimeOpenCutscene 0x2C6218 : {
 		*(.patch_DoorOfTimeOpenCutscene)
 	}
@@ -734,6 +738,10 @@ SECTIONS
 
 	.patch_FairyReviveHealAmount 0x34AF48 : {
 		*(.patch_FairyReviveHealAmount)
+	}
+
+	.patch_FishingIgnoreTempBTwo 0x34CFCC : {
+		*(.patch_FishingIgnoreTempBTwo)
 	}
 
 	.patch_FWLoadSet 0x34D9E8 : {
@@ -1186,14 +1194,6 @@ SECTIONS
 
 	.patch_CheckForPocketCuccoHatchKankyo 0x470D1C : {
 		*(.patch_CheckForPocketCuccoHatchKankyo)
-	}
-
-	.patch_FishingStoreTempB 0x475F8C : {
-		*(.patch_FishingStoreTempB)
-	}
-
-	.patch_FishingRestoreTempB 0x475FC0 : {
-		*(.patch_FishingRestoreTempB)
 	}
 
 	.patch_EnableFW 0x476D1C : {

--- a/code/src/actor.c
+++ b/code/src/actor.c
@@ -38,6 +38,7 @@
 #include "shooting_gallery_man.h"
 #include "malon.h"
 #include "jabu.h"
+#include "dampe.h"
 
 #define OBJECT_GI_KEY 170
 #define OBJECT_GI_BOSSKEY 185
@@ -71,6 +72,8 @@ void Actor_Init() {
     gActorOverlayTable[0x5F].initInfo->init = ItemBHeart_rInit;
     gActorOverlayTable[0x5F].initInfo->destroy = ItemBHeart_rDestroy;
     gActorOverlayTable[0x5F].initInfo->draw = ItemBHeart_rDraw;
+
+    gActorOverlayTable[0x85].initInfo->update = EnTk_rUpdate;
 
     gActorOverlayTable[0x8B].initInfo->init = DemoEffect_rInit;
     gActorOverlayTable[0x8B].initInfo->destroy = DemoEffect_rDestroy;

--- a/code/src/dampe.c
+++ b/code/src/dampe.c
@@ -1,30 +1,20 @@
-#include "z3D/z3D.h"
+#include "dampe.h"
 
-typedef struct {
-    /* 0x000 */ char unk_00[0xBA8];
-    /* 0xBA8 */ u32 currentReward;
-} EnTk;
+#define EnTk_Update_addr 0x1BC088
+#define EnTk_Update ((ActorFunc)EnTk_Update_addr)
 
-typedef struct {
-    /* 0x000 */ char unk_00[0xB1C];
-    /* 0xB1C */ u8 unk_B1C;
-} EnPoRelay;
-
-// Sets the flag for having received the reward from Dampe
-// Upgrades the current reward to 4, the highest
-void EnTk_SetRewardFlag(EnTk* dampe) {
-    gSaveContext.itemGetInf[1] |= 0x1000;
-    dampe->currentReward = 4;
+void EnTk_rUpdate(Actor* thisx, GlobalContext* globalCtx) {
+    // Custom collectible flag for the heart piece
+    if (gGlobalContext->actorCtx.flags.collect & 0x100) {
+        // Sets the flag for having received the reward from Dampe
+        gSaveContext.itemGetInf[1] |= 0x1000;
+    }
+    EnTk_Update(thisx, globalCtx);
 }
 
-// Runs in the destroy function for Dampe
-// Checks if the reward was collected, and if not
-// unsets the flag for having received the reward
-void EnTk_CheckCollectFlag(void) {
-    // Custom collectible flag for the heart piece
-    if (!(gGlobalContext->actorCtx.flags.collect & 0x100)) {
-        gSaveContext.itemGetInf[1] &= ~0x1000;
-    }
+// Upgrades the current reward to 4, the highest
+void EnTk_SetRewardFlag(EnTk* dampe) {
+    dampe->currentReward = 4;
 }
 
 // Checks the clear flag for the first race (chest spawned, not opened)

--- a/code/src/dampe.h
+++ b/code/src/dampe.h
@@ -1,0 +1,18 @@
+#ifndef _DAMPE_H_
+#define _DAMPE_H_
+
+#include "z3D/z3D.h"
+
+typedef struct {
+    /* 0x000 */ char unk_00[0xBA8];
+    /* 0xBA8 */ u32 currentReward;
+} EnTk;
+
+typedef struct {
+    /* 0x000 */ char unk_00[0xB1C];
+    /* 0xB1C */ u8 unk_B1C;
+} EnPoRelay;
+
+void EnTk_rUpdate(Actor* thisx, GlobalContext* globalCtx);
+
+#endif

--- a/code/src/fishing.c
+++ b/code/src/fishing.c
@@ -1,17 +1,5 @@
 #include "z3D/z3D.h"
 
-void Fishing_StoreTempB(void) {
-    if (gSaveContext.equips.buttonItems[0] == ITEM_NONE) {
-        gSaveContext.buttonStatus[0] = ITEM_BRACELET; // Just use a magic item to detect in restore
-    } else {
-        gSaveContext.buttonStatus[0] = gSaveContext.equips.buttonItems[0];
-    }
-}
-
-void Fishing_RestoreTempB(void) {
-    if (gSaveContext.buttonStatus[0] != ITEM_BRACELET) {
-        gSaveContext.equips.buttonItems[0] = gSaveContext.buttonStatus[0];
-    } else {
-        gSaveContext.equips.buttonItems[0] = ITEM_NONE;
-    }
+u32 isFishing(void) {
+    return gSaveContext.equips.buttonItems[0] == ITEM_FISHING_POLE && gGlobalContext->sceneNum == 73;
 }

--- a/code/src/hooks.s
+++ b/code/src/hooks.s
@@ -363,19 +363,27 @@ hook_LullabyCheckFlag:
     pop {r0-r12, lr}
     bx lr
 
-.global hook_FishingStoreTempB
-hook_FishingStoreTempB:
+.global hook_FishingIgnoreTempBOne
+hook_FishingIgnoreTempBOne:
+    bne 0x2C3A14
     push {r0-r12, lr}
-    bl Fishing_StoreTempB
+    bl isFishing
+    cmp r0,#0x1
     pop {r0-r12, lr}
-    bx lr
+    bne 0x2C3998
+    moveq r0,#89
+    b 0x2C3A14
 
-.global hook_FishingRestoreTempB
-hook_FishingRestoreTempB:
+.global hook_FishingIgnoreTempBTwo
+hook_FishingIgnoreTempBTwo:
+    blt 0x34CFD0
     push {r0-r12, lr}
-    bl Fishing_RestoreTempB
+    bl isFishing
+    cmp r0,#0x1
     pop {r0-r12, lr}
-    bx lr
+    bne 0x34CFF0
+    ldrb r1,[r4,#0x80]
+    b 0x34CFD0
 
 .global hook_ConvertBombDropOne
 hook_ConvertBombDropOne:

--- a/code/src/hooks.s
+++ b/code/src/hooks.s
@@ -185,14 +185,6 @@ hook_DaruniaStrengthCheck:
     pop {r0-r12, lr}
     b 0x1E48A0
 
-.global hook_DampeCheckCollectibleFlag
-hook_DampeCheckCollectibleFlag:
-    push {r0-r12, lr}
-    bl EnTk_CheckCollectFlag
-    pop {r0-r12, lr}
-    cpy r4,r0
-    bx lr
-
 .global hook_GetToken
 hook_GetToken:
     push {r0-r12, lr}

--- a/code/src/malon.c
+++ b/code/src/malon.c
@@ -4,7 +4,7 @@
 #define EnMa1_Init ((ActorFunc)EnMa1_Init_addr)
 
 void EnMa1_rInit(Actor* thisx, GlobalContext* globalCtx) {
-    if (gSaveContext.eventChkInf[0x1] & 0x0001) { //If Talon has fled the castle...
+    if (gSaveContext.eventChkInf[0x1] & 0x0010) { //If Talon has fled the castle...
         gSaveContext.eventChkInf[0x1] |= 0x0040;  //...set "Invited to Sing With Child Malon" flag
     }
     EnMa1_Init(thisx, globalCtx);

--- a/code/src/patches.s
+++ b/code/src/patches.s
@@ -221,11 +221,6 @@ DampeCheckRewardFlag_patch:
 .section .patch_DampeSetCollectibleFlag
     .word 0x00000806
 
-.section .patch_DampeCheckCollectibleFlag
-.global DampeCheckCollectibleFlag_patch
-DampeCheckCollectibleFlag_patch:
-    bl hook_DampeCheckCollectibleFlag
-
 .section .patch_DampeCheckCanDig1
 .global DampeCheckCanDig1_patch
 DampeCheckCanDig1_patch:

--- a/code/src/patches.s
+++ b/code/src/patches.s
@@ -829,15 +829,15 @@ ChildDontEquipSwordSlotByDefault_patch:
 LullabyCheckFlag_patch:
     bl hook_LullabyCheckFlag
 
-.section .patch_FishingStoreTempB
-.global FishingStoreTempB_patch
-FishingStoreTempB_patch:
-    bl hook_FishingStoreTempB
+.section .patch_FishingIgnoreTempBOne
+.global FishingIgnoreTempBOne_patch
+FishingIgnoreTempBOne_patch:
+    b hook_FishingIgnoreTempBOne
 
-.section .patch_FishingRestoreTempB
-.global FishingRestoreTempB_patch
-FishingRestoreTempB_patch:
-    bl hook_FishingRestoreTempB
+.section .patch_FishingIgnoreTempBTwo
+.global FishingIgnoreTempBTwo_patch
+FishingIgnoreTempBTwo_patch:
+    b hook_FishingIgnoreTempBTwo
 
 .section .patch_ItemGiveBombchuDropOne
 .global ItemGiveBombchuDropOne_patch

--- a/source/hint_list.cpp
+++ b/source/hint_list.cpp
@@ -6801,35 +6801,35 @@ void HintTable_Init() {
                      //obscure text                                                  singular        plural
                      Text{"The awakened ones will await for the&Hero to collect #%d |Spiritual Stone|Spiritual Stones|#.",
                 /*french*/"Les êtres de sagesse attendront le&héros muni de #%d |pierre spirituelle|pierres spirituelles|#.",
-               /*spanish*/"Los sabios aguardarán a que el héroe&obtenga #%d |una piedra espiritual|unas piedras espirituales|#."},
+               /*spanish*/"Los sabios aguardarán a que el héroe&obtenga #%d |piedra espiritual|piedras espirituales|#."},
     });
 
     hintTable[BRIDGE_MEDALLIONS_HINT] = HintText::Bridge({
                      //obscure text                                                  singular  plural
                      Text{"The awakened ones will await for the&Hero to collect #%d |Medallion|Medallions|#.",
                 /*french*/"Les êtres de sagesse attendront le&héros muni de #%d |médaillon|médaillons|#.",
-               /*spanish*/"Los sabios aguardarán a que el héroe&obtenga #%d |un medallón|unos medallones|#."},
+               /*spanish*/"Los sabios aguardarán a que el héroe&obtenga #%d |medallón|medallones|#."},
     });
 
     hintTable[BRIDGE_REWARDS_HINT] = HintText::Bridge({
                      //obscure text                                                  singular                     plural
                      Text{"The awakened ones will await for the&Hero to collect #%d |Spiritual Stone&or Medallion|Spiritual Stones&and Medallions|#.",
                 /*french*/"Les êtres de sagesse attendront le&héros muni de #%d |pierre spirituelle&ou médaillon|pierres spirituelles&et médaillons|#.",
-               /*spanish*/"Los sabios aguardarán a que el héroe&obtenga #%d |una piedra espiritual o medallón|unas piedras espirtuales y unos medallones|#."},
+               /*spanish*/"Los sabios aguardarán a que el héroe&obtenga #%d |piedra espiritual o medallón|piedras espirtuales y medallones|#."},
     });
 
     hintTable[BRIDGE_DUNGEONS_HINT] = HintText::Bridge({
                      //obscure text                                                  singular plural
                      Text{"The awakened ones will await for the&Hero to conquer #%d |Dungeon|Dungeons|#.",
                 /*french*/"Les êtres de sagesse attendront la&conquête de #%d |donjon|donjons|#.",
-               /*spanish*/"Los sabios aguardarán a que el héroe& complete #%d |una mazmorra|unas mazmorras|#."},
+               /*spanish*/"Los sabios aguardarán a que el héroe& complete #%d |mazmorra|mazmorras|#."},
     });
 
     hintTable[BRIDGE_TOKENS_HINT] = HintText::Bridge({
                      //obscure text
                      Text{"The awakened ones will await for the&Hero to collect #%d |Gold Skulltula&Token|Gold Skulltula&Tokens|#.",
                 /*french*/"Les êtres de sagesse attendront le&héros muni de #%d |symbole|symboles| de&Skulltula d'or#.",
-               /*spanish*/"Los sabios aguardarán a que el héroe&obtenga #%d |un símbolo|unos símbolos| de&skulltula dorada#."},
+               /*spanish*/"Los sabios aguardarán a que el héroe&obtenga #%d |símbolo|símbolos| de&skulltula dorada#."},
     });
 
     /*--------------------------
@@ -6900,35 +6900,35 @@ void HintTable_Init() {
                      //obscure text                                                     singular      plural
                      Text{"And the #evil one#'s key will be&provided by Zelda once #%d&|Medallion# is|Medallions# are| retrieved.",
                 /*french*/"Aussi, Zelda crééra la clé du&#Malin# avec #%d |médaillon|médaillons|#.",
-               /*spanish*/"Y Zelda entregará la llave&del #señor del mal# tras obtener&#%d |un medallón|unos medallones|#."},
+               /*spanish*/"Y Zelda entregará la llave&del #señor del mal# tras obtener&#%d |medallón|medallones|#."},
     });
 
     hintTable[LACS_STONES_HINT] = HintText::LACS({
                      //obscure text                                                     singular            plural
                      Text{"And the #evil one#'s key will be&provided by Zelda once #%d |Spiritual&Stone# is|Spiritual&Stones# are| retrieved.",
                 /*french*/"Aussi, Zelda crééra la clé du&#Malin# avec #%d des |pierre&spirituelle|pierres&spirituelles|#.",
-               /*spanish*/"Y Zelda entregará la llave&del #señor del mal# tras obtener&#%d |una piedra espiritual|unas piedras espirituales|#."},
+               /*spanish*/"Y Zelda entregará la llave&del #señor del mal# tras obtener&#%d |piedra espiritual|piedras espirituales|#."},
     });
 
     hintTable[LACS_REWARDS_HINT] = HintText::LACS({
                      //obscure text                                                     singular                         plural
                      Text{"And the #evil one#'s key will be&provided by Zelda once #%d |Spiritual&Stone or Medallion# is|Spiritual&Stones and Medallions# are| retrieved.",
                 /*french*/"Aussi, Zelda crééra la clé du&#Malin# avec #%d |pierre spirituelle&et des médaillon|pierres spirituelles&et des médaillons|#.",
-               /*spanish*/"Y Zelda entregará la llave&del #señor del mal# tras obtener&#%d |una piedra espiritual o medallón|unas piedras espirituales o unos medallones|#."},
+               /*spanish*/"Y Zelda entregará la llave&del #señor del mal# tras obtener&#%d |piedra espiritual o medallón|piedras espirituales o medallones|#."},
     });
 
     hintTable[LACS_DUNGEONS_HINT] = HintText::LACS({
                      //obscure text                                                     singular    plural
                      Text{"And the #evil one#'s key will be&provided by Zelda once #%d |Dungeon#&is|Dungeons#&are| conquered.",
                 /*french*/"Aussi, Zelda crééra la clé du&#Malin# une fois #%d |donjon conquéri|donjons conquéris|#.",
-               /*spanish*/"las #piedras espirituales y los medallones#"},
+               /*spanish*/"Y Zelda entregará la llave&del #señor del mal# tras completar&#%d |mazmorra|mazmorras|#."},
     });
 
     hintTable[LACS_TOKENS_HINT] = HintText::LACS({
                      //obscure text                                                     singular                 plural
                      Text{"And the #evil one#'s key will be&provided by Zelda once #%d |Gold&Skulltula Token# is|Gold&Skulltula Tokens# are| retrieved.",
                 /*french*/"Aussi, Zelda crééra la clé du&#Malin# avec #%d |symbole|symboles| de&Skulltula d'or#.",
-               /*spanish*/"Y Zelda entregará la llave&del #señor del mal# tras obtener&#%d |un símbolo|unos símbolos| de&skulltula dorada#."},
+               /*spanish*/"Y Zelda entregará la llave&del #señor del mal# tras obtener&#%d |símbolo|símbolos| de&skulltula dorada#."},
     });
     /*--------------------------
     |     TRIAL HINT TEXT      |


### PR DESCRIPTION
- The flag check to skip having to talk to Malon 3 times is fixed.
- The fishing rod can now be used normally in the fishing pond even when Temp B is 0xFF; placing the Goron Bracelet there is no longer needed, so it can't accidentally appear on the B button anymore.
- Some errors with the Spanish hints are corrected
- Savewarping after Dampe digs up the HP no longer makes the HP unobtainable the next time you pay for digging.