### PR TITLE
Workflow: Update workflow to include stable releases

### DIFF
--- a/.github/workflows/create_release.yml
+++ b/.github/workflows/create_release.yml
@@ -1,0 +1,388 @@
+name: OoT3DR Release Builds
+
+on:
+  push:
+    branches: [ stable ]
+
+jobs:
+  build-cia-3dsx:
+    runs-on: ubuntu-latest
+    container:
+      image: phlex/oot3dr-build-tools
+
+    steps:
+      - uses: actions/checkout@v2
+
+      - name: Run Build Script
+      
+        run: |
+          chmod +x linux_build_rando.sh
+          ./linux_build_rando.sh
+          
+      - name: Get realease version from last merge.
+        id: vars
+        run: |
+          mkdir tmp
+          git clone --bare --no-checkout --single-branch --branch stable ${{ github.repositoryUrl }} ./tmp
+          cd tmp
+          echo "::set-output name=release_version::$(git log --pretty=format:%b -n 1 HEAD | awk '{print $2}')"
+          cd ../
+        
+
+      - name: Create Release
+        uses: ncipollo/release-action@v1.8.3
+        with:
+          token: "${{ secrets.GITHUB_TOKEN }}"
+          artifacts: "OoT3D_Randomizer.cia,OoT3D_Randomizer.3dsx,cia.png,3dsx.png"
+          prerelease: false
+          commit: "${{ github.sha }}"
+          tag: "v${{ steps.vars.outputs.release_version }}"
+          name: "v${{ steps.vars.outputs.release_version }}"
+          body: |
+            ${{ steps.vars.outputs.release_version }} Changes:
+            - Please check back later for a full list of changes.
+            
+            When reporting issues, please mention the six character commit listed in the randomizer menu.
+            You can use the FBI homebrew application to install the randomizer using either of these QR codes.
+            CIA QR Code:
+            ![CIA Download](https://github.com/${{ github.repository }}/releases/download/Nightly-${{ steps.vars.outputs.sha_short }}/cia.png)
+            3DSX QR Code:
+            ![CIA Download](https://github.com/${{ github.repository }}/releases/download/Nightly-${{ steps.vars.outputs.sha_short }}/3dsx.png)
+
+  deploy-gist:
+    needs: build-cia-3dsx
+    runs-on: ubuntu-latest
+    steps:
+      - name: Create basic JSON struct.
+
+        run: |
+          cat >> ./OoT3DR.unistore<< EOF
+          {
+            "storeContent": [
+              {
+                "info": {
+                  "title": "OoT3D Randomizer <VERSION_STABLE>",
+                  "author": "OoT3DR Team",
+                  "description": "A randomizer patch for OoT3D to be used with Luma for Nintendo 3DS",
+                  "category": [
+                    "game patch"
+                  ],
+                  "console": [
+                    "3DS"
+                  ],
+                  "icon_index": 2,
+                  "sheet_index": 0,
+                  "last_updated": "<VERSION_STABLE_MODIFIED> at <VERSION_STABLE_TIME> (UTC)",
+                  "license": "MIT",
+                  "version": "<VERSION_STABLE>"
+                },
+                "Download OoT3D_Randomizer.3dsx": [
+                  {
+                    "file": "https://github.com/gamestabled/Oot3d_randomizer/releases/latest/download/OoT3D_Randomizer.3dsx",
+                    "message": "Downloading OoT3D_Randomizer_<VERSION_STABLE>.3dsx...",
+                    "output": "%3DSX%/OoT3D_Randomizer_<VERSION_STABLE>.3dsx",
+                    "type": "downloadFile"
+                  }
+                ],
+                "Download OoT3D_Randomizer.cia": [
+                  {
+                    "file": "https://github.com/gamestabled/Oot3d_randomizer/releases/latest/download/OoT3D_Randomizer.cia",
+                    "message": "Downloading OoT3D_Randomizer_<VERSION_STABLE>.cia...",
+                    "output": "sdmc:/OoT3D_Randomizer_<VERSION_STABLE>.cia",
+                    "type": "downloadFile"
+                  },
+                  {
+                    "file": "/OoT3D_Randomizer_<VERSION_STABLE>.cia",
+                    "message": "Installing OoT3D_Randomizer_<VERSION_STABLE>.cia...",
+                    "type": "installCia"
+                  },
+                  {
+                    "file": "sdmc:/OoT3D_Randomizer_<VERSION_STABLE>.cia",
+                    "message": "Deleting OoT3D_Randomizer_<VERSION_STABLE>.cia.",
+                    "type": "deleteFile"
+                  }
+                ]
+              },
+              {
+                "info": {
+                  "title": "OoT3D Randomizer Nightly <NIGHTLY_1>",
+                  "author": "OoT3DR Team",
+                  "description": "A randomizer patch for OoT3D to be used with Luma for Nintendo 3DS",
+                  "category": [
+                    "game patch"
+                  ],
+                  "console": [
+                    "3DS"
+                  ],
+                  "icon_index": 1,
+                  "sheet_index": 0,
+                  "last_updated": "<NIGHTLY_1_CREATED> at <NIGHTLY_1_TIME> (UTC)",
+                  "license": "MIT",
+                  "version": "<NIGHTLY_1>"
+                },
+                "Download OoT3D_Randomizer.3dsx": [
+                  {
+                    "file": "<NIGHTLY_1_URL_3DSX>",
+                    "message": "Downloading OoT3D_Randomizer_<NIGHTLY_1>.3dsx...",
+                    "output": "%3DSX%/OoT3D_Randomizer_<NIGHTLY_1>.3dsx",
+                    "type": "downloadFile"
+                  }
+                ],
+                "Download OoT3D_Randomizer.cia": [
+                  {
+                    "file": "<NIGHTLY_1_URL_CIA>",
+                    "message": "Downloading OoT3D_Randomizer_<NIGHTLY_1>.cia...",
+                    "output": "sdmc:/OoT3D_Randomizer_<NIGHTLY_1>.cia",
+                    "type": "downloadFile"
+                  },
+                  {
+                    "file": "/OoT3D_Randomizer_<NIGHTLY_1>.cia",
+                    "message": "Installing OoT3D_Randomizer_<NIGHTLY_1>.cia...",
+                    "type": "installCia"
+                  },
+                  {
+                    "file": "sdmc:/OoT3D_Randomizer_<NIGHTLY_1>.cia",
+                    "message": "Deleting OoT3D_Randomizer_<NIGHTLY_1>.cia.",
+                    "type": "deleteFile"
+                  }
+                ]
+              },
+              {
+                "info": {
+                  "title": "OoT3D Randomizer Nightly <NIGHTLY_2>",
+                  "author": "OoT3DR Team",
+                  "description": "A randomizer patch for OoT3D to be used with Luma for Nintendo 3DS",
+                  "category": [
+                    "game patch"
+                  ],
+                  "console": [
+                    "3DS"
+                  ],
+                  "icon_index": 1,
+                  "sheet_index": 0,
+                  "last_updated": "<NIGHTLY_2_CREATED> at <NIGHTLY_2_TIME> (UTC)",
+                  "license": "MIT",
+                  "version": "<NIGHTLY_2>"
+                },
+                "Download OoT3D_Randomizer.3dsx": [
+                  {
+                    "file": "<NIGHTLY_2_URL_3DSX>",
+                    "message": "Downloading OoT3D_Randomizer_<NIGHTLY_2>.3dsx...",
+                    "output": "%3DSX%/OoT3D_Randomizer_<NIGHTLY_2>.3dsx",
+                    "type": "downloadFile"
+                  }
+                ],
+                "Download OoT3D_Randomizer.cia": [
+                  {
+                    "file": "<NIGHTLY_2_URL_CIA>",
+                    "message": "Downloading OoT3D_Randomizer_<NIGHTLY_2>.cia...",
+                    "output": "sdmc:/OoT3D_Randomizer_<NIGHTLY_2>.cia",
+                    "type": "downloadFile"
+                  },
+                  {
+                    "file": "/OoT3D_Randomizer_<NIGHTLY_2>.cia",
+                    "message": "Installing OoT3D_Randomizer_<NIGHTLY_2>.cia...",
+                    "type": "installCia"
+                  },
+                  {
+                    "file": "sdmc:/OoT3D_Randomizer_<NIGHTLY_2>.cia",
+                    "message": "Deleting OoT3D_Randomizer_<NIGHTLY_2>.cia.",
+                    "type": "deleteFile"
+                  }
+                ]
+              },
+              {
+                "info": {
+                  "title": "OoT3D Randomizer Nightly <NIGHTLY_3>",
+                  "author": "OoT3DR Team",
+                  "description": "A randomizer patch for OoT3D to be used with Luma for Nintendo 3DS",
+                  "category": [
+                    "game patch"
+                  ],
+                  "console": [
+                    "3DS"
+                  ],
+                  "icon_index": 1,
+                  "sheet_index": 0,
+                  "last_updated": "<NIGHTLY_3_CREATED> at <NIGHTLY_3_TIME> (UTC)",
+                  "license": "MIT",
+                  "version": "<NIGHTLY_3>"
+                },
+                "Download OoT3D_Randomizer.3dsx": [
+                  {
+                    "file": "<NIGHTLY_3_URL_3DSX>",
+                    "message": "Downloading OoT3D_Randomizer_<NIGHTLY_3>.3dsx...",
+                    "output": "%3DSX%/OoT3D_Randomizer_<NIGHTLY_3>.3dsx",
+                    "type": "downloadFile"
+                  }
+                ],
+                "Download OoT3D_Randomizer.cia": [
+                  {
+                    "file": "<NIGHTLY_3_URL_CIA>",
+                    "message": "Downloading OoT3D_Randomizer_<NIGHTLY_3>.cia...",
+                    "output": "sdmc:/OoT3D_Randomizer_<NIGHTLY_3>.cia",
+                    "type": "downloadFile"
+                  },
+                  {
+                    "file": "/OoT3D_Randomizer_<NIGHTLY_3>.cia",
+                    "message": "Installing OoT3D_Randomizer_<NIGHTLY_3>.cia...",
+                    "type": "installCia"
+                  },
+                  {
+                    "file": "sdmc:/OoT3D_Randomizer_<NIGHTLY_3>.cia",
+                    "message": "Deleting OoT3D_Randomizer_<NIGHTLY_3>.cia.",
+                    "type": "deleteFile"
+                  }
+                ]
+              },
+              {
+                "info": {
+                  "title": "OoT3D Randomizer Nightly <NIGHTLY_4>",
+                  "author": "OoT3DR Team",
+                  "description": "A randomizer patch for OoT3D to be used with Luma for Nintendo 3DS",
+                  "category": [
+                    "game patch"
+                  ],
+                  "console": [
+                    "3DS"
+                  ],
+                  "icon_index": 1,
+                  "sheet_index": 0,
+                  "last_updated": "<NIGHTLY_4_CREATED> at <NIGHTLY_4_TIME> (UTC)",
+                  "license": "MIT",
+                  "version": "<NIGHTLY_4>"
+                },
+                "Download OoT3D_Randomizer.3dsx": [
+                  {
+                    "file": "<NIGHTLY_4_URL_3DSX>",
+                    "message": "Downloading OoT3D_Randomizer_<NIGHTLY_4>.3dsx...",
+                    "output": "%3DSX%/OoT3D_Randomizer_<NIGHTLY_4>.3dsx",
+                    "type": "downloadFile"
+                  }
+                ],
+                "Download OoT3D_Randomizer.cia": [
+                  {
+                    "file": "<NIGHTLY_4_URL_CIA>",
+                    "message": "Downloading OoT3D_Randomizer_<NIGHTLY_4>.cia...",
+                    "output": "sdmc:/OoT3D_Randomizer_<NIGHTLY_4>.cia",
+                    "type": "downloadFile"
+                  },
+                  {
+                    "file": "/OoT3D_Randomizer_<NIGHTLY_4>.cia",
+                    "message": "Installing OoT3D_Randomizer_<NIGHTLY_4>.cia...",
+                    "type": "installCia"
+                  },
+                  {
+                    "file": "sdmc:/OoT3D_Randomizer_<NIGHTLY_4>.cia",
+                    "message": "Deleting OoT3D_Randomizer_<NIGHTLY_4>.cia.",
+                    "type": "deleteFile"
+                  }
+                ]
+              },
+              {
+                "info": {
+                  "title": "OoT3D Randomizer Nightly <NIGHTLY_5>",
+                  "author": "OoT3DR Team",
+                  "description": "A randomizer patch for OoT3D to be used with Luma for Nintendo 3DS",
+                  "category": [
+                    "game patch"
+                  ],
+                  "console": [
+                    "3DS"
+                  ],
+                  "icon_index": 1,
+                  "sheet_index": 0,
+                  "last_updated": "<NIGHTLY_5_CREATED> at <NIGHTLY_5_TIME> (UTC)",
+                  "license": "MIT",
+                  "version": "<NIGHTLY_5>"
+                },
+                "Download OoT3D_Randomizer.3dsx": [
+                  {
+                    "file": "<NIGHTLY_5_URL_3DSX>",
+                    "message": "Downloading OoT3D_Randomizer_<NIGHTLY_5>.3dsx...",
+                    "output": "%3DSX%/OoT3D_Randomizer_<NIGHTLY_5>.3dsx",
+                    "type": "downloadFile"
+                  }
+                ],
+                "Download OoT3D_Randomizer.cia": [
+                  {
+                    "file": "<NIGHTLY_5_URL_CIA>",
+                    "message": "Downloading OoT3D_Randomizer_<NIGHTLY_5>.cia...",
+                    "output": "sdmc:/OoT3D_Randomizer_<NIGHTLY_5>.cia",
+                    "type": "downloadFile"
+                  },
+                  {
+                    "file": "/OoT3D_Randomizer_<NIGHTLY_5>.cia",
+                    "message": "Installing OoT3D_Randomizer_<NIGHTLY_5>.cia...",
+                    "type": "installCia"
+                  },
+                  {
+                    "file": "sdmc:/OoT3D_Randomizer_<NIGHTLY_5>.cia",
+                    "message": "Deleting OoT3D_Randomizer_<NIGHTLY_5>.cia.",
+                    "type": "deleteFile"
+                  }
+                ]
+              }
+            ],
+            "storeInfo": {
+              "title": "OoT3D Randomizer",
+              "author": "OoT3DR Team",
+              "description": "OoT3D Randomizer - An online database of the most recent versions of the random experience for OoT3D",
+              "url": "http://tiny.cc/unistore",
+              "file": "Oot3DR.unistore",
+              "sheetURL": "https://dl.dropboxusercontent.com/s/5qv4ngozhgmyyen/OoT3DR.t3x?dl=1",
+              "sheet": "OoT3DR.t3x",
+              "bg_index": 1,
+              "bg_sheet": 0,
+              "revision": <REV_NUMBER>,
+              "version": 3
+            }
+          }
+          EOF
+          echo "Forgive me for this."
+          curl -sb -H "https://api.github.com/repos/gamestabled/OoT3D_Randomizer/releases" | jq '.[0:8] | .[].assets | .[3] | (.browser_download_url + " " +.created_at)' | grep "Nightly" | head -n 5 >> ciaDownloads.txt
+          curl -sb -H "https://api.github.com/repos/gamestabled/OoT3D_Randomizer/releases" | jq '.[0:8] | .[].assets | .[2] | (.browser_download_url + " " +.created_at)' | grep "Nightly" | head -n 5 >> 3dsxDownloads.txt
+          STABLEVERSION=`curl -sb -H "https://api.github.com/repos/gamestabled/OoT3D_Randomizer/releases/latest" | jq '.name'`
+          STABLEMODIFIED=`curl -sb -H "https://api.github.com/repos/gamestabled/OoT3D_Randomizer/releases/latest" | jq '.published_at'`
+          STABLEVERSION=`sed -e 's/^"//' -e 's/"$//' <<<"$STABLEVERSION"`
+          STABLEMODIFIED=`sed -e 's/^"//' -e 's/"$//' <<<"$STABLEMODIFIED"`
+          REVISION=`curl -Is -k "https://api.github.com/repos/gamestabled/OoT3D_Randomizer/commits?per_page=1" | sed -n '/^[Ll]ink:/ s/.*"next".*page=\([0-9]*\).*"last".*/\1/p'`
+          MODIFIED=$(echo ${STABLEMODIFIED} | cut -c1-10)
+          MODIFIED_DATE=$(echo ${STABLEMODIFIED} | cut -c12-19)
+          sed -i "s#<VERSION_STABLE>#${STABLEVERSION}#g" OoT3DR.unistore
+          sed -i "s#<VERSION_STABLE_MODIFIED>#$MODIFIED#g" OoT3DR.unistore
+          sed -i "s#<VERSION_STABLE_TIME>#$MODIFIED_DATE#g" OoT3DR.unistore
+          sed -i "s#<REV_NUMBER>#$REVISION#g" OoT3DR.unistore
+          LINES=$(cat ciaDownloads.txt)
+          LINENUM=1
+          IFS=$'\n' 
+          for LINE in $LINES
+          do
+              LINE=`sed -e 's/^"//' -e 's/"$//' <<<"$LINE"`
+              ARRLINE=($(echo $LINE | tr " " "\n"))
+              sed -i "s#<NIGHTLY_${LINENUM}_URL_CIA>#${ARRLINE[0]}#g" OoT3DR.unistore
+              VERSION=$(echo ${ARRLINE[0]} | cut -c75-80)
+              MODIFIED=$(echo ${ARRLINE[1]} | cut -c1-10)
+              MODIFIED_DATE=$(echo ${ARRLINE[1]} | cut -c12-19)
+              sed -i "s#<NIGHTLY_$LINENUM>#$VERSION#g" OoT3DR.unistore
+              sed -i "s#<NIGHTLY_${LINENUM}_CREATED>#$MODIFIED#g" OoT3DR.unistore
+              sed -i "s#<NIGHTLY_${LINENUM}_TIME>#$MODIFIED_DATE#g" OoT3DR.unistore
+              LINENUM=`expr $LINENUM + 1`
+          done
+          LINES=$(cat 3dsxDownloads.txt)
+          LINENUM=1
+          for LINE in $LINES
+          do
+              LINE=`sed -e 's/^"//' -e 's/"$//' <<<"$LINE"`
+              ARRLINE=($(echo $LINE | tr " " "\n"))
+              sed -i "s#<NIGHTLY_${LINENUM}_URL_3DSX>#${ARRLINE[0]}#g" OoT3DR.unistore
+              LINENUM=`expr $LINENUM + 1`
+          done
+
+      - name: Deploy to Gist
+        uses: exuanbo/actions-deploy-gist@v1
+        with:
+          token: ${{ secrets.TOKEN }}
+          gist_id: fa5ea9b42b99377c63bede1cf8ddfdad
+          gist_file_name: OoT3DR.unistore
+          file_path: ./OoT3DR.unistore


### PR DESCRIPTION
Goodbye annoying workflow for releasing stable version releases. With this merge request I've created a new workflow that operates only on the `stable` branch. When merging into stable, you just have to ensure the body of the merge request (attached photo) has "Release X` where X is the version number.
![image](https://user-images.githubusercontent.com/3514085/152000378-ae699213-a223-44ef-8471-9897a0b709f4.png)

This will create a brand new release, and only thing that would need to be done is just adjust the list of changes. If you wish, it's also possible to change it to a draft and then publish it after the changelog is inserted as well. 