### PR TITLE
Alert for missing romfs folder

### DIFF
--- a/code/src/main.c
+++ b/code/src/main.c
@@ -5,6 +5,9 @@
 #include "models.h"
 #include "entrance.h"
 #include "settings.h"
+#include "title_screen.h"
+#include "draw.h"
+#include "common.h"
 
 #include "z3D/z3D.h"
 #include "3ds/extdata.h"
@@ -38,4 +41,11 @@ void before_GlobalContext_Update(GlobalContext* globalCtx) {
 }
 
 void after_GlobalContext_Update() {
+    // The alert is always displayed on the Title Screen, and for 10 seconds after opening a save file.
+    if (missingRomfsAlert && romfsAlertFrames > 0) {
+        Draw_DrawFormattedStringTop(75, 180, COLOR_WHITE, "WARNING: THE ROMFS FOLDER IS MISSING!\nCOPY IT FROM AND TO THE SAME LOCATIONS\nUSED FOR CODE.IPS AND EXHEADER.BIN");
+        if (IsInGame()) {
+            romfsAlertFrames--;
+        }
+    }
 }

--- a/code/src/title_screen.c
+++ b/code/src/title_screen.c
@@ -6,6 +6,9 @@
 #define EnMag_Init_addr 0x18CBB8
 #define EnMag_Init ((ActorFunc)EnMag_Init_addr)
 
+u8 missingRomfsAlert = 0;
+s16 romfsAlertFrames = 0;
+
 void EnMag_rInit(Actor* thisx, GlobalContext* globalCtx) {
     EnMag* this = (EnMag*)thisx;
 
@@ -31,4 +34,11 @@ void EnMag_rInit(Actor* thisx, GlobalContext* globalCtx) {
     TexAnim_Spawn(this->copyrightModel->unk_0C, cmabMan);
     this->copyrightModel->unk_0C->animSpeed = 0.0f;
     this->copyrightModel->unk_0C->animMode = 0;
+
+    if (cmabMan == 0) {
+        // If the pointer is 0, the romfs folder is not present.
+        // The 3DS would've crashed by this point, so this alert is for Citra only.
+        missingRomfsAlert = 1;
+        romfsAlertFrames = 300;
+    }
 }

--- a/code/src/title_screen.h
+++ b/code/src/title_screen.h
@@ -13,4 +13,7 @@ typedef struct {
 
 void EnMag_rInit(Actor* thisx, GlobalContext* globalCtx);
 
+extern u8 missingRomfsAlert;
+extern s16 romfsAlertFrames;
+
 #endif //_TITLE_SCREEN_H_


### PR DESCRIPTION
This will display an alert on the top screen if the romfs folder has not been copied over to the mods folder when playing on Citra.

The alert is always visible on the title screen. Once a file is opened, it disappears after 10 seconds.