### PR TITLE
Add local multiplayer

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,5 @@
 *vscode/*
+*vs/*
 backup/*
 build/*
 *.txt

--- a/code/Makefile
+++ b/code/Makefile
@@ -65,7 +65,7 @@ CFLAGS	+=	$(INCLUDE) -DARM11 -D_3DS $(VERFLAGS)
 CXXFLAGS	:= $(CFLAGS) -fno-rtti -fno-exceptions -std=gnu++11
 
 ASFLAGS	+=	-g $(ARCH) $(VERFLAGS)
-LDFLAGS	=	-g $(ARCH) -Wl,-Map,$(notdir $*.map) -T $(TOPDIR)/$(LINK_SCRIPT) -nostdlib $(VERFLAGS) -lgcc
+LDFLAGS	=	-g $(ARCH) -Wl,-Map,$(notdir $*.map) -T $(TOPDIR)/$(LINK_SCRIPT) $(VERFLAGS) -lgcc
 
 LIBS	:=	-lgcc
 

--- a/code/include/3ds/services/cfgu.h
+++ b/code/include/3ds/services/cfgu.h
@@ -1,0 +1,220 @@
+/**
+ * @file cfgu.h
+ * @brief CFGU (Configuration) Service
+ */
+#pragma once
+#include <3ds/types.h>
+
+/// Configuration region values.
+typedef enum
+{
+	CFG_REGION_JPN = 0, ///< Japan
+	CFG_REGION_USA = 1, ///< USA
+	CFG_REGION_EUR = 2, ///< Europe
+	CFG_REGION_AUS = 3, ///< Australia
+	CFG_REGION_CHN = 4, ///< China
+	CFG_REGION_KOR = 5, ///< Korea
+	CFG_REGION_TWN = 6, ///< Taiwan
+} CFG_Region;
+
+/// Configuration language values.
+typedef enum
+{
+	CFG_LANGUAGE_JP = 0,  ///< Japanese
+	CFG_LANGUAGE_EN = 1,  ///< English
+	CFG_LANGUAGE_FR = 2,  ///< French
+	CFG_LANGUAGE_DE = 3,  ///< German
+	CFG_LANGUAGE_IT = 4,  ///< Italian
+	CFG_LANGUAGE_ES = 5,  ///< Spanish
+	CFG_LANGUAGE_ZH = 6,  ///< Simplified Chinese
+	CFG_LANGUAGE_KO = 7,  ///< Korean
+	CFG_LANGUAGE_NL = 8,  ///< Dutch
+	CFG_LANGUAGE_PT = 9,  ///< Portugese
+	CFG_LANGUAGE_RU = 10, ///< Russian
+	CFG_LANGUAGE_TW = 11, ///< Traditional Chinese
+} CFG_Language;
+
+// Configuration system model values.
+typedef enum
+{
+	CFG_MODEL_3DS    = 0, ///< Old 3DS (CTR)
+	CFG_MODEL_3DSXL  = 1, ///< Old 3DS XL (SPR)
+	CFG_MODEL_N3DS   = 2, ///< New 3DS (KTR)
+	CFG_MODEL_2DS    = 3, ///< Old 2DS (FTR)
+	CFG_MODEL_N3DSXL = 4, ///< New 3DS XL (RED)
+	CFG_MODEL_N2DSXL = 5, ///< New 2DS XL (JAN)
+} CFG_SystemModel;
+
+/// Initializes CFGU.
+Result cfguInit(void);
+
+/// Exits CFGU.
+void cfguExit(void);
+
+/**
+ * @brief Gets the system's region from secure info.
+ * @param region Pointer to output the region to. (see @ref CFG_Region)
+ */
+Result CFGU_SecureInfoGetRegion(u8* region);
+
+/**
+ * @brief Generates a console-unique hash.
+ * @param appIDSalt Salt to use.
+ * @param hash Pointer to output the hash to.
+ */
+Result CFGU_GenHashConsoleUnique(u32 appIDSalt, u64* hash);
+
+/**
+ * @brief Gets whether the system's region is Canada or USA.
+ * @param value Pointer to output the result to. (0 = no, 1 = yes)
+ */
+Result CFGU_GetRegionCanadaUSA(u8* value);
+
+/**
+ * @brief Gets the system's model.
+ * @param model Pointer to output the model to. (see @ref CFG_SystemModel)
+ */
+Result CFGU_GetSystemModel(u8* model);
+
+/**
+ * @brief Gets whether the system is a 2DS.
+ * @param value Pointer to output the result to. (0 = yes, 1 = no)
+ */
+Result CFGU_GetModelNintendo2DS(u8* value);
+
+/**
+ * @brief Gets a string representing a country code.
+ * @param code Country code to use.
+ * @param string Pointer to output the string to.
+ */
+Result CFGU_GetCountryCodeString(u16 code, u16* string);
+
+/**
+ * @brief Gets a country code ID from its string.
+ * @param string String to use.
+ * @param code Pointer to output the country code to.
+ */
+Result CFGU_GetCountryCodeID(u16 string, u16* code);
+
+/**
+ * @brief Checks if NFC (code name: fangate) is supported.
+ * @param isSupported pointer to the output the result to.
+ */
+Result CFGU_IsNFCSupported(bool* isSupported);
+
+/**
+ * @brief Gets a config info block with flags = 2.
+ * @param size Size of the data to retrieve.
+ * @param blkID ID of the block to retrieve.
+ * @param outData Pointer to write the block data to.
+ */
+Result CFGU_GetConfigInfoBlk2(u32 size, u32 blkID, void* outData);
+
+/**
+ * @brief Gets a config info block with flags = 4.
+ * @param size Size of the data to retrieve.
+ * @param blkID ID of the block to retrieve.
+ * @param outData Pointer to write the block data to.
+ */
+Result CFG_GetConfigInfoBlk4(u32 size, u32 blkID, void* outData);
+
+/**
+ * @brief Gets a config info block with flags = 8.
+ * @param size Size of the data to retrieve.
+ * @param blkID ID of the block to retrieve.
+ * @param outData Pointer to write the block data to.
+ */
+Result CFG_GetConfigInfoBlk8(u32 size, u32 blkID, void* outData);
+
+/**
+ * @brief Sets a config info block with flags = 4.
+ * @param size Size of the data to retrieve.
+ * @param blkID ID of the block to retrieve.
+ * @param inData Pointer to block data to write.
+ */
+Result CFG_SetConfigInfoBlk4(u32 size, u32 blkID, const void* inData);
+
+/**
+ * @brief Sets a config info block with flags = 8.
+ * @param size Size of the data to retrieve.
+ * @param blkID ID of the block to retrieve.
+ * @param inData Pointer to block data to write.
+ */
+Result CFG_SetConfigInfoBlk8(u32 size, u32 blkID, const void* inData);
+
+
+/**
+ * @brief Writes the CFG buffer in memory to the savegame in NAND.
+ */
+Result CFG_UpdateConfigSavegame(void);
+
+/**
+ * @brief Gets the system's language.
+ * @param language Pointer to write the language to. (see @ref CFG_Language)
+ */
+Result CFGU_GetSystemLanguage(u8* language);
+
+/**
+ * @brief Deletes the NAND LocalFriendCodeSeed file, then recreates it using the LocalFriendCodeSeed data stored in memory.
+ */
+Result CFGI_RestoreLocalFriendCodeSeed(void);
+
+/**
+ * @brief Deletes the NAND SecureInfo file, then recreates it using the SecureInfo data stored in memory.
+ */
+Result CFGI_RestoreSecureInfo(void);
+
+/**
+ * @brief Deletes the "config" file stored in the NAND Config_Savegame.
+ */
+Result CFGI_DeleteConfigSavefile(void);
+
+/**
+ * @brief Formats Config_Savegame.
+ */
+Result CFGI_FormatConfig(void);
+
+/**
+ * @brief Clears parental controls
+ */
+Result CFGI_ClearParentalControls(void);
+
+/**
+ * @brief Verifies the RSA signature for the LocalFriendCodeSeed data already stored in memory.
+ */
+Result CFGI_VerifySigLocalFriendCodeSeed(void);
+
+/**
+ * @brief Verifies the RSA signature for the SecureInfo data already stored in memory.
+ */
+Result CFGI_VerifySigSecureInfo(void);
+
+/**
+ * @brief Gets the system's serial number.
+ * @param serial Pointer to output the serial to. (This is normally 0xF)
+ */
+Result CFGI_SecureInfoGetSerialNumber(u8 *serial);
+
+/**
+ * @brief Gets the 0x110-byte buffer containing the data for the LocalFriendCodeSeed.
+ * @param data Pointer to output the buffer. (The size must be at least 0x110-bytes)
+ */
+Result CFGI_GetLocalFriendCodeSeedData(u8 *data);
+
+/**
+ * @brief Gets the 64-bit local friend code seed.
+ * @param seed Pointer to write the friend code seed to.
+ */
+Result CFGI_GetLocalFriendCodeSeed(u64* seed);
+
+/**
+ * @brief Gets the 0x11-byte data following the SecureInfo signature.
+ * @param data Pointer to output the buffer. (The size must be at least 0x11-bytes)
+ */
+Result CFGI_GetSecureInfoData(u8 *data);
+
+/**
+ * @brief Gets the 0x100-byte RSA-2048 SecureInfo signature.
+ * @param data Pointer to output the buffer. (The size must be at least 0x100-bytes)
+ */
+Result CFGI_GetSecureInfoSignature(u8 *data);

--- a/code/include/3ds/services/ndm.h
+++ b/code/include/3ds/services/ndm.h
@@ -1,0 +1,147 @@
+/**
+ * @file ndm.h
+ * @brief NDMU service. https://3dbrew.org/wiki/NDM_Services
+ */
+#pragma once
+
+/// Exclusive states.
+typedef enum {
+	NDM_EXCLUSIVE_STATE_NONE = 0,
+	NDM_EXCLUSIVE_STATE_INFRASTRUCTURE = 1,
+	NDM_EXCLUSIVE_STATE_LOCAL_COMMUNICATIONS = 2,
+	NDM_EXCLUSIVE_STATE_STREETPASS = 3,
+	NDM_EXCLUSIVE_STATE_STREETPASS_DATA = 4,
+} ndmExclusiveState;
+
+/// Current states.
+typedef enum {
+	NDM_STATE_INITIAL = 0,
+	NDM_STATE_SUSPENDED = 1,
+	NDM_STATE_INFRASTRUCTURE_CONNECTING = 2,
+	NDM_STATE_INFRASTRUCTURE_CONNECTED = 3,
+	NDM_STATE_INFRASTRUCTURE_WORKING = 4,
+	NDM_STATE_INFRASTRUCTURE_SUSPENDING = 5,
+	NDM_STATE_INFRASTRUCTURE_FORCE_SUSPENDING = 6,
+	NDM_STATE_INFRASTRUCTURE_DISCONNECTING = 7,
+	NDM_STATE_INFRASTRUCTURE_FORCE_DISCONNECTING = 8,
+	NDM_STATE_CEC_WORKING = 9,
+	NDM_STATE_CEC_FORCE_SUSPENDING = 10,
+	NDM_STATE_CEC_SUSPENDING = 11,
+} ndmState;
+
+// Daemons.
+typedef enum {
+	NDM_DAEMON_CEC = 0,
+	NDM_DAEMON_BOSS = 1,
+	NDM_DAEMON_NIM = 2,
+	NDM_DAEMON_FRIENDS = 3,
+} ndmDaemon;
+
+/// Used to specify multiple daemons.
+typedef enum {
+	NDM_DAEMON_MASK_CEC = BIT(NDM_DAEMON_CEC),
+	NDM_DAEMON_MASK_BOSS = BIT(NDM_DAEMON_BOSS),
+	NDM_DAEMON_MASK_NIM = BIT(NDM_DAEMON_NIM),
+	NDM_DAEMON_MASK_FRIENDS = BIT(NDM_DAEMON_FRIENDS),
+	NDM_DAEMON_MASK_BACKGROUOND = NDM_DAEMON_MASK_CEC | NDM_DAEMON_MASK_BOSS | NDM_DAEMON_MASK_NIM,
+	NDM_DAEMON_MASK_ALL = NDM_DAEMON_MASK_CEC | NDM_DAEMON_MASK_BOSS | NDM_DAEMON_MASK_NIM | NDM_DAEMON_MASK_FRIENDS,
+	NDM_DAEMON_MASK_DEFAULT = NDM_DAEMON_MASK_CEC | NDM_DAEMON_MASK_FRIENDS,
+} ndmDaemonMask;
+
+// Daemon status.
+typedef enum {
+	NDM_DAEMON_STATUS_BUSY = 0,
+	NDM_DAEMON_STATUS_IDLE = 1,
+	NDM_DAEMON_STATUS_SUSPENDING = 2,
+	NDM_DAEMON_STATUS_SUSPENDED = 3,
+} ndmDaemonStatus;
+
+/// Initializes ndmu.
+Result ndmuInit(void);
+
+/// Exits ndmu.
+void ndmuExit(void);
+
+/**
+ * @brief Sets the network daemon to an exclusive state.
+ * @param state State specified in the ndmExclusiveState enumerator.
+ */
+Result NDMU_EnterExclusiveState(ndmExclusiveState state);
+
+///  Cancels an exclusive state for the network daemon.
+Result NDMU_LeaveExclusiveState(void);
+
+/**
+ * @brief Returns the exclusive state for the network daemon.
+ * @param state Pointer to write the exclsuive state to.
+ */
+Result NDMU_GetExclusiveState(ndmExclusiveState *state);
+
+///  Locks the exclusive state.
+Result NDMU_LockState(void);
+
+///  Unlocks the exclusive state.
+Result NDMU_UnlockState(void);
+
+/**
+ * @brief Suspends network daemon.
+ * @param mask The specified daemon.
+ */
+Result NDMU_SuspendDaemons(ndmDaemonMask mask);
+
+/**
+ * @brief Resumes network daemon.
+ * @param mask The specified daemon.
+ */
+Result NDMU_ResumeDaemons(ndmDaemonMask mask);
+
+/**
+ * @brief Suspends scheduling for all network daemons.
+ * @param flag 0 = Wait for completion, 1 = Perform in background.
+ */
+Result NDMU_SuspendScheduler(u32 flag);
+
+/// Resumes daemon scheduling.
+Result NDMU_ResumeScheduler(void);
+
+/**
+ * @brief Returns the current state for the network daemon.
+ * @param state Pointer to write the current state to.
+ */
+Result NDMU_GetCurrentState(ndmState *state);
+
+/**
+ * @brief Returns the daemon state.
+ * @param state Pointer to write the daemons state to.
+ */
+Result NDMU_QueryStatus(ndmDaemonStatus *status);
+
+/**
+ * @brief Sets the scan interval.
+ * @param interval Value to set the scan interval to.
+ */
+Result NDMU_SetScanInterval(u32 interval);
+
+/**
+ * @brief Returns the scan interval.
+ * @param interval Pointer to write the interval value to.
+ */
+Result NDMU_GetScanInterval(u32 *interval);
+
+/**
+ * @brief Returns the retry interval.
+ * @param interval Pointer to write the interval value to.
+ */
+Result NDMU_GetRetryInterval(u32 *interval);
+
+/// Reverts network daemon to defaults.
+Result NDMU_ResetDaemons(void);
+
+/**
+ * @brief Gets the current default daemon bit mask.
+ * @param interval Pointer to write the default daemon mask value to. The default value is (DAEMONMASK_CEC | DAEMONMASK_FRIENDS)
+ */
+Result NDMU_GetDefaultDaemons(ndmDaemonMask *mask);
+
+///  Clears half awake mac filter.
+Result NDMU_ClearMacFilter(void);

--- a/code/include/3ds/services/uds.h
+++ b/code/include/3ds/services/uds.h
@@ -1,0 +1,370 @@
+/**
+ * @file uds.h
+ * @brief UDS(NWMUDS) local-WLAN service. https://3dbrew.org/wiki/NWM_Services
+ * Edited from https://github.com/devkitPro/libctru/blob/c941b0d2d2409376fc80ed4da4cb1338ce8a71ed/libctru/include/3ds/services/uds.h
+ */
+#pragma once
+
+#include <3ds/types.h>
+
+ /// Maximum number of nodes(devices) that can be connected to the network.
+#define UDS_MAXNODES 16
+
+/// Broadcast value for NetworkNodeID / alias for all NetworkNodeIDs.
+#define UDS_BROADCAST_NETWORKNODEID 0xFFFF
+
+/// NetworkNodeID for the host(the first node).
+#define UDS_HOST_NETWORKNODEID 0x1
+
+/// Default recv_buffer_size that can be used for udsBind() input / code which uses udsBind() internally.
+#define UDS_DEFAULT_RECVBUFSIZE 0x2E30
+
+/// Max size of user data-frames.
+#define UDS_DATAFRAME_MAXSIZE 0x5C6
+
+/// Check whether a fatal udsSendTo error occured(some error(s) from udsSendTo() can be ignored, but the frame won't be sent when that happens).
+#define UDS_CHECK_SENDTO_FATALERROR(x) (R_FAILED(x) && x!=0xC86113F0)
+
+/// Node info struct.
+typedef struct {
+	u64 uds_friendcodeseed;//UDS version of the FriendCodeSeed.
+
+	union {
+		u8 usercfg[0x18];//This is the first 0x18-bytes from this config block: https://www.3dbrew.org/wiki/Config_Savegame#0x000A0000_Block
+
+		struct {
+			u16 username[10];
+
+			u16 unk_x1c;//Unknown, normally zero. Set to 0x0 with the output from udsScanBeacons().
+			u8 flag;//"u8 flag, unknown. Originates from the u16 bitmask in the beacon node-list header. This flag is normally 0 since that bitmask is normally 0?"
+			u8 pad_x1f;//Unknown, normally zero.
+		};
+	};
+
+	//The rest of this is initialized by NWM-module.
+	u16 NetworkNodeID;
+	u16 pad_x22;//Unknown, normally zero?
+	u32 word_x24;//Normally zero?
+} udsNodeInfo;
+
+/// Connection status struct.
+typedef struct {
+	u32 status;
+	u32 unk_x4;
+	u16 cur_NetworkNodeID;//"u16 NetworkNodeID for this device."
+	u16 unk_xa;
+	u32 unk_xc[0x20 >> 2];
+
+	u8 total_nodes;
+	u8 max_nodes;
+	u16 node_bitmask;//"This is a bitmask of NetworkNodeIDs: bit0 for NetworkNodeID 0x1(host), bit1 for NetworkNodeID 0x2(first original client), and so on."
+} udsConnectionStatus;
+
+/// Network struct stored as big-endian.
+typedef struct {
+	u8 host_macaddress[6];
+	u8 channel;//Wifi channel for this network. If you want to create a network on a specific channel instead of the system selecting it, you can set this to a non-zero channel value.
+	u8 pad_x7;
+
+	u8 initialized_flag;//Must be non-zero otherwise NWM-module will use zeros internally instead of the actual field data, for most/all(?) of the fields in this struct.
+
+	u8 unk_x9[3];
+
+	u8 oui_value[3];//"This is the OUI value for use with the beacon tags. Normally this is 001F32."
+	u8 oui_type;//"OUI type (21/0x15)"
+
+	u32 wlancommID;//Unique local-WLAN communications ID for each application.
+	u8 id8;//Additional ID that can be used by the application for different types of networks.
+	u8 unk_x15;
+
+	u16 attributes;//See the UDSNETATTR enum values below.
+
+	u32 networkID;
+
+	u8 total_nodes;
+	u8 max_nodes;
+	u8 unk_x1e;
+	u8 unk_x1f;
+	u8 unk_x20[0x1f];
+
+	u8 appdata_size;
+	u8 appdata[0xc8];
+} udsNetworkStruct;
+
+typedef struct {
+	u32 BindNodeID;
+	Handle event;
+	bool spectator;
+} udsBindContext;
+
+/// General NWM input structure used for AP scanning.
+typedef struct {
+	u16 unk_x0;
+	u16 unk_x2;
+	u16 unk_x4;
+	u16 unk_x6;
+
+	u8 mac_address[6];
+
+	u8 unk_xe[0x26];//Not initialized by dlp.
+} nwmScanInputStruct;
+
+/// General NWM output structure from AP scanning.
+typedef struct {
+	u32 maxsize;//"Max output size, from the command request."
+	u32 size;//"Total amount of output data written relative to struct+0. 0xC when there's no entries."
+	u32 total_entries;//"Total entries, 0 for none. "
+
+	//The entries start here.
+} nwmBeaconDataReplyHeader;
+
+/// General NWM output structure from AP scanning, for each entry.
+typedef struct {
+	u32 size;//"Size of this entire entry. The next entry starts at curentry_startoffset+curentry_size."
+	u8 unk_x4;
+	u8 channel;//Wifi channel for the AP.
+	u8 unk_x6;
+	u8 unk_x7;
+	u8 mac_address[6];//"AP MAC address."
+	u8 unk_xe[6];
+	u32 unk_x14;
+	u32 val_x1c;//"Value 0x1C(size of this header and/or offset to the actual beacon data)."
+
+	//The actual beacon data starts here.
+} nwmBeaconDataReplyEntry;
+
+/// Output structure generated from host scanning output.
+typedef struct {
+	nwmBeaconDataReplyEntry datareply_entry;
+	udsNetworkStruct network;
+	udsNodeInfo nodes[UDS_MAXNODES];
+} udsNetworkScanInfo;
+
+enum {
+	UDSNETATTR_DisableConnectSpectators = BIT(0), //When set new Spectators are not allowed to connect.
+	UDSNETATTR_DisableConnectClients = BIT(1), //When set new Clients are not allowed to connect.
+	UDSNETATTR_x4 = BIT(2), //Unknown what this bit is for.
+	UDSNETATTR_Default = BIT(15), //Unknown what this bit is for.
+};
+
+enum {
+	UDS_SENDFLAG_Default = BIT(0), //Unknown what this bit is for.
+	UDS_SENDFLAG_Broadcast = BIT(1) //When set, broadcast the data frame via the destination MAC address even when UDS_BROADCAST_NETWORKNODEID isn't used.
+};
+
+typedef enum {
+	UDSCONTYPE_Client = 0x1,
+	UDSCONTYPE_Spectator = 0x2
+} udsConnectionType;
+
+/**
+ * @brief Initializes UDS.
+ * @param sharedmem_size This must be 0x1000-byte aligned.
+ * @param username Optional custom UTF-8 username(converted to UTF-16 internally) that other nodes on the UDS network can use. If not set the username from system-config is used. Max len is 10 characters without NUL-terminator.
+ */
+Result udsInit(size_t sharedmem_size, const char* username);
+
+/// Exits UDS.
+void udsExit(void);
+
+/**
+ * @brief Generates a NodeInfo struct with data loaded from system-config.
+ * @param nodeinfo Output NodeInfo struct.
+ * @param username If set, this is the UTF-8 string to convert for use in the struct. Max len is 10 characters without NUL-terminator.
+ */
+Result udsGenerateNodeInfo(udsNodeInfo* nodeinfo, const char* username);
+
+/**
+ * @brief Loads the UTF-16 username stored in the input NodeInfo struct, converted to UTF-8.
+ * @param nodeinfo Input NodeInfo struct.
+ * @param username This is the output UTF-8 string. Max len is 10 characters without NUL-terminator.
+ */
+Result udsGetNodeInfoUsername(const udsNodeInfo* nodeinfo, char* username);
+
+/**
+ * @brief Checks whether a NodeInfo struct was initialized by NWM-module(not any output from udsGenerateNodeInfo()).
+ * @param nodeinfo Input NodeInfo struct.
+ */
+bool udsCheckNodeInfoInitialized(const udsNodeInfo* nodeinfo);
+
+/**
+ * @brief Generates a default NetworkStruct for creating networks.
+ * @param network The output struct.
+ * @param wlancommID Unique local-WLAN communications ID for each application.
+ * @param id8 Additional ID that can be used by the application for different types of networks.
+ * @param max_nodes Maximum number of nodes(devices) that can be connected to the network, including the host.
+ */
+void udsGenerateDefaultNetworkStruct(udsNetworkStruct* network, u32 wlancommID, u8 id8, u8 max_nodes);
+
+/**
+ * @brief Scans for networks via beacon-scanning.
+ * @param outbuf Buffer which will be used by the beacon-scanning command and for the data parsing afterwards. Normally there's no need to use the contents of this buffer once this function returns.
+ * @param maxsize Max size of the buffer.
+ * @Param networks Ptr where the allocated udsNetworkScanInfo array buffer is written. The allocsize is sizeof(udsNetworkScanInfo)*total_networks.
+ * @Param total_networks Total number of networks stored under the networks buffer.
+ * @param wlancommID Unique local-WLAN communications ID for each application.
+ * @param id8 Additional ID that can be used by the application for different types of networks.
+ * @param host_macaddress When set, this code will only return network info from the specified host MAC address.
+ * @connected When not connected to a network this *must* be false. When connected to a network this *must* be true.
+ */
+Result udsScanBeacons(void* outbuf, size_t maxsize, udsNetworkScanInfo** networks, size_t* total_networks, u32 wlancommID, u8 id8, const u8* host_macaddress, bool connected);
+
+/**
+ * @brief This can be used by the host to set the appdata contained in the broadcasted beacons.
+ * @param buf Appdata buffer.
+ * @param size Size of the input appdata.
+ */
+Result udsSetApplicationData(const void* buf, size_t size);
+
+/**
+ * @brief This can be used while on a network(host/client) to get the appdata from the current beacon.
+ * @param buf Appdata buffer.
+ * @param size Max size of the output buffer.
+ * @param actual_size If set, the actual size of the appdata written into the buffer is stored here.
+ */
+Result udsGetApplicationData(void* buf, size_t size, size_t* actual_size);
+
+/**
+ * @brief This can be used with a NetworkStruct, from udsScanBeacons() mainly, for getting the appdata.
+ * @param buf Appdata buffer.
+ * @param size Max size of the output buffer.
+ * @param actual_size If set, the actual size of the appdata written into the buffer is stored here.
+ */
+Result udsGetNetworkStructApplicationData(const udsNetworkStruct* network, void* buf, size_t size, size_t* actual_size);
+
+/**
+ * @brief Create a bind.
+ * @param bindcontext The output bind context.
+ * @param NetworkNodeID This is the NetworkNodeID which this bind can receive data from.
+ * @param spectator False for a regular bind, true for a spectator.
+ * @param data_channel This is an arbitrary value to use for data-frame filtering. This bind will only receive data frames which contain a matching data_channel value, which was specified by udsSendTo(). The data_channel must be non-zero.
+ * @param recv_buffer_size Size of the buffer under sharedmem used for temporarily storing received data-frames which are then loaded by udsPullPacket(). The system requires this to be >=0x5F4. UDS_DEFAULT_RECVBUFSIZE can be used for this.
+ */
+Result udsBind(udsBindContext* bindcontext, u16 NetworkNodeID, bool spectator, u8 data_channel, u32 recv_buffer_size);
+
+/**
+ * @brief Remove a bind.
+ * @param bindcontext The bind context.
+ */
+Result udsUnbind(udsBindContext* bindcontext);
+
+/**
+ * @brief Waits for the bind event to occur, or checks if the event was signaled. This event is signaled every time new data is available via udsPullPacket().
+ * @return Always true. However if wait=false, this will return false if the event wasn't signaled.
+ * @param bindcontext The bind context.
+ * @param nextEvent Whether to discard the current event and wait for the next event.
+ * @param wait When true this will not return until the event is signaled. When false this checks if the event was signaled without waiting for it.
+ */
+bool udsWaitDataAvailable(const udsBindContext* bindcontext, bool nextEvent, bool wait);
+
+/**
+ * @brief Receives data over the network. This data is loaded from the recv_buffer setup by udsBind(). When a node disconnects, this will still return data from that node until there's no more frames from that node in the recv_buffer.
+ * @param bindcontext Bind context.
+ * @param buf Output receive buffer.
+ * @param size Size of the buffer.
+ * @param actual_size If set, the actual size written into the output buffer is stored here. This is zero when no data was received.
+ * @param src_NetworkNodeID If set, the source NetworkNodeID is written here. This is zero when no data was received.
+ */
+Result udsPullPacket(const udsBindContext* bindcontext, void* buf, size_t size, size_t* actual_size, u16* src_NetworkNodeID);
+
+/**
+ * @brief Sends data over the network.
+ * @param dst_NetworkNodeID Destination NetworkNodeID.
+ * @param data_channel See udsBind().
+ * @param flags Send flags, see the UDS_SENDFLAG enum values.
+ * @param buf Input send buffer.
+ * @param size Size of the buffer.
+ */
+Result udsSendTo(u16 dst_NetworkNodeID, u8 data_channel, u8 flags, const void* buf, size_t size);
+
+/**
+ * @brief Gets the wifi channel currently being used.
+ * @param channel Output channel.
+ */
+Result udsGetChannel(u8* channel);
+
+/**
+ * @brief Starts hosting a new network.
+ * @param network The NetworkStruct, you can use udsGenerateDefaultNetworkStruct() for generating this.
+ * @param passphrase Raw input passphrase buffer.
+ * @param passphrase_size Size of the passphrase buffer.
+ * @param context Optional output bind context which will be created for this host, with NetworkNodeID=UDS_BROADCAST_NETWORKNODEID.
+ * @param data_channel This is the data_channel value which will be passed to udsBind() internally.
+ * @param recv_buffer_size This is the recv_buffer_size value which will be passed to udsBind() internally.
+ */
+Result udsCreateNetwork(const udsNetworkStruct* network, const void* passphrase, size_t passphrase_size, udsBindContext* context, u8 data_channel, u32 recv_buffer_size);
+
+/**
+ * @brief Connect to a network.
+ * @param network The NetworkStruct, you can use udsScanBeacons() for this.
+ * @param passphrase Raw input passphrase buffer.
+ * @param passphrase_size Size of the passphrase buffer.
+ * @param context Optional output bind context which will be created for this host.
+ * @param recv_NetworkNodeID This is the NetworkNodeID passed to udsBind() internally.
+ * @param connection_type Type of connection, see the udsConnectionType enum values.
+ * @param data_channel This is the data_channel value which will be passed to udsBind() internally.
+ * @param recv_buffer_size This is the recv_buffer_size value which will be passed to udsBind() internally.
+ */
+Result udsConnectNetwork(const udsNetworkStruct* network, const void* passphrase, size_t passphrase_size, udsBindContext* context, u16 recv_NetworkNodeID, udsConnectionType connection_type, u8 data_channel, u32 recv_buffer_size);
+
+/**
+ * @brief Stop hosting the network.
+ */
+Result udsDestroyNetwork(void);
+
+/**
+ * @brief Disconnect this client device from the network.
+ */
+Result udsDisconnectNetwork(void);
+
+/**
+ * @brief This can be used by the host to force-disconnect client(s).
+ * @param NetworkNodeID Target NetworkNodeID. UDS_BROADCAST_NETWORKNODEID can be used to disconnect all clients.
+ */
+Result udsEjectClient(u16 NetworkNodeID);
+
+/**
+ * @brief This can be used by the host to force-disconnect the spectators. Afterwards new spectators will not be allowed to connect until udsAllowSpectators() is used.
+ */
+Result udsEjectSpectator(void);
+
+/**
+ * @brief This can be used by the host to update the network attributes. If bitmask 0x4 is clear in the input bitmask, this clears that bit in the value before actually writing the value into state. Normally you should use the below wrapper functions.
+ * @param bitmask Bitmask to clear/set in the attributes. See the UDSNETATTR enum values.
+ * @param flag When false, bit-clear, otherwise bit-set.
+ */
+Result udsUpdateNetworkAttribute(u16 bitmask, bool flag);
+
+/**
+ * @brief This uses udsUpdateNetworkAttribute() for (un)blocking new connections to this host.
+ * @param block When true, block the specified connection types(bitmask set). Otherwise allow them(bitmask clear).
+ * @param clients When true, (un)block regular clients.
+ * @param flag When true, update UDSNETATTR_x4. Normally this should be false.
+ */
+Result udsSetNewConnectionsBlocked(bool block, bool clients, bool flag);
+
+/**
+ * @brief This uses udsUpdateNetworkAttribute() for unblocking new spectator connections to this host. See udsEjectSpectator() for blocking new spectators.
+ */
+Result udsAllowSpectators(void);
+
+/**
+ * @brief This loads the current ConnectionStatus struct.
+ * @param output Output ConnectionStatus struct.
+ */
+Result udsGetConnectionStatus(udsConnectionStatus* output);
+
+/**
+ * @brief Waits for the ConnectionStatus event to occur, or checks if the event was signaled. This event is signaled when the data from udsGetConnectionStatus() was updated internally.
+ * @return Always true. However if wait=false, this will return false if the event wasn't signaled.
+ * @param nextEvent Whether to discard the current event and wait for the next event.
+ * @param wait When true this will not return until the event is signaled. When false this checks if the event was signaled without waiting for it.
+ */
+bool udsWaitConnectionStatusEvent(bool nextEvent, bool wait);
+
+/**
+ * @brief This loads a NodeInfo struct for the specified NetworkNodeID. The broadcast alias can't be used with this.
+ * @param NetworkNodeID Target NetworkNodeID.
+ * @param output Output NodeInfo struct.
+ */
+Result udsGetNodeInformation(u16 NetworkNodeID, udsNodeInfo* output);

--- a/code/include/3ds/util/utf.h
+++ b/code/include/3ds/util/utf.h
@@ -1,0 +1,155 @@
+/**
+ * @file utf.h
+ * @brief UTF conversion functions.
+ */
+#pragma once
+
+#include <stdint.h>
+#include <sys/types.h>
+
+/** Convert a UTF-8 sequence into a UTF-32 codepoint
+ *
+ *  @param[out] out Output codepoint
+ *  @param[in]  in  Input sequence
+ *
+ *  @returns number of input code units consumed
+ *  @returns -1 for error
+ */
+ssize_t decode_utf8 (uint32_t *out, const uint8_t *in);
+
+/** Convert a UTF-16 sequence into a UTF-32 codepoint
+ *
+ *  @param[out] out Output codepoint
+ *  @param[in]  in  Input sequence
+ *
+ *  @returns number of input code units consumed
+ *  @returns -1 for error
+ */
+ssize_t decode_utf16(uint32_t *out, const uint16_t *in);
+
+/** Convert a UTF-32 codepoint into a UTF-8 sequence
+ *
+ *  @param[out] out Output sequence
+ *  @param[in]  in  Input codepoint
+ *
+ *  @returns number of output code units produced
+ *  @returns -1 for error
+ *
+ *  @note \a out must be able to store 4 code units
+ */
+ssize_t encode_utf8 (uint8_t *out, uint32_t in);
+
+/** Convert a UTF-32 codepoint into a UTF-16 sequence
+ *
+ *  @param[out] out Output sequence
+ *  @param[in]  in  Input codepoint
+ *
+ *  @returns number of output code units produced
+ *  @returns -1 for error
+ *
+ *  @note \a out must be able to store 2 code units
+ */
+ssize_t encode_utf16(uint16_t *out, uint32_t in);
+
+/** Convert a UTF-8 sequence into a UTF-16 sequence
+ *
+ *  Fills the output buffer up to \a len code units.
+ *  Returns the number of code units that the input would produce;
+ *  if it returns greater than \a len, the output has been
+ *  truncated.
+ *
+ *  @param[out] out Output sequence
+ *  @param[in]  in  Input sequence (null-terminated)
+ *  @param[in]  len Output length
+ *
+ *  @returns number of output code units produced
+ *  @returns -1 for error
+ *
+ *  @note \a out is not null-terminated
+ */
+ssize_t utf8_to_utf16(uint16_t *out, const uint8_t  *in, size_t len);
+
+/** Convert a UTF-8 sequence into a UTF-32 sequence
+ *
+ *  Fills the output buffer up to \a len code units.
+ *  Returns the number of code units that the input would produce;
+ *  if it returns greater than \a len, the output has been
+ *  truncated.
+ *
+ *  @param[out] out Output sequence
+ *  @param[in]  in  Input sequence (null-terminated)
+ *  @param[in]  len Output length
+ *
+ *  @returns number of output code units produced
+ *  @returns -1 for error
+ *
+ *  @note \a out is not null-terminated
+ */
+ssize_t utf8_to_utf32(uint32_t *out, const uint8_t  *in, size_t len);
+
+/** Convert a UTF-16 sequence into a UTF-8 sequence
+ *
+ *  Fills the output buffer up to \a len code units.
+ *  Returns the number of code units that the input would produce;
+ *  if it returns greater than \a len, the output has been
+ *  truncated.
+ *
+ *  @param[out] out Output sequence
+ *  @param[in]  in  Input sequence (null-terminated)
+ *  @param[in]  len Output length
+ *
+ *  @returns number of output code units produced
+ *  @returns -1 for error
+ *
+ *  @note \a out is not null-terminated
+ */
+ssize_t utf16_to_utf8(uint8_t  *out, const uint16_t *in, size_t len);
+
+/** Convert a UTF-16 sequence into a UTF-32 sequence
+ *
+ *  Fills the output buffer up to \a len code units.
+ *  Returns the number of code units that the input would produce;
+ *  if it returns greater than \a len, the output has been
+ *  truncated.
+ *
+ *  @param[out] out Output sequence
+ *  @param[in]  in  Input sequence (null-terminated)
+ *  @param[in]  len Output length
+ *
+ *  @returns number of output code units produced
+ *  @returns -1 for error
+ *
+ *  @note \a out is not null-terminated
+ */
+ssize_t utf16_to_utf32(uint32_t *out, const uint16_t *in, size_t len);
+
+/** Convert a UTF-32 sequence into a UTF-8 sequence
+ *
+ *  Fills the output buffer up to \a len code units.
+ *  Returns the number of code units that the input would produce;
+ *  if it returns greater than \a len, the output has been
+ *  truncated.
+ *
+ *  @param[out] out Output sequence
+ *  @param[in]  in  Input sequence (null-terminated)
+ *  @param[in]  len Output length
+ *
+ *  @returns number of output code units produced
+ *  @returns -1 for error
+ *
+ *  @note \a out is not null-terminated
+ */
+ssize_t utf32_to_utf8(uint8_t  *out, const uint32_t *in, size_t len);
+
+/** Convert a UTF-32 sequence into a UTF-16 sequence
+ *
+ *  @param[out] out Output sequence
+ *  @param[in]  in  Input sequence (null-terminated)
+ *  @param[in]  len Output length
+ *
+ *  @returns number of output code units produced
+ *  @returns -1 for error
+ *
+ *  @note \a out is not null-terminated
+ */
+ssize_t utf32_to_utf16(uint16_t *out, const uint32_t *in, size_t len);

--- a/code/include/arpa/inet.h
+++ b/code/include/arpa/inet.h
@@ -1,0 +1,39 @@
+#pragma once
+
+#include <netinet/in.h>
+#include <stdint.h>
+
+static inline uint32_t htonl(uint32_t hostlong)
+{
+	return __builtin_bswap32(hostlong);
+}
+
+static inline uint16_t htons(uint16_t hostshort)
+{
+	return __builtin_bswap16(hostshort);
+}
+
+static inline uint32_t ntohl(uint32_t netlong)
+{
+	return __builtin_bswap32(netlong);
+}
+
+static inline uint16_t ntohs(uint16_t netshort)
+{
+	return __builtin_bswap16(netshort);
+}
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+	in_addr_t inet_addr(const char *cp);
+	int       inet_aton(const char *cp, struct in_addr *inp);
+	char*     inet_ntoa(struct in_addr in);
+
+	const char *inet_ntop(int af, const void * src, char * dst, socklen_t size);
+	int        inet_pton(int af, const char * src, void * dst);
+
+#ifdef __cplusplus
+}
+#endif

--- a/code/include/netinet/in.h
+++ b/code/include/netinet/in.h
@@ -1,0 +1,49 @@
+/* Edited from https://github.com/devkitPro/libctru/blob/be64a95c749dd354e507c87c6b5e55d39d2faf6e/libctru/include/netinet/in.h */
+
+#pragma once
+
+#include <stdint.h>
+//#include <sys/socket.h>
+typedef unsigned int sa_family_t;
+typedef int socklen_t;
+
+#define INADDR_LOOPBACK  0x7f000001
+#define INADDR_ANY       0x00000000
+#define INADDR_BROADCAST 0xFFFFFFFF
+#define INADDR_NONE      0xFFFFFFFF
+
+#define INET_ADDRSTRLEN  16
+
+/*
+ * Protocols (See RFC 1700 and the IANA)
+ */
+#define IPPROTO_IP          0               /* dummy for IP */
+#define IPPROTO_UDP        17               /* user datagram protocol */
+#define IPPROTO_TCP         6               /* tcp */
+
+#define IP_TOS              7
+#define IP_TTL              8
+#define IP_MULTICAST_LOOP   9
+#define IP_MULTICAST_TTL   10
+#define IP_ADD_MEMBERSHIP  11
+#define IP_DROP_MEMBERSHIP 12
+
+typedef uint16_t in_port_t;
+typedef uint32_t in_addr_t;
+
+struct in_addr {
+	in_addr_t       s_addr;
+};
+
+struct sockaddr_in {
+	sa_family_t     sin_family;
+	in_port_t       sin_port;
+	struct in_addr  sin_addr;
+	unsigned char   sin_zero[8];
+};
+
+/* Request struct for multicast socket ops */
+struct ip_mreq  {
+	struct in_addr imr_multiaddr;	/* IP multicast address of group */
+	struct in_addr imr_interface;	/* local IP address of interface */
+};

--- a/code/include/z3D/actors/z_en_dns.h
+++ b/code/include/z3D/actors/z_en_dns.h
@@ -18,7 +18,14 @@ typedef struct {
 
 typedef struct EnDns {
     /* 0x000 */ Actor actor;
-    /* 0x1A4 */ char unk_1A4[0x64];
+    /* 0x1A4 */ void* action_fn;
+    /* 0x1A8 */ char collider[0x58];
+    /* 0x200 */ s16 dust_timer;
+    /* 0x202 */ char unk_202;
+    /* 0x203 */ u8 maintain_collider;
+    /* 0x204 */ u8 stand_on_ground;
+    /* 0x205 */ u8 drop_collectible;
+    /* 0x206 */ char unk_206[0x2];
     /* 0x208 */ DnsItemEntry* dnsItemEntry;
     /* 0x20C */ char unk_20C[0x6A0];
 } EnDns; // size 0x8AC

--- a/code/include/z3D/actors/z_en_item00.h
+++ b/code/include/z3D/actors/z_en_item00.h
@@ -5,7 +5,7 @@
 
 typedef struct EnItem00 {
     /* 0x000 */ Actor actor;
-    /* 0x1A4 */ char unk_1A4[0x4];
+    /* 0x1A4 */ void* action_fn;
     /* 0x1A8 */ u16 collectibleFlag;
     /* 0x1AA */ char unk_1AA[0x4];
     /* 0x1AE */ u16 unk_1AE;

--- a/code/include/z3D/actors/z_en_shopnuts.h
+++ b/code/include/z3D/actors/z_en_shopnuts.h
@@ -5,7 +5,8 @@
 
 typedef struct EnShopnuts {
     /* 0x000 */ Actor actor;
-    /* 0x1A4 */ char unk_1A4[0x6FC];
+    /* 0x1A4 */ void* action_fn;
+    /* 0x1A8 */ char unk_1A8[0x6F8];
 } EnShopnuts; // size 0x8A0
 
 #endif //_EN_SHOPNUTS_H_

--- a/code/include/z3D/z3D.h
+++ b/code/include/z3D/z3D.h
@@ -273,6 +273,18 @@ typedef struct {
 } ActorListEntry; // size = 0x08
 
 typedef struct {
+    /* 0x00 */ u32    swch;
+    /* 0x04 */ u32    tempSwch;
+    /* 0x08 */ u32    unk0;
+    /* 0x0C */ u32    unk1;
+    /* 0x10 */ u32    chest;
+    /* 0x14 */ u32    clear;
+    /* 0x18 */ u32    tempClear;
+    /* 0x1C */ u32    collect;
+    /* 0x20 */ u32    tempCollect;
+} ActorFlags; // size = 0x24
+
+typedef struct {
     /* 0x0000 */ u8     unk_00;
     /* 0x0001 */ char   unk_01[0x01];
     /* 0x0002 */ u8     unk_02;
@@ -283,17 +295,7 @@ typedef struct {
     /* 0x000C */ ActorListEntry actorList[12];
     // /* 0x006C */ TargetContext targetCtx;
     /* 0x006C */ char   unk_6C[0x130];
-    struct {
-        /* 0x019C */ u32    swch;
-        /* 0x01A0 */ u32    tempSwch;
-        /* 0x01A4 */ u32    unk0;
-        /* 0x01A8 */ u32    unk1;
-        /* 0x01AC */ u32    chest;
-        /* 0x01B0 */ u32    clear;
-        /* 0x01B4 */ u32    tempClear;
-        /* 0x01B8 */ u32    collect;
-        /* 0x01BC */ u32    tempCollect;
-    }                   flags;
+    /* 0x019C */ ActorFlags flags;
     /* 0x01C0 */ TitleCardContext titleCtx;
 } ActorContext; // TODO: size = 0x1D8
 
@@ -568,5 +570,25 @@ typedef void (*Message_CloseTextbox_proc)(GlobalContext* globalCtx);
 typedef void (*SetupItemInWater_proc)(Player* player, GlobalContext* globalCtx);
 #define SetupItemInWater_addr 0x354894
 #define SetupItemInWater ((SetupItemInWater_proc)SetupItemInWater_addr)
+
+typedef void (*Health_ChangeBy_proc)(GlobalContext* arg1, u32 arg2);
+#define Health_ChangeBy_addr 0x352DBC
+#define Health_ChangeBy ((Health_ChangeBy_proc)Health_ChangeBy_addr)
+
+typedef void (*PlaySFX_proc)(u32 sfxId, Vec3f* pos, u32 token, f32* freqScale, f32* a4, s8* reverbAdd);
+#define PlaySFX_addr 0x37547C
+#define PlaySFX ((PlaySFX_proc)PlaySFX_addr)
+
+typedef void (*Flags_SetSwitch_proc)(GlobalContext* globalCtx, u32 flag);
+#define Flags_SetSwitch_addr 0x375C10
+#define Flags_SetSwitch ((Flags_SetSwitch_proc)Flags_SetSwitch_addr)
+
+typedef u32 (*Flags_GetSwitch_proc)(GlobalContext* globalCtx, u32 flag);
+#define Flags_GetSwitch_addr 0x36E864
+#define Flags_GetSwitch ((Flags_GetSwitch_proc)Flags_GetSwitch_addr)
+
+typedef u32 (*Flags_GetCollectible_proc)(GlobalContext* globalCtx, u32 flag);
+#define Flags_GetCollectible_addr 0x36405C
+#define Flags_GetCollectible ((Flags_GetCollectible_proc)Flags_GetCollectible_addr)
 
 #endif //_Z3D_H_

--- a/code/oot.ld
+++ b/code/oot.ld
@@ -576,6 +576,14 @@ SECTIONS
 		*(.patch_WaterTempleItemGiveTwo)
 	}
 
+	.patch_BrownBoulderExplode 0x26F9F8 : {
+		*(.patch_BrownBoulderExplode)
+	}
+
+	.patch_RedBoulderExplode 0x26FE7C : {
+		*(.patch_RedBoulderExplode)
+	}
+
 	.patch_SongOfTimeJingle 0x274B1C : {
 		*(.patch_SongOfTimeJingle)
 	}
@@ -1104,6 +1112,10 @@ SECTIONS
 		*(.patch_SaveFile_Init)
 	}
 
+	.patch_Multiplayer_OnLoadFile 0x449EFC : {
+		*(.patch_Multiplayer_OnLoadFile)
+	}
+
 	.patch_GetCustomMessageEntryTwo 0x44D564 : {
 		*(.patch_GetCustomMessageEntryTwo)
 	}
@@ -1118,6 +1130,10 @@ SECTIONS
 
 	.patch_ExtendedObjectClear 0x44E754 : {
 		*(.patch_ExtendedObjectClear)
+	}
+
+	.patch_Multiplayer_UpdatePrevActorFlags 0x44E878 : {
+		*(.patch_Multiplayer_UpdatePrevActorFlags)
 	}
 
 	.patch_PlayEntranceCutscene 0x44F068 : {
@@ -1254,6 +1270,10 @@ SECTIONS
 
 	.patch_FairyUseHealAmount 0x4968B4 : {
 		*(.patch_FairyUseHealAmount)
+	}
+
+	.patch_SendDroppedBottleContents 0x496A1C : {
+		*(.patch_SendDroppedBottleContents)
 	}
 
 	.patch_ReturnFWSetupGrottoInfo 0x496B88 : {

--- a/code/src/actor.c
+++ b/code/src/actor.c
@@ -42,6 +42,12 @@
 #include "malon.h"
 #include "jabu.h"
 #include "dampe.h"
+#include "web.h"
+#include "boulder_red.h"
+#include "skulltula.h"
+#include "collapsing_platform.h"
+#include "carpenter.h"
+#include "pushblock.h"
 
 #define OBJECT_GI_KEY 170
 #define OBJECT_GI_BOSSKEY 185
@@ -61,14 +67,20 @@ void Actor_Init() {
     gActorOverlayTable[0x4].initInfo->init = ShopsanityItem_Init;
     gActorOverlayTable[0x4].initInfo->instanceSize = sizeof(ShopsanityItem);
 
+    gActorOverlayTable[0x9].initInfo->update = (ActorFunc)EnDoor_rUpdate;
+
     gActorOverlayTable[0xA].initInfo->init = EnBox_rInit;
     gActorOverlayTable[0xA].initInfo->update = EnBox_rUpdate;
 
+    gActorOverlayTable[0xF].initInfo->update = (ActorFunc)BgYdanSp_rUpdate;
+
     gActorOverlayTable[0x15].initInfo->init = EnItem00_rInit;
     gActorOverlayTable[0x15].initInfo->destroy = EnItem00_rDestroy;
+    gActorOverlayTable[0x15].initInfo->update = EnItem00_rUpdate;
     gActorOverlayTable[0x15].initInfo->draw = EnItem00_rDraw;
 
     gActorOverlayTable[0x2E].initInfo->init = DoorShutter_rInit;
+    gActorOverlayTable[0x2E].initInfo->update = (ActorFunc)DoorShutter_rUpdate;
 
     gActorOverlayTable[0x3D].initInfo->destroy = EnOssan_rDestroy;
 
@@ -78,6 +90,7 @@ void Actor_Init() {
 
     gActorOverlayTable[0x5F].initInfo->init = ItemBHeart_rInit;
     gActorOverlayTable[0x5F].initInfo->destroy = ItemBHeart_rDestroy;
+    gActorOverlayTable[0x5F].initInfo->update = ItemBHeart_rUpdate;
     gActorOverlayTable[0x5F].initInfo->draw = ItemBHeart_rDraw;
 
     gActorOverlayTable[0x85].initInfo->update = EnTk_rUpdate;
@@ -87,6 +100,8 @@ void Actor_Init() {
     gActorOverlayTable[0x8B].initInfo->update = DemoEffect_rUpdate;
 
     gActorOverlayTable[0x8C].initInfo->update = DemoKankyo_rUpdate;
+
+    gActorOverlayTable[0x95].initInfo->update = (ActorFunc)EnSw_rUpdate;
 
     gActorOverlayTable[0x9C].initInfo->update = BgSpot02Objects_rUpdate;
 
@@ -110,16 +125,27 @@ void Actor_Init() {
     gActorOverlayTable[0xF1].initInfo->destroy = ItemOcarina_rDestroy;
     gActorOverlayTable[0xF1].initInfo->draw = ItemOcarina_rDraw;
 
+    gActorOverlayTable[0xFF].initInfo->update = ObjOshihiki_rUpdate;
+
     gActorOverlayTable[0x104].initInfo->init = BgSpot01Idomizu_rInit;
+
+    gActorOverlayTable[0x107].initInfo->update = BgSpot15Rrbox_rUpdate;
 
     gActorOverlayTable[0x10F].initInfo->init = ItemEtcetera_rInit;
     gActorOverlayTable[0x10F].initInfo->destroy = ItemEtcetera_rDestroy;
+    gActorOverlayTable[0x10F].initInfo->update = ItemEtcetera_rUpdate;
+
+    gActorOverlayTable[0x11A].initInfo->update = EnDns_rUpdate;
 
     gActorOverlayTable[0x11B].initInfo->update = NULL;
 
     gActorOverlayTable[0x12A].initInfo->init = ObjSwitch_rInit;
 
+    gActorOverlayTable[0x12C].initInfo->update = (ActorFunc)ObjLift_rUpdate;
+
     gActorOverlayTable[0x131].initInfo->update = EnExRuppy_rUpdate;
+
+    gActorOverlayTable[0x133].initInfo->update = (ActorFunc)EnDaiku_rUpdate;
 
     gActorOverlayTable[0x138].initInfo->init = EnGe1_rInit;
     gActorOverlayTable[0x138].initInfo->update = EnGe1_rUpdate;
@@ -130,6 +156,7 @@ void Actor_Init() {
     gActorOverlayTable[0x14D].initInfo->update = EnOwl_rUpdate;
 
     gActorOverlayTable[0x14E].initInfo->init = EnIshi_rInit;
+    gActorOverlayTable[0x14E].initInfo->update = (ActorFunc)EnIshi_rUpdate;
 
     gActorOverlayTable[0x153].initInfo->update = EnFu_rUpdate;
 
@@ -141,6 +168,8 @@ void Actor_Init() {
 
     gActorOverlayTable[0x168].initInfo->init = EnExItem_rInit;
     gActorOverlayTable[0x168].initInfo->destroy = EnExItem_rDestroy;
+
+    gActorOverlayTable[0x172].initInfo->update = (ActorFunc)DoorGerudo_rUpdate;
 
     gActorOverlayTable[0x174].initInfo->update = DemoGt_rUpdate;
 
@@ -163,6 +192,7 @@ void Actor_Init() {
 
     gActorOverlayTable[0x19C].initInfo->init = EnSi_rInit;
     gActorOverlayTable[0x19C].initInfo->destroy = EnSi_rDestroy;
+    gActorOverlayTable[0x19C].initInfo->update = EnSi_rUpdate;
     gActorOverlayTable[0x19C].initInfo->draw = EnSi_rDraw;
 
     gActorOverlayTable[0x1B9].initInfo->init = EnGs_rInit;
@@ -171,6 +201,8 @@ void Actor_Init() {
 
     gActorOverlayTable[0x1C6].initInfo->init = EnCow_rInit;
     gActorOverlayTable[0x1C6].initInfo->destroy = EnCow_rDestroy;
+
+    gActorOverlayTable[0x1D2].initInfo->update = (ActorFunc)ObjHamishi_rUpdate;
 
     // Define object 4 to be by default the same as object 189
     strncpy(gObjectTable[OBJECT_CUSTOM_DOUBLE_DEFENSE].filename, gObjectTable[OBJECT_GI_HEARTS].filename, 0x40);

--- a/code/src/bottle.c
+++ b/code/src/bottle.c
@@ -1,0 +1,18 @@
+#include "settings.h"
+#include "multiplayer.h"
+
+void SendDroppedBottleContents(s16 actorId, f32 posX, f32 posY, f32 posZ) {
+    if (gSettingsContext.mp_Enabled == OFF || gSettingsContext.mp_SharedProgress == OFF) {
+        return;
+    }
+    //             Bugs               Fish             Blue Fire
+    if (actorId != 0x20 && actorId != 0x21 && actorId != 0xF0) {
+        return;
+    }
+    PosRot posRot = { { posX, posY, posZ }, { 0x4000, PLAYER->actor.shape.rot.y, 0 } };
+    s16 params = 0;
+    if (actorId == 0x20) {
+        params = 2;
+    }
+    Multiplayer_Send_ActorSpawn(actorId, posRot, params);
+}

--- a/code/src/boulder_brown.c
+++ b/code/src/boulder_brown.c
@@ -1,0 +1,5 @@
+#include "z3D/z3D.h"
+
+u32 ObjBombiwa_GetFlag(Actor* thisx, GlobalContext* globalCtx) {
+    return Flags_GetSwitch(globalCtx, (u16)thisx->params & 0x3F);
+}

--- a/code/src/boulder_red.c
+++ b/code/src/boulder_red.c
@@ -1,0 +1,28 @@
+#include "boulder_red.h"
+#include "multiplayer.h"
+
+#define ObjHamishi_Update_addr 0x26FD24
+#define ObjHamishi_Update ((ActorFunc)ObjHamishi_Update_addr)
+
+void ObjHamishi_rUpdate(ObjHamishi* thisx, GlobalContext* globalCtx) {
+    s16 prevHitCount = thisx->hit_count;
+
+    ObjHamishi_Update((Actor*)thisx, globalCtx);
+
+    if (thisx->hit_count != prevHitCount) {
+        Multiplayer_Send_ActorUpdate((Actor*)thisx, NULL, 0);
+    }
+}
+
+void ObjHamishi_Hit(ObjHamishi* thisx) {
+    thisx->hit_count++;
+    if (thisx->hit_count < 2) {
+        thisx->shake_frames = 15;
+        thisx->shake_position_size = 2.0;
+        thisx->shake_rotation_size = 400.0;
+    }
+}
+
+s16 ObjHamishi_HitCount(ObjHamishi* thisx) {
+    return thisx->hit_count;
+}

--- a/code/src/boulder_red.h
+++ b/code/src/boulder_red.h
@@ -1,0 +1,21 @@
+#ifndef _BOULDER_RED_H_
+#define _BOULDER_RED_H_
+
+#include "z3D/z3D.h"
+
+typedef struct {
+    Actor base;
+    char collider[88];
+    f32 shake_position_size;
+    f32 shake_rotation_size;
+    s16 shake_frames;
+    s16 shake_position_phase;
+    s16 shake_rotation_phase;
+    s16 hit_count;
+    SkeletonAnimationModel* animation_model;
+} ObjHamishi;
+
+void ObjHamishi_rUpdate(ObjHamishi* thisx, GlobalContext* globalCtx);
+void ObjHamishi_Hit(ObjHamishi* thisx);
+
+#endif //_BOULDER_RED_H_

--- a/code/src/business_scrubs.h
+++ b/code/src/business_scrubs.h
@@ -2,6 +2,11 @@
 #define _BUSINESS_SCRUBS_H_
 
 #include "z3D/z3D.h"
+#include "z3D/actors/z_en_dns.h"
+#include "z3D/actors/z_en_shopnuts.h"
+
+void EnDns_rUpdate(Actor* thisx, GlobalContext* globalCtx);
+void EnDns_StartBurrow(EnDns* thisx);
 
 void EnShopnuts_rInit(Actor* thisx, GlobalContext* globalCtx);
 

--- a/code/src/carpenter.c
+++ b/code/src/carpenter.c
@@ -1,5 +1,32 @@
-#include "z3D/z3D.h"
+#include "carpenter.h"
+#include "multiplayer.h"
 
 void EnToryo_SetTradedSawFlag(void) {
     gSaveContext.itemGetInf[3] |= 0x4;
+}
+
+#define EnDaiku_Update_addr 0x20F1A8
+#define EnDaiku_Update ((ActorFunc)EnDaiku_Update_addr)
+
+#define EnDaiku_WaitFreedom (void*)0x182FF0
+#define EnDaiku_InitEscape (void*)0x25A8E4
+#define EnDaiku_EscapeRotate (void*)0x2754E4
+
+void EnDaiku_rUpdate(EnDaiku* thisx, GlobalContext* globalCtx) {
+    void* prev_action_fn = thisx->action_fn;
+
+    EnDaiku_Update((Actor*)thisx, globalCtx);
+
+    if (prev_action_fn == EnDaiku_WaitFreedom && thisx->action_fn == EnDaiku_InitEscape) {
+        Multiplayer_Send_ActorUpdate((Actor*)thisx, NULL, 0);
+    }
+}
+
+void EnDaiku_StartEscape(EnDaiku* thisx) {
+    if (thisx->action_fn != EnDaiku_WaitFreedom) {
+        return;
+    }
+    Actor_Kill((Actor*)thisx);
+    // TODO: Start escape instead
+    //thisx->action_fn = EnDaiku_EscapeRotate;
 }

--- a/code/src/carpenter.h
+++ b/code/src/carpenter.h
@@ -1,0 +1,16 @@
+#ifndef _CARPENTER_H_
+#define _CARPENTER_H_
+
+#include "z3D/z3D.h"
+
+typedef struct {
+    Actor base;
+    SkelAnime anime;
+    char unk_228[2080];
+    void* action_fn;
+} EnDaiku;
+
+void EnDaiku_rUpdate(EnDaiku* thisx, GlobalContext* globalCtx);
+void EnDaiku_StartEscape(EnDaiku* thisx);
+
+#endif //_CARPENTER_H_

--- a/code/src/cfgu.c
+++ b/code/src/cfgu.c
@@ -1,0 +1,405 @@
+#include <stdlib.h>
+#include <3ds/types.h>
+#include <3ds/result.h>
+#include <3ds/svc.h>
+#include <3ds/srv.h>
+#include <3ds/synchronization.h>
+#include <3ds/services/cfgu.h>
+#include <3ds/ipc.h>
+
+static Handle cfguHandle;
+static int cfguRefCount;
+
+Result cfguInit(void)
+{
+	Result ret;
+
+	if (AtomicPostIncrement(&cfguRefCount)) return 0;
+
+	// cfg:i has the most commands, then cfg:s, then cfg:u
+	ret = srvGetServiceHandle(&cfguHandle, "cfg:i");
+	if(R_FAILED(ret)) ret = srvGetServiceHandle(&cfguHandle, "cfg:s");
+	if(R_FAILED(ret)) ret = srvGetServiceHandle(&cfguHandle, "cfg:u");
+	if(R_FAILED(ret)) AtomicDecrement(&cfguRefCount);
+
+	return ret;
+}
+
+void cfguExit(void)
+{
+	if (AtomicDecrement(&cfguRefCount)) return;
+	svcCloseHandle(cfguHandle);
+}
+
+Result CFGU_SecureInfoGetRegion(u8* region)
+{
+	Result ret = 0;
+	u32 *cmdbuf = getThreadCommandBuffer();
+
+	cmdbuf[0] = IPC_MakeHeader(0x2,0,0); // 0x20000
+
+	if(R_FAILED(ret = svcSendSyncRequest(cfguHandle)))return ret;
+
+	*region = (u8)cmdbuf[2] & 0xFF;
+
+	return (Result)cmdbuf[1];
+}
+
+Result CFGU_GenHashConsoleUnique(u32 appIDSalt, u64* hash)
+{
+	Result ret = 0;
+	u32 *cmdbuf = getThreadCommandBuffer();
+
+	cmdbuf[0] = IPC_MakeHeader(0x3,1,0); // 0x30040
+	cmdbuf[1] = appIDSalt;
+
+	if(R_FAILED(ret = svcSendSyncRequest(cfguHandle)))return ret;
+
+	*hash = (u64)cmdbuf[2];
+	*hash |= ((u64)cmdbuf[3])<<32;
+
+	return (Result)cmdbuf[1];
+}
+
+Result CFGU_GetRegionCanadaUSA(u8* value)
+{
+	Result ret = 0;
+	u32 *cmdbuf = getThreadCommandBuffer();
+
+	cmdbuf[0] = IPC_MakeHeader(0x4,0,0); // 0x40000
+
+	if(R_FAILED(ret = svcSendSyncRequest(cfguHandle)))return ret;
+
+	*value = (u8)cmdbuf[2] & 0xFF;
+
+	return (Result)cmdbuf[1];
+}
+
+Result CFGU_GetSystemModel(u8* model)
+{
+	Result ret = 0;
+	u32 *cmdbuf = getThreadCommandBuffer();
+
+	cmdbuf[0] = IPC_MakeHeader(0x5,0,0); // 0x50000
+
+	if(R_FAILED(ret = svcSendSyncRequest(cfguHandle)))return ret;
+
+	*model = (u8)cmdbuf[2] & 0xFF;
+
+	return (Result)cmdbuf[1];
+}
+
+Result CFGU_GetModelNintendo2DS(u8* value)
+{
+	Result ret = 0;
+	u32 *cmdbuf = getThreadCommandBuffer();
+
+	cmdbuf[0] = IPC_MakeHeader(0x6,0,0); // 0x60000
+
+	if(R_FAILED(ret = svcSendSyncRequest(cfguHandle)))return ret;
+
+	*value = (u8)cmdbuf[2] & 0xFF;
+
+	return (Result)cmdbuf[1];
+}
+
+Result CFGU_GetCountryCodeString(u16 code, u16* string)
+{
+	Result ret = 0;
+	u32 *cmdbuf = getThreadCommandBuffer();
+
+	cmdbuf[0] = IPC_MakeHeader(0x9,1,0); // 0x90040
+	cmdbuf[1] = (u32)code;
+
+	if(R_FAILED(ret = svcSendSyncRequest(cfguHandle)))return ret;
+
+	*string = (u16)cmdbuf[2] & 0xFFFF;
+
+	return (Result)cmdbuf[1];
+}
+
+Result CFGU_GetCountryCodeID(u16 string, u16* code)
+{
+	Result ret = 0;
+	u32 *cmdbuf = getThreadCommandBuffer();
+
+	cmdbuf[0] = IPC_MakeHeader(0xA,1,0); // 0xA0040
+	cmdbuf[1] = (u32)string;
+
+	if(R_FAILED(ret = svcSendSyncRequest(cfguHandle)))return ret;
+
+	*code = (u16)cmdbuf[2] & 0xFFFF;
+
+	return (Result)cmdbuf[1];
+}
+
+Result CFGU_IsNFCSupported(bool* isSupported)
+{
+	Result ret = 0;
+	u32 *cmdbuf = getThreadCommandBuffer();
+
+	cmdbuf[0] = IPC_MakeHeader(0xB,0,0); // 0x000B0000
+
+	if(R_FAILED(ret = svcSendSyncRequest(cfguHandle)))return ret;
+
+	*isSupported = cmdbuf[2] & 0xFF;
+
+	return (Result)cmdbuf[1];
+}
+
+// See here for block IDs:
+// http://3dbrew.org/wiki/Config_Savegame#Configuration_blocks
+Result CFGU_GetConfigInfoBlk2(u32 size, u32 blkID, void* outData)
+{
+	Result ret = 0;
+	u32 *cmdbuf = getThreadCommandBuffer();
+
+	cmdbuf[0] = IPC_MakeHeader(0x1,2,2); // 0x10082
+	cmdbuf[1] = size;
+	cmdbuf[2] = blkID;
+	cmdbuf[3] = IPC_Desc_Buffer(size,IPC_BUFFER_W);
+	cmdbuf[4] = (u32)outData;
+
+	if(R_FAILED(ret = svcSendSyncRequest(cfguHandle)))return ret;
+
+	return (Result)cmdbuf[1];
+}
+
+Result CFG_GetConfigInfoBlk4(u32 size, u32 blkID, void* outData)
+{
+	Result ret = 0;
+	u32 *cmdbuf = getThreadCommandBuffer();
+
+	cmdbuf[0] = IPC_MakeHeader(0x401,2,2); // 0x4010082
+	cmdbuf[1] = size;
+	cmdbuf[2] = blkID;
+	cmdbuf[3] = IPC_Desc_Buffer(size,IPC_BUFFER_W);
+	cmdbuf[4] = (u32)outData;
+
+	if(R_FAILED(ret = svcSendSyncRequest(cfguHandle)))return ret;
+
+	return (Result)cmdbuf[1];
+}
+
+Result CFG_GetConfigInfoBlk8(u32 size, u32 blkID, void* outData)
+{
+	Result ret = 0;
+	u32 *cmdbuf = getThreadCommandBuffer();
+
+	cmdbuf[0] = IPC_MakeHeader(0x801,2,2); // 0x8010082
+	cmdbuf[1] = size;
+	cmdbuf[2] = blkID;
+	cmdbuf[3] = IPC_Desc_Buffer(size,IPC_BUFFER_W);
+	cmdbuf[4] = (u32)outData;
+
+	if(R_FAILED(ret = svcSendSyncRequest(cfguHandle)))return ret;
+
+	return (Result)cmdbuf[1];
+}
+
+Result CFG_SetConfigInfoBlk4(u32 size, u32 blkID, const void* inData)
+{
+	Result ret = 0;
+	u32 *cmdbuf = getThreadCommandBuffer();
+
+	cmdbuf[0] = IPC_MakeHeader(0x402,2,2); // 0x4020082
+	cmdbuf[1] = blkID;
+	cmdbuf[2] = size;
+	cmdbuf[3] = IPC_Desc_Buffer(size,IPC_BUFFER_R);
+	cmdbuf[4] = (u32)inData;
+
+	if(R_FAILED(ret = svcSendSyncRequest(cfguHandle)))return ret;
+
+	return (Result)cmdbuf[1];
+}
+
+Result CFG_SetConfigInfoBlk8(u32 size, u32 blkID, const void* inData)
+{
+	Result ret = 0;
+	u32 *cmdbuf = getThreadCommandBuffer();
+
+	cmdbuf[0] = IPC_MakeHeader(0x802,2,2); // 0x8020082
+	cmdbuf[1] = blkID;
+	cmdbuf[2] = size;
+	cmdbuf[3] = IPC_Desc_Buffer(size,IPC_BUFFER_R);
+	cmdbuf[4] = (u32)inData;
+
+	if(R_FAILED(ret = svcSendSyncRequest(cfguHandle)))return ret;
+
+	return (Result)cmdbuf[1];
+}
+
+Result CFG_UpdateConfigSavegame(void)
+{
+	Result ret = 0;
+	u32 *cmdbuf = getThreadCommandBuffer();
+
+	cmdbuf[0] = IPC_MakeHeader(0x803,0,0); // 0x8030000
+
+	if(R_FAILED(ret = svcSendSyncRequest(cfguHandle)))return ret;
+
+	return (Result)cmdbuf[1];
+}
+
+Result CFGU_GetSystemLanguage(u8* language)
+{
+	return CFGU_GetConfigInfoBlk2(1, 0xA0002, language);
+}
+
+Result CFGI_RestoreLocalFriendCodeSeed(void)
+{
+	Result ret = 0;
+	u32 *cmdbuf = getThreadCommandBuffer();
+
+	cmdbuf[0] = IPC_MakeHeader(0x80D, 0, 0); // 0x80D0000
+
+	if(R_FAILED(ret = svcSendSyncRequest(cfguHandle)))return ret;
+
+	return (Result)cmdbuf[1];
+}
+
+Result CFGI_RestoreSecureInfo(void)
+{
+	Result ret = 0;
+	u32 *cmdbuf = getThreadCommandBuffer();
+
+	cmdbuf[0] = IPC_MakeHeader(0x812,0,0); // 0x8120000
+
+	if(R_FAILED(ret = svcSendSyncRequest(cfguHandle)))return ret;
+
+	return (Result)cmdbuf[1];
+}
+
+Result CFGI_DeleteConfigSavefile(void)
+{
+	Result ret = 0;
+	u32 *cmdbuf = getThreadCommandBuffer();
+
+	cmdbuf[0] = IPC_MakeHeader(0x805,0,0); // 0x8050000
+
+	if(R_FAILED(ret = svcSendSyncRequest(cfguHandle)))return ret;
+
+	return (Result)cmdbuf[1];
+}
+
+Result CFGI_FormatConfig(void)
+{
+	Result ret = 0;
+	u32 *cmdbuf = getThreadCommandBuffer();
+
+	cmdbuf[0] = IPC_MakeHeader(0x806,0,0); // 0x8060000
+
+	if(R_FAILED(ret = svcSendSyncRequest(cfguHandle)))return ret;
+
+	return (Result)cmdbuf[1];
+}
+
+Result CFGI_ClearParentalControls(void)
+{
+	Result ret = 0;
+	u32 *cmdbuf = getThreadCommandBuffer();
+
+	cmdbuf[0] = IPC_MakeHeader(0x40F,0,0); // 0x40F0000
+
+	if(R_FAILED(ret = svcSendSyncRequest(cfguHandle)))return ret;
+
+	return (Result)cmdbuf[1];
+}
+
+Result CFGI_VerifySigLocalFriendCodeSeed(void)
+{
+	Result ret = 0;
+	u32 *cmdbuf = getThreadCommandBuffer();
+
+	cmdbuf[0] = IPC_MakeHeader(0x80E,0,0); // 0x80E0000
+
+	if(R_FAILED(ret = svcSendSyncRequest(cfguHandle)))return ret;
+
+	return (Result)cmdbuf[1];
+}
+
+Result CFGI_VerifySigSecureInfo(void)
+{
+	Result ret = 0;
+	u32 *cmdbuf = getThreadCommandBuffer();
+
+	cmdbuf[0] = IPC_MakeHeader(0x813,0,0); // 0x8130000
+
+	if(R_FAILED(ret = svcSendSyncRequest(cfguHandle)))return ret;
+
+	return (Result)cmdbuf[1];
+}
+
+Result CFGI_SecureInfoGetSerialNumber(u8 *serial)
+{
+	Result ret = 0;
+	u32 *cmdbuf = getThreadCommandBuffer();
+
+	cmdbuf[0] = IPC_MakeHeader(0x408,1,2); // 0x4080042
+	cmdbuf[1] = 0xF;
+	cmdbuf[2] = IPC_Desc_Buffer(0xF, IPC_BUFFER_W);
+	cmdbuf[3] = (u32)serial;
+
+	if(R_FAILED(ret = svcSendSyncRequest(cfguHandle)))return ret;
+
+	return (Result)cmdbuf[1];
+}
+
+Result CFGI_GetLocalFriendCodeSeedData(u8 *data)
+{
+	Result ret = 0;
+	u32 *cmdbuf = getThreadCommandBuffer();
+
+	cmdbuf[0] = IPC_MakeHeader(0x404,1,2); // 0x4040042
+	cmdbuf[1] = 0x110;
+	cmdbuf[2] = IPC_Desc_Buffer(0x110, IPC_BUFFER_W);
+	cmdbuf[3] = (u32)data;
+
+	if(R_FAILED(ret = svcSendSyncRequest(cfguHandle)))return ret;
+
+	return (Result)cmdbuf[1];
+}
+
+Result CFGI_GetLocalFriendCodeSeed(u64* seed)
+{
+	Result ret = 0;
+	u32 *cmdbuf = getThreadCommandBuffer();
+
+	cmdbuf[0] = IPC_MakeHeader(0x405,0,0); // 0x4050000
+
+	if(R_FAILED(ret = svcSendSyncRequest(cfguHandle)))return ret;
+
+	*seed = (u64)cmdbuf[2] | (u64)cmdbuf[3] << 32;
+
+	return (Result)cmdbuf[1];
+}
+
+Result CFGI_GetSecureInfoData(u8 *data)
+{
+	Result ret = 0;
+	u32 *cmdbuf = getThreadCommandBuffer();
+
+	cmdbuf[0] = IPC_MakeHeader(0x814,1,2); // 0x8140042
+	cmdbuf[1] = 0x11;
+	cmdbuf[2] = IPC_Desc_Buffer(0x11, IPC_BUFFER_W);
+	cmdbuf[3] = (u32)data;
+
+	if(R_FAILED(ret = svcSendSyncRequest(cfguHandle)))return ret;
+
+	return (Result)cmdbuf[1];
+}
+
+Result CFGI_GetSecureInfoSignature(u8 *data)
+{
+	Result ret = 0;
+	u32 *cmdbuf = getThreadCommandBuffer();
+
+	cmdbuf[0] = IPC_MakeHeader(0x815,1,2); // 0x8150042
+	cmdbuf[1] = 0x100;
+	cmdbuf[2] = IPC_Desc_Buffer(0x100, IPC_BUFFER_W);
+	cmdbuf[3] = (u32)data;
+
+	if(R_FAILED(ret = svcSendSyncRequest(cfguHandle)))return ret;
+
+	return (Result)cmdbuf[1];
+}

--- a/code/src/collapsing_platform.c
+++ b/code/src/collapsing_platform.c
@@ -1,0 +1,33 @@
+#include "collapsing_platform.h"
+#include "multiplayer.h"
+
+#define ObjLift_Update_addr 0x2159DC
+#define ObjLift_Update ((ActorFunc)ObjLift_Update_addr)
+
+#define ObjLift_Wait (void*)0x3C05B0
+#define ObjLift_Shake (void*)0x110E98
+#define ObjLift_Fall (void*)0x3BB7BC
+
+void ObjLift_rUpdate(ObjLift* thisx, GlobalContext* globalCtx) {
+    void* prev_action_fn = thisx->action_fn;
+
+    ObjLift_Update((Actor*)thisx, globalCtx);
+
+    if (prev_action_fn != thisx->action_fn && prev_action_fn == ObjLift_Wait) {
+        Multiplayer_Send_ActorUpdate((Actor*)thisx, &thisx->action_fn, sizeof(void*));
+    }
+}
+
+void ObjLift_SetActionFn(ObjLift* thisx, void* new_action_fn) {
+    if (thisx->action_fn != ObjLift_Wait) {
+        return;
+    }
+    if (new_action_fn == ObjLift_Shake) {
+        thisx->timer = 30;
+    } else if (new_action_fn == ObjLift_Fall) {
+        thisx->base.world.pos = thisx->base.home.pos;
+        thisx->base.world.rot = thisx->base.home.rot;
+        thisx->base.shape.rot = thisx->base.world.rot;
+    }
+    thisx->action_fn = new_action_fn;
+}

--- a/code/src/collapsing_platform.h
+++ b/code/src/collapsing_platform.h
@@ -1,0 +1,18 @@
+#ifndef _COLLAPSING_PLATFORM_H_
+#define _COLLAPSING_PLATFORM_H_
+
+#include "z3D/z3D.h"
+
+typedef struct {
+    Actor base;
+    char dyna[24];
+    void* action_fn;
+    SkeletonAnimationModel* animation_model;
+    char unk_1C4[6];
+    u16 timer;
+} ObjLift;
+
+void ObjLift_rUpdate(ObjLift* thisx, GlobalContext* globalCtx);
+void ObjLift_SetActionFn(ObjLift* thisx, void* new_action_fn);
+
+#endif //_COLLAPSING_PLATFORM_H_

--- a/code/src/common.c
+++ b/code/src/common.c
@@ -1,5 +1,16 @@
 #include "common.h"
 #include "settings.h"
+#include "3ds/svc.h"
+#include "lib/printf.h"
+
+s8 BitCompare(u32 value1, u32 value2, u8 bit) {
+    if ((value1 & (1 << bit)) > (value2 & (1 << bit))) {
+        return 1;
+    } else if ((value2 & (1 << bit)) > (value1 & (1 << bit))) {
+        return -1;
+    }
+    return 0;
+}
 
 // From section 5 of https://www.cs.ubc.ca/~rbridson/docs/schechter-sca08-turbulence.pdf
 u32 Hash(u32 state) {

--- a/code/src/common.h
+++ b/code/src/common.h
@@ -2,17 +2,20 @@
 #define _COMMON_H_
 
 #include "../include/z3D/z3D.h"
-#include "../include/3ds/svc.h"
-#include "../include/lib/printf.h"
 
 #define ARRAY_SIZE(x) (sizeof(x) / sizeof(x[0]))
+#define BIT_COUNT(x) (sizeof(x) * 8)
 
+#define TICKS_PER_SEC 268123480
 #define SEQ_AUDIO_BLANK 0x1000142
+
+/// Returns 1 if the bit is set in value1 but not in value2, -1 if vice versa, and 0 if they're the same
+s8 BitCompare(u32 value1, u32 value2, u8 bit);
 
 u32 Hash(u32);
 u8  Bias(u32);
 
 u8 IsInGame(void);
-void DebugPrintNumber(const char *, int);
+void DebugPrintNumber(const char*, int);
 
 #endif //_COMMON_H_

--- a/code/src/decode_utf16.c
+++ b/code/src/decode_utf16.c
@@ -1,0 +1,25 @@
+#include "3ds/util/utf.h"
+
+ssize_t
+decode_utf16(uint32_t       *out,
+             const uint16_t *in)
+{
+  uint16_t code1, code2;
+
+  code1 = *in++;
+  if(code1 >= 0xD800 && code1 < 0xDC00)
+  {
+    /* surrogate pair */
+    code2 = *in++;
+    if(code2 >= 0xDC00 && code2 < 0xE000)
+    {
+      *out = (code1 << 10) + code2 - 0x35FDC00;
+      return 2;
+    }
+
+    return -1;
+  }
+
+  *out = code1;
+  return 1;
+}

--- a/code/src/decode_utf8.c
+++ b/code/src/decode_utf8.c
@@ -1,0 +1,88 @@
+#include "3ds/util/utf.h"
+
+ssize_t
+decode_utf8(uint32_t      *out,
+            const uint8_t *in)
+{
+  uint8_t code1, code2, code3, code4;
+
+  code1 = *in++;
+  if(code1 < 0x80)
+  {
+    /* 1-byte sequence */
+    *out = code1;
+    return 1;
+  }
+  else if(code1 < 0xC2)
+  {
+    return -1;
+  }
+  else if(code1 < 0xE0)
+  {
+    /* 2-byte sequence */
+    code2 = *in++;
+    if((code2 & 0xC0) != 0x80)
+    {
+      return -1;
+    }
+
+    *out = (code1 << 6) + code2 - 0x3080;
+    return 2;
+  }
+  else if(code1 < 0xF0)
+  {
+    /* 3-byte sequence */
+    code2 = *in++;
+    if((code2 & 0xC0) != 0x80)
+    {
+      return -1;
+    }
+    if(code1 == 0xE0 && code2 < 0xA0)
+    {
+      return -1;
+    }
+
+    code3 = *in++;
+    if((code3 & 0xC0) != 0x80)
+    {
+      return -1;
+    }
+
+    *out = (code1 << 12) + (code2 << 6) + code3 - 0xE2080;
+    return 3;
+  }
+  else if(code1 < 0xF5)
+  {
+    /* 4-byte sequence */
+    code2 = *in++;
+    if((code2 & 0xC0) != 0x80)
+    {
+      return -1;
+    }
+    if(code1 == 0xF0 && code2 < 0x90)
+    {
+      return -1;
+    }
+    if(code1 == 0xF4 && code2 >= 0x90)
+    {
+      return -1;
+    }
+
+    code3 = *in++;
+    if((code3 & 0xC0) != 0x80)
+    {
+      return -1;
+    }
+
+    code4 = *in++;
+    if((code4 & 0xC0) != 0x80)
+    {
+      return -1;
+    }
+
+    *out = (code1 << 18) + (code2 << 12) + (code3 << 6) + code4 - 0x3C82080;
+    return 4;
+  }
+
+  return -1;
+}

--- a/code/src/door.c
+++ b/code/src/door.c
@@ -1,18 +1,7 @@
-#include "z3D/z3D.h"
+#include "door.h"
 #include "models.h"
 #include "settings.h"
-
-#define DoorShutter_Init_addr 0x2453E0
-#define DoorShutter_Init ((ActorFunc)DoorShutter_Init_addr)
-
-void DoorShutter_rInit(Actor* thisx, GlobalContext* globalCtx) {
-    // In Treasure Chest Shop when its chests are shuffled,
-    // make doors use permanent flags instead of temp ones
-    if(globalCtx->sceneNum == 16 && gSettingsContext.shuffleChestMinigame) {
-        thisx->params &= ~0x0020;
-    }
-    DoorShutter_Init(thisx, globalCtx);
-}
+#include "multiplayer.h"
 
 // Certain doors can cause a crash depending on a freestanding
 // model in the room that is being transitioned out of. We can
@@ -25,4 +14,114 @@ void Door_CheckToDeleteCustomModels(Actor* door) {
         (gGlobalContext->sceneNum != 0x0001)) { // Dodongo's Cavern
         Model_DestroyAll();
     }
+}
+
+// EnDoor
+
+#define EnDoor_Update_addr 0x1F53C8
+#define EnDoor_Update ((ActorFunc)EnDoor_Update_addr)
+
+#define EnDoor_Idle (void*)0x3F1B28
+#define EnDoor_Open (void*)0x3EC04C
+void EnDoor_Unlocking(EnDoor* thisx, GlobalContext* globalCtx);
+
+void EnDoor_rUpdate(EnDoor* thisx, GlobalContext* globalCtx) {
+    void* prev_action_fn = thisx->action_fn;
+
+    EnDoor_Update((Actor*)thisx, globalCtx);
+
+    if (thisx->lock_timer != 0 && prev_action_fn == EnDoor_Idle && thisx->action_fn == EnDoor_Open) {
+        Multiplayer_Send_ActorUpdate((Actor*)thisx, NULL, 0);
+    }
+}
+
+void EnDoor_Unlock(EnDoor* thisx) {
+    if (thisx->action_fn != EnDoor_Idle) {
+        return;
+    }
+    thisx->action_fn = &EnDoor_Unlocking;
+    PlaySFX(0x10001D3, &thisx->base.world.pos, 4, (f32*)0x54AC20, (f32*)0x54AC20, (s8*)0x54AC24); // NA_SE_EV_CHAIN_KEY_UNLOCK
+}
+
+void EnDoor_Unlocking(EnDoor* thisx, GlobalContext* globalCtx) {
+    if (thisx->lock_timer > 0) {
+        thisx->lock_timer--;
+        return;
+    }
+    thisx->action_fn = EnDoor_Idle;
+}
+
+// DoorShutter
+
+#define DoorShutter_Init_addr 0x2453E0
+#define DoorShutter_Init ((ActorFunc)DoorShutter_Init_addr)
+
+void DoorShutter_rInit(Actor* thisx, GlobalContext* globalCtx) {
+    // In Treasure Chest Shop when its chests are shuffled,
+    // make doors use permanent flags instead of temp ones
+    if (globalCtx->sceneNum == 16 && gSettingsContext.shuffleChestMinigame) {
+        thisx->params &= ~0x0020;
+    }
+    DoorShutter_Init(thisx, globalCtx);
+}
+
+#define DoorShutter_Update_addr 0x27E6E0
+#define DoorShutter_Update ((ActorFunc)DoorShutter_Update_addr)
+
+#define DoorShutter_SlidingDoor_Idle (void*)0x3F4A3C
+#define DoorShutter_SlidingDoor_Open (void*)0x3EEE7C
+void DoorShutter_Unlocking(DoorShutter* thisx, GlobalContext* globalCtx);
+
+void DoorShutter_rUpdate(DoorShutter* thisx, GlobalContext* globalCtx) {
+    void* prev_action_fn = thisx->action_fn;
+
+    DoorShutter_Update((Actor*)thisx, globalCtx);
+
+    if (thisx->lock_timer != 0 && prev_action_fn == DoorShutter_SlidingDoor_Idle && thisx->action_fn == DoorShutter_SlidingDoor_Open) {
+        Multiplayer_Send_ActorUpdate((Actor*)thisx, NULL, 0);
+    }
+}
+
+void DoorShutter_Unlock(DoorShutter* thisx) {
+    if (thisx->action_fn != DoorShutter_SlidingDoor_Idle) {
+        return;
+    }
+    thisx->action_fn = &DoorShutter_Unlocking;
+    //                         NA_SE_EV_CHAIN_KEY_UNLOCK : NA_SE_EV_CHAIN_KEY_UNLOCK_B
+    u32 sfx_id = thisx->door_type_maybe != 5 ? 0x10001D3 : 0x1000200;
+    PlaySFX(sfx_id, &thisx->base.world.pos, 4, (f32*)0x54AC20, (f32*)0x54AC20, (s8*)0x54AC24);
+}
+
+void DoorShutter_Unlocking(DoorShutter* thisx, GlobalContext* globalCtx) {
+    if (thisx->lock_timer > 0) {
+        thisx->lock_timer--;
+        return;
+    }
+    thisx->action_fn = DoorShutter_SlidingDoor_Idle;
+}
+
+// DoorGerudo
+
+#define DoorGerudo_Update_addr 0x263118
+#define DoorGerudo_Update ((ActorFunc)DoorGerudo_Update_addr)
+
+#define DoorGerudo_Idle (void*)0x3F3FA0
+#define DoorGerudo_Unlocking (void*)0x3EEE38
+
+void DoorGerudo_rUpdate(DoorGerudo* thisx, GlobalContext* globalCtx) {
+    void* prev_action_fn = thisx->action_fn;
+
+    DoorGerudo_Update((Actor*)thisx, globalCtx);
+
+    if (thisx->lock_timer != 0 && prev_action_fn == DoorGerudo_Idle && thisx->action_fn == DoorGerudo_Unlocking) {
+        Multiplayer_Send_ActorUpdate((Actor*)thisx, NULL, 0);
+    }
+}
+
+void DoorGerudo_Unlock(DoorGerudo* thisx) {
+    if (thisx->action_fn != DoorGerudo_Idle || thisx->lock_timer == 0) {
+        return;
+    }
+    thisx->action_fn = DoorGerudo_Unlocking;
+    PlaySFX(0x10001D3, &thisx->base.world.pos, 4, (f32*)0x54AC20, (f32*)0x54AC20, (s8*)0x54AC24); // NA_SE_EV_CHAIN_KEY_UNLOCK
 }

--- a/code/src/door.h
+++ b/code/src/door.h
@@ -3,6 +3,42 @@
 
 #include "z3D/z3D.h"
 
+typedef struct {
+    Actor base;
+    SkelAnime anime;
+    char unk_228[444];
+    void* action_fn;
+    s16 lock_timer;
+} EnDoor;
+
+void EnDoor_rUpdate(EnDoor* thisx, GlobalContext* globalCtx);
+void EnDoor_Unlock(EnDoor* thisx);
+
+typedef struct {
+    Actor base;
+    char dyna[24];
+    char unk_1BC[6];
+    s8 door_type_maybe;
+    char unk_1C3[3];
+    s8 lock_timer;
+    char unk_1C7[9];
+    void* action_fn;
+} DoorShutter;
+
 void DoorShutter_rInit(Actor* thisx, GlobalContext* globalCtx);
+void DoorShutter_rUpdate(DoorShutter* thisx, GlobalContext* globalCtx);
+void DoorShutter_Unlock(DoorShutter* thisx);
+
+typedef struct {
+    Actor base;
+    char dyna[24];
+    char unk_1BC[2];
+    s8 lock_timer;
+    char unk_1BF[1];
+    void* action_fn;
+} DoorGerudo;
+
+void DoorGerudo_rUpdate(DoorGerudo* thisx, GlobalContext* globalCtx);
+void DoorGerudo_Unlock(DoorGerudo* thisx);
 
 #endif //_DOOR_H_

--- a/code/src/encode_utf16.c
+++ b/code/src/encode_utf16.c
@@ -1,0 +1,24 @@
+#include "3ds/util/utf.h"
+
+ssize_t
+encode_utf16(uint16_t *out,
+             uint32_t in)
+{
+  if(in < 0x10000)
+  {
+    if(out != NULL)
+      *out++ = in;
+    return 1;
+  }
+  else if(in < 0x110000)
+  {
+    if(out != NULL)
+    {
+      *out++ = (in >> 10) + 0xD7C0;
+      *out++ = (in & 0x3FF) + 0xDC00;
+    }
+    return 2;
+  }
+
+  return -1;
+}

--- a/code/src/encode_utf8.c
+++ b/code/src/encode_utf8.c
@@ -1,0 +1,45 @@
+#include "3ds/util/utf.h"
+
+ssize_t
+encode_utf8(uint8_t  *out,
+            uint32_t in)
+{
+  if(in < 0x80)
+  {
+    if(out != NULL)
+      *out++ = in;
+    return 1;
+  }
+  else if(in < 0x800)
+  {
+    if(out != NULL)
+    {
+      *out++ = (in >> 6) + 0xC0;
+      *out++ = (in & 0x3F) + 0x80;
+    }
+    return 2;
+  }
+  else if(in < 0x10000)
+  {
+    if(out != NULL)
+    {
+      *out++ = (in >> 12) + 0xE0;
+      *out++ = ((in >> 6) & 0x3F) + 0x80;
+      *out++ = (in & 0x3F) + 0x80;
+    }
+    return 3;
+  }
+  else if(in < 0x110000)
+  {
+    if(out != NULL)
+    {
+      *out++ = (in >> 18) + 0xF0;
+      *out++ = ((in >> 12) & 0x3F) + 0x80;
+      *out++ = ((in >> 6) & 0x3F) + 0x80;
+      *out++ = (in & 0x3F) + 0x80;
+    }
+    return 4;
+  }
+
+  return -1;
+}

--- a/code/src/gfx.h
+++ b/code/src/gfx.h
@@ -1,10 +1,7 @@
 #ifndef _GFX_H_
 #define _GFX_H_
 
-#include "../include/draw.h"
-#include "../include/input.h"
-#include "3ds/extdata.h"
-#include "savefile.h"
+#include "3ds/types.h"
 
 extern u32 pressed;
 extern bool handledInput;

--- a/code/src/gfx_options.c
+++ b/code/src/gfx_options.c
@@ -1,5 +1,9 @@
 #include <string.h>
 #include "gfx_options.h"
+#include "gfx.h"
+#include "savefile.h"
+#include "draw.h"
+#include "input.h"
 
 #define BORDER_WIDTH 2
 #define CHOICE_COLUMN 240

--- a/code/src/gfx_options.h
+++ b/code/src/gfx_options.h
@@ -1,8 +1,6 @@
 #ifndef _GFX_OPTIONS_H_
 #define _GFX_OPTIONS_H_
 
-#include "gfx.h"
-
 void InitOptions(void);
 void Gfx_DrawOptions(void);
 void Gfx_OptionsUpdate(void);

--- a/code/src/graveyard_objects.c
+++ b/code/src/graveyard_objects.c
@@ -1,18 +1,28 @@
-#include "z3D/z3D.h"
 #include "graveyard_objects.h"
+#include "multiplayer.h"
 
 #define CsTimer (gGlobalContext->csCtx.frames)
 
 #define BgSpot02Objects_Update_addr 0x3831AC
 #define BgSpot02Objects_Update ((ActorFunc)BgSpot02Objects_Update_addr)
 
+#define BgSpot02Objects_Explode (void*)0x205EDC
+
 void BgSpot02Objects_rUpdate(Actor* thisx, GlobalContext* globalCtx) {
     BgSpot02Objects_Update(thisx, globalCtx);
-    // Royal Family's Tomb.        Tomb opened (or opening).                Just for safety in case of WW.
+    // Royal Family's Tomb.        Tomb opened (or opening).                 Just for safety in case of WW.
     if (thisx->params == 0x0002 && (gSaveContext.eventChkInf[1] & 0x2000) && gSaveContext.sceneSetupIndex < 4) {
-        if (CsTimer > 0 && CsTimer < 740)
+        if (CsTimer > 0 && CsTimer < 740) {
+            Multiplayer_Send_ActorUpdate(thisx, NULL, 0);
             CsTimer = 740;
-        else if (CsTimer > 740 && CsTimer < 869)
+        } else if (CsTimer > 740 && CsTimer < 869) {
             CsTimer = 869;
+        }
     }
+}
+
+void BgSpot02Objects_ExplodeGrave(BgSpot02Objects* thisx) {
+    PlaySFX(0x1000219, &thisx->base.world.pos, 4, (f32*)0x54AC20, (f32*)0x54AC20, (s8*)0x54AC24); // NA_SE_EV_GRAVE_EXPLOSION
+    thisx->timer = 38;
+    thisx->action_fn = BgSpot02Objects_Explode;
 }

--- a/code/src/graveyard_objects.h
+++ b/code/src/graveyard_objects.h
@@ -3,6 +3,14 @@
 
 #include "z3D/z3D.h"
 
+typedef struct {
+    Actor base;
+    char dyna[24];
+    void* action_fn;
+    s16 timer;
+} BgSpot02Objects;
+
 void BgSpot02Objects_rUpdate(Actor* thisx, GlobalContext* globalCtx);
+void BgSpot02Objects_ExplodeGrave(BgSpot02Objects* thisx);
 
 #endif //_GRAVEYARD_OBJECTS_H_

--- a/code/src/heart_container.c
+++ b/code/src/heart_container.c
@@ -8,6 +8,9 @@
 #define ItemBHeart_Destroy_addr 0x2537D4
 #define ItemBHeart_Destroy ((ActorFunc)ItemBHeart_Destroy_addr)
 
+#define ItemBHeart_Update_addr 0x285C18
+#define ItemBHeart_Update ((ActorFunc)ItemBHeart_Update_addr)
+
 #define ItemBHeart_Draw_addr 0x285BEC
 #define ItemBHeart_Draw ((ActorFunc)ItemBHeart_Draw_addr)
 
@@ -25,6 +28,17 @@ void ItemBHeart_rDestroy(Actor* thisx, GlobalContext* globalCtx) {
 
     Model_DestroyByActor(&container->actor);
     ItemBHeart_Destroy(&container->actor, globalCtx);
+}
+
+void ItemBHeart_rUpdate(Actor* thisx, GlobalContext* globalCtx) {
+    ItemBHeart* container = THIS;
+
+    if (Flags_GetCollectible(globalCtx, 0x1F)) {
+        Actor_Kill(&container->actor);
+        return;
+    }
+
+    ItemBHeart_Update(&container->actor, globalCtx);
 }
 
 void ItemBHeart_rDraw(Actor* thisx, GlobalContext* globalCtX) {

--- a/code/src/heart_container.h
+++ b/code/src/heart_container.h
@@ -6,6 +6,7 @@
 
 void ItemBHeart_rInit(Actor* thisx, GlobalContext* globalCtx);
 void ItemBHeart_rDestroy(Actor* thisx, GlobalContext* globalCtx);
+void ItemBHeart_rUpdate(Actor* thisx, GlobalContext* globalCtx);
 void ItemBHeart_rDraw(Actor* thisx, GlobalContext* globalCtX);
 
 #endif //_HEART_CONTAINER_H_

--- a/code/src/hooks.s
+++ b/code/src/hooks.s
@@ -1246,6 +1246,55 @@ hook_ReturnFWSetupGrottoInfo:
     add sp,sp,#0x8
     bx lr
 
+.global hook_BrownBoulderExplode
+hook_BrownBoulderExplode:
+    push {r0-r12, lr}
+    cpy r0,r5
+    cpy r1,r7
+    bl ObjBombiwa_GetFlag
+    cmp r0,#0x0
+    pop {r0-r12, lr}
+    bne 0x26FA7C
+    b 0x346D94
+
+.global hook_RedBoulderExplode
+hook_RedBoulderExplode:
+    ldrb r0,[r5,#0x1B5]
+    push {r0-r12, lr}
+    cpy r0,r5
+    bl ObjHamishi_HitCount
+    cmp r0,#0x2
+    pop {r0-r12, lr}
+    bge 0x26FE9C
+    b 0x26FE80
+
+.global hook_Multiplayer_UpdatePrevActorFlags
+hook_Multiplayer_UpdatePrevActorFlags:
+    str r0,[r5,#0x1b8]
+    push {r0-r12, lr}
+    bl Multiplayer_Sync_UpdatePrevActorFlags
+    pop {r0-r12, pc}
+
+.global hook_Multiplayer_OnLoadFile
+hook_Multiplayer_OnLoadFile:
+    strh r6,[r0,#0x4C]
+    push {r0-r12, lr}
+    bl Multiplayer_OnFileLoad
+    pop {r0-r12, lr}
+    b 0x449F00
+
+.global hook_SendDroppedBottleContents
+hook_SendDroppedBottleContents:
+    add r0,r0,#0x8C
+    push {r0-r12, lr}
+    cpy r0,r2
+    vmov r1,s0
+    vmov r2,s1
+    vmov r3,s2
+    bl SendDroppedBottleContents
+    pop {r0-r12, lr}
+    bx lr
+
 .section .loader
 .global hook_into_loader
 hook_into_loader:

--- a/code/src/item00.c
+++ b/code/src/item00.c
@@ -9,10 +9,15 @@
 #define EnItem00_Destroy_addr 0x1F706C
 #define EnItem00_Destroy ((ActorFunc)EnItem00_Destroy_addr)
 
+#define EnItem00_Update_addr 0x22B71C
+#define EnItem00_Update ((ActorFunc)EnItem00_Update_addr)
+
 #define EnItem00_Draw_addr 0x22B6C0
 #define EnItem00_Draw ((ActorFunc)EnItem00_Draw_addr)
 
 #define THIS ((EnItem00*)thisx)
+
+#define FUN_002B175C (void*)0x2B175C
 
 typedef enum {
     /* 0x00 */ ITEM00_RUPEE_GREEN,
@@ -80,6 +85,17 @@ void EnItem00_rDestroy(Actor* thisx, GlobalContext* globalCtx) {
 
     Model_DestroyByActor(&item->actor);
     EnItem00_Destroy(&item->actor, globalCtx);
+}
+
+void EnItem00_rUpdate(Actor* thisx, GlobalContext* globalCtx) {
+    EnItem00* item = THIS;
+
+    if (Flags_GetCollectible(globalCtx, item->collectibleFlag) && item->action_fn != FUN_002B175C) {
+        Actor_Kill(&item->actor);
+        return;
+    }
+
+    EnItem00_Update(&item->actor, globalCtx);
 }
 
 void EnItem00_rDraw(Actor* thisx, GlobalContext* globalCtX) {

--- a/code/src/item00.h
+++ b/code/src/item00.h
@@ -6,6 +6,7 @@
 
 void EnItem00_rInit(Actor* item, GlobalContext* globalCtx);
 void EnItem00_rDestroy(Actor* item, GlobalContext* globalCtx);
+void EnItem00_rUpdate(Actor* item, GlobalContext* globalCtx);
 void EnItem00_rDraw(Actor* item, GlobalContext* globalCtx);
 
 #endif //_ITEM00_H_

--- a/code/src/item_effect.c
+++ b/code/src/item_effect.c
@@ -2,6 +2,7 @@
 #include "settings.h"
 #include "z3D/z3D.h"
 #include "savefile.h"
+#include "multiplayer.h"
 
 void ItemEffect_None(SaveContext* saveCtx, s16 arg1, s16 arg2) {
 }
@@ -44,6 +45,10 @@ void ItemEffect_GiveTycoonWallet(SaveContext* saveCtx, s16 arg1, s16 arg2) {
 
 void ItemEffect_GiveBiggoronSword(SaveContext* saveCtx, s16 arg1, s16 arg2) {
     saveCtx->bgsFlag = 1; // Set flag to make the sword durable
+
+    if (gSettingsContext.mp_SharedProgress == ON) {
+        Multiplayer_Send_BGSFlag();
+    }
 }
 
 void ItemEffect_GiveBottle(SaveContext* saveCtx, s16 bottleItemId, s16 arg2) {
@@ -78,6 +83,10 @@ void ItemEffect_GiveDefense(SaveContext* saveCtx, s16 arg1, s16 arg2) {
     if((gSettingsContext.heartDropRefill != HEARTDROPREFILL_NOREFILL) && (gSettingsContext.heartDropRefill != HEARTDROPREFILL_NODROPREFILL)){
         saveCtx->healthAccumulator = 20 * 0x10;
     }
+
+    if (gSettingsContext.mp_SharedProgress == ON) {
+        Multiplayer_Send_GreatFairyBuff(0);
+    }
 }
 
 void ItemEffect_GiveMagic(SaveContext* saveCtx, s16 arg1, s16 arg2) {
@@ -85,6 +94,10 @@ void ItemEffect_GiveMagic(SaveContext* saveCtx, s16 arg1, s16 arg2) {
     saveCtx->magicAcquired = 1;     // Required for meter to persist on save load
     saveCtx->magicMeterSize = 0x30; // Set meter size
     saveCtx->magic = 0x30;          // Fill meter
+
+    if (gSettingsContext.mp_SharedProgress == ON) {
+        Multiplayer_Send_GreatFairyBuff(1);
+    }
 }
 
 void ItemEffect_GiveDoubleMagic(SaveContext* saveCtx, s16 arg1, s16 arg2) {
@@ -93,6 +106,10 @@ void ItemEffect_GiveDoubleMagic(SaveContext* saveCtx, s16 arg1, s16 arg2) {
     saveCtx->doubleMagic = 1;       // Required for meter to persist on save load
     saveCtx->magicMeterSize = 0x60; // Set meter size
     saveCtx->magic = 0x60;          // Fill meter
+
+    if (gSettingsContext.mp_SharedProgress == ON) {
+        Multiplayer_Send_GreatFairyBuff(2);
+    }
 }
 
 void ItemEffect_GiveFairyOcarina(SaveContext* saveCtx, s16 arg1, s16 arg2) {
@@ -213,7 +230,7 @@ static u8 MakeSpaceInItemMenu(u8* itemMenu) {
     return 0xFF;
 }
 
-static void PushSlotIntoInventoryMenu(u8 itemSlot) {
+void PushSlotIntoInventoryMenu(u8 itemSlot) {
     u8 currentSlot = 0;
     while ((currentSlot + 1) % 6 == 0 || gSaveContext.itemMenuChild[currentSlot] != 0xFF) {
         currentSlot++;
@@ -244,20 +261,37 @@ void ItemEffect_PlaceMagicArrowsInInventory(SaveContext* saveCtx, s16 arg1, s16 
         SaveFile_ResetItemSlotsIfMatchesID(ItemSlots[ITEM_ARROW_FIRE]);
         SaveFile_ResetItemSlotsIfMatchesID(ItemSlots[ITEM_ARROW_ICE]);
         SaveFile_ResetItemSlotsIfMatchesID(ItemSlots[ITEM_ARROW_LIGHT]);
+        if (gSettingsContext.mp_SharedProgress == ON && !duplicateSendProtection) {
+            Multiplayer_Send_MagicArrow(arg1);
+        }
     } else if (saveCtx->items[ItemSlots[ITEM_BOW]] == ITEM_NONE) {
         if (arg1 == 1 && saveCtx->items[ItemSlots[ITEM_ARROW_FIRE]] == ITEM_NONE) { // Fire Arrow
             PushSlotIntoInventoryMenu(ItemSlots[ITEM_ARROW_FIRE]);
+            if (gSettingsContext.mp_SharedProgress == ON && !duplicateSendProtection) {
+                Multiplayer_Send_MagicArrow(arg1);
+            }
         } else if (arg1 == 2 && saveCtx->items[ItemSlots[ITEM_ARROW_ICE]] == ITEM_NONE) { // Ice Arrow
             PushSlotIntoInventoryMenu(ItemSlots[ITEM_ARROW_ICE]);
+            if (gSettingsContext.mp_SharedProgress == ON && !duplicateSendProtection) {
+                Multiplayer_Send_MagicArrow(arg1);
+            }
         } else if (arg1 == 3 && saveCtx->items[ItemSlots[ITEM_ARROW_LIGHT]] == ITEM_NONE) { // Light Arrow
             PushSlotIntoInventoryMenu(ItemSlots[ITEM_ARROW_LIGHT]);
+            if (gSettingsContext.mp_SharedProgress == ON && !duplicateSendProtection) {
+                Multiplayer_Send_MagicArrow(arg1);
+            }
         }
     }
+    duplicateSendProtection = false;
 }
 
 void ItemEffect_GiveChildKokiriSword(SaveContext* saveCtx, s16 arg1, s16 arg2) {
     // Put the Kokiri Sword on Child B button when Link goes back child
     saveCtx->childEquips.buttonItems[0] = ITEM_SWORD_KOKIRI;
+
+    if (gSettingsContext.mp_SharedProgress == ON) {
+        Multiplayer_Send_KokiriSwordEquip();
+    }
 }
 
 void ItemEffect_GiveStone(SaveContext* saveCtx, s16 mask, s16 arg2) {

--- a/code/src/item_effect.h
+++ b/code/src/item_effect.h
@@ -23,6 +23,7 @@ void ItemEffect_IceTrap(SaveContext* saveCtx, s16 arg1, s16 arg2);
 void ItemEffect_BeanPack(SaveContext* saveCtx, s16 arg1, s16 arg2);
 void ItemEffect_FillWalletUpgrade(SaveContext* saveCtx, s16 arg1, s16 arg2);
 void ItemEffect_OpenMaskShop(SaveContext* saveCtx, s16 arg1, s16 arg2);
+void PushSlotIntoInventoryMenu(u8 itemSlot);
 void ItemEffect_PlaceMagicArrowsInInventory(SaveContext* saveCtx, s16 arg1, s16 arg2);
 void ItemEffect_GiveChildKokiriSword(SaveContext* saveCtx, s16 arg1, s16 arg2);
 void ItemEffect_GiveStone(SaveContext* saveCtx, s16 mask, s16 arg2);

--- a/code/src/item_etcetera.c
+++ b/code/src/item_etcetera.c
@@ -9,6 +9,9 @@
 #define ItemEtcetera_Destroy_addr 0x2740BC
 #define ItemEtcetera_Destroy ((ActorFunc)ItemEtcetera_Destroy_addr)
 
+#define ItemEtcetera_Update_addr 0x298D88
+#define ItemEtcetera_Update ((ActorFunc)ItemEtcetera_Update_addr)
+
 #define ItemEtcetera_Draw_addr 0x11707C
 #define ItemEtcetera_Draw ((ActorFunc)ItemEtcetera_Draw_addr)
 
@@ -33,4 +36,25 @@ void ItemEtcetera_rDestroy(Actor* thisx, GlobalContext* globalCtx) {
 
     Model_DestroyByActor(&item->actor);
     ItemEtcetera_Destroy(&item->actor, globalCtx);
+}
+
+void ItemEtcetera_rUpdate(Actor* thisx, GlobalContext* globalCtx) {
+    ItemEtcetera* item = THIS;
+
+    switch (item->actor.params & 0xFF) {
+        case 1: // Ruto's Letter
+            if (gSaveContext.eventChkInf[3] & 0x2) {
+                Actor_Kill(&item->actor);
+                return;
+            }
+            break;
+        case 7: // Fire Arrows
+            if (gGlobalContext->actorCtx.flags.chest & 0x1) {
+                Actor_Kill(&item->actor);
+                return;
+            }
+            break;
+    }
+
+    ItemEtcetera_Update(&item->actor, globalCtx);
 }

--- a/code/src/item_etcetera.h
+++ b/code/src/item_etcetera.h
@@ -6,5 +6,6 @@
 
 void ItemEtcetera_rInit(Actor* item, GlobalContext* globalCtx);
 void ItemEtcetera_rDestroy(Actor* item, GlobalContext* globalCtx);
+void ItemEtcetera_rUpdate(Actor* item, GlobalContext* globalCtx);
 
 #endif //_ITEM_ETCETERA_H_

--- a/code/src/liftable_rock.c
+++ b/code/src/liftable_rock.c
@@ -1,8 +1,14 @@
 #include "liftable_rock.h"
 #include "settings.h"
+#include "multiplayer.h"
 
 #define EnIshi_Init_addr 0x1B5460
 #define EnIshi_Init ((ActorFunc)EnIshi_Init_addr)
+
+#define EnIshi_Update_addr 0x1F69AC
+#define EnIshi_Update ((ActorFunc)EnIshi_Update_addr)
+
+#define EnIshi_LiftedUp (void*)0x3CBAC4
 
 void EnIshi_rInit(Actor* thisx, GlobalContext* globalCtx) {
 
@@ -15,4 +21,15 @@ void EnIshi_rInit(Actor* thisx, GlobalContext* globalCtx) {
         Actor_Kill(thisx);
     }
 
+}
+
+void EnIshi_rUpdate(EnIshi* thisx, GlobalContext* globalCtx) {
+    void* prev_action_fn = thisx->action_fn;
+
+    EnIshi_Update((Actor*)thisx, globalCtx);
+
+    s16 type = thisx->base.params & 0x1;
+    if (type == LARGE_ROCK && prev_action_fn != thisx->action_fn && thisx->action_fn == EnIshi_LiftedUp) {
+        Multiplayer_Send_ActorUpdate((Actor*)thisx, NULL, 0);
+    }
 }

--- a/code/src/liftable_rock.h
+++ b/code/src/liftable_rock.h
@@ -1,11 +1,19 @@
-#ifndef _LIFTABLE_ROCK_H
-#define _LIFTABLE_ROCK_H
+#ifndef _LIFTABLE_ROCK_H_
+#define _LIFTABLE_ROCK_H_
 
 #define SMALL_ROCK 0
 #define LARGE_ROCK 1
 
-#include "z3D/z3D.h"
+#include "../include/z3D/z3D.h"
+
+typedef struct {
+    Actor base;
+    void* action_fn;
+    char collider[88];
+    SkeletonAnimationModel* animation_model;
+} EnIshi;
 
 void EnIshi_rInit(Actor* thisx, GlobalContext* globalCtx);
+void EnIshi_rUpdate(EnIshi* thisx, GlobalContext* globalCtx);
 
-#endif
+#endif //_LIFTABLE_ROCK_H_

--- a/code/src/main.c
+++ b/code/src/main.c
@@ -8,11 +8,12 @@
 #include "title_screen.h"
 #include "draw.h"
 #include "common.h"
+#include "multiplayer.h"
 
 #include "z3D/z3D.h"
 #include "3ds/extdata.h"
 
-GlobalContext* gGlobalContext;
+GlobalContext* gGlobalContext = NULL;
 static u8 rRandomizerInit = 0;
 
 void set_GlobalContext(GlobalContext* globalCtx) {
@@ -38,6 +39,8 @@ void before_GlobalContext_Update(GlobalContext* globalCtx) {
     Input_Update();
 
     Settings_SkipSongReplays();
+
+    Multiplayer_Run();
 }
 
 void after_GlobalContext_Update() {
@@ -48,4 +51,6 @@ void after_GlobalContext_Update() {
             romfsAlertFrames--;
         }
     }
+
+    Multiplayer_Sync_Update();
 }

--- a/code/src/multiplayer.c
+++ b/code/src/multiplayer.c
@@ -1,0 +1,2439 @@
+#include <string.h>
+#include "3ds/services/uds.h"
+#include "3ds/result.h"
+#include "multiplayer.h"
+#include "multiplayer_ghosts.h"
+#include "oot_malloc.h"
+#include "common.h"
+#include "item_effect.h"
+#include "savefile.h"
+#include "settings.h"
+#include "giants_knife.h"
+
+#include "web.h"
+#include "skulltula.h"
+#include "graveyard_objects.h"
+#include "collapsing_platform.h"
+#include "boulder_red.h"
+#include "door.h"
+#include "carpenter.h"
+#include "business_scrubs.h"
+#include "shops.h"
+#include "pushblock.h"
+
+// Self Vars
+u32 receivedPackets = 0;
+bool duplicateSendProtection = false;
+static s8 netStage = 0;
+static bool mSaveContextInit = false;
+
+// Network Vars
+u32* mBuffer;
+size_t mBufSize;
+u8 data_channel = 1;
+udsBindContext bindctx;
+
+static void Multiplayer_Sync_Init();
+static void Multiplayer_Sync_SharedProgress();
+static void Multiplayer_SendPacket(u8 packageSize, u16 targetID);
+static void Multiplayer_UnpackPacket(u16 senderID);
+
+typedef struct {
+    // SaveContext
+    u16 healthCapacity;
+    s16 health;
+    s16 rupees;
+    s8 magicLevel;
+    s8 magic;
+    u16 bgsHitsLeft;
+    u8 magicAcquired;
+    u8 doubleMagic;
+    u8 doubleDefense;
+    s8 bgsFlag;
+    u8 childEquipsButtonB;
+    u8 items[26];
+    s8 ammo[15];
+    u8 magic_beans_available;
+    u16 equipment;
+    u32 upgrades;
+    u32 questItems;
+    u8 dungeonItems[20];
+    s8 dungeonKeys[19];
+    s16 gsTokens;
+    SaveSceneFlags sceneFlags[124];
+    u8 gsFlags[22];
+    u8 fishingFlags;
+    u16 eventChkInf[14];
+    u16 itemGetInf[4];
+    u16 infTable[30];
+    u32 worldMapAreaData;
+    u16 magicMeterSize;
+    // ExtData
+    u8 biggoronTrades;
+    u32 scenesDiscovered[SAVEFILE_SCENES_DISCOVERED_IDX_COUNT];
+    u32 entrancesDiscovered[SAVEFILE_ENTRANCES_DISCOVERED_IDX_COUNT];
+} MultiplayerSaveContext;
+
+static MultiplayerSaveContext mSaveContext;
+
+static void Multiplayer_Overwrite_mSaveContext(void) {
+    // SaveContext
+    mSaveContext.healthCapacity = gSaveContext.healthCapacity;
+    mSaveContext.health = gSaveContext.health;
+    mSaveContext.rupees = gSaveContext.rupees;
+    mSaveContext.magicLevel = gSaveContext.magicLevel;
+    mSaveContext.magic = gSaveContext.magic;
+    mSaveContext.bgsHitsLeft = gSaveContext.bgsHitsLeft;
+    mSaveContext.magicAcquired = gSaveContext.magicAcquired;
+    mSaveContext.doubleMagic = gSaveContext.doubleMagic;
+    mSaveContext.doubleDefense = gSaveContext.doubleDefense;
+    mSaveContext.bgsFlag = gSaveContext.bgsFlag;
+    mSaveContext.childEquipsButtonB = gSaveContext.childEquips.buttonItems[0];
+    for (size_t i = 0; i < ARRAY_SIZE(gSaveContext.items); i++) {
+        mSaveContext.items[i] = gSaveContext.items[i];
+    }
+    for (size_t i = 0; i < ARRAY_SIZE(gSaveContext.ammo); i++) {
+        mSaveContext.ammo[i] = gSaveContext.ammo[i];
+    }
+    mSaveContext.magic_beans_available = gSaveContext.magic_beans_available;
+    mSaveContext.equipment = gSaveContext.equipment;
+    mSaveContext.upgrades = gSaveContext.upgrades;
+    mSaveContext.questItems = gSaveContext.questItems;
+    for (size_t i = 0; i < ARRAY_SIZE(gSaveContext.dungeonItems); i++) {
+        mSaveContext.dungeonItems[i] = gSaveContext.dungeonItems[i];
+    }
+    for (size_t i = 0; i < ARRAY_SIZE(gSaveContext.dungeonKeys); i++) {
+        mSaveContext.dungeonKeys[i] = gSaveContext.dungeonKeys[i];
+    }
+    mSaveContext.gsTokens = gSaveContext.gsTokens;
+    for (size_t i = 0; i < ARRAY_SIZE(gSaveContext.sceneFlags); i++) {
+        mSaveContext.sceneFlags[i] = gSaveContext.sceneFlags[i];
+    }
+    for (size_t i = 0; i < ARRAY_SIZE(gSaveContext.gsFlags); i++) {
+        mSaveContext.gsFlags[i] = gSaveContext.gsFlags[i];
+    }
+    mSaveContext.fishingFlags = gSaveContext.fishingStats.flags;
+    for (size_t i = 0; i < ARRAY_SIZE(gSaveContext.eventChkInf); i++) {
+        mSaveContext.eventChkInf[i] = gSaveContext.eventChkInf[i];
+    }
+    for (size_t i = 0; i < ARRAY_SIZE(gSaveContext.itemGetInf); i++) {
+        mSaveContext.itemGetInf[i] = gSaveContext.itemGetInf[i];
+    }
+    for (size_t i = 0; i < ARRAY_SIZE(gSaveContext.infTable); i++) {
+        mSaveContext.infTable[i] = gSaveContext.infTable[i];
+    }
+    mSaveContext.worldMapAreaData = gSaveContext.worldMapAreaData;
+    mSaveContext.magicMeterSize = gSaveContext.magicMeterSize;
+    // ExtData
+    mSaveContext.biggoronTrades = gExtSaveData.biggoronTrades;
+    for (size_t i = 0; i < SAVEFILE_SCENES_DISCOVERED_IDX_COUNT; i++) {
+        mSaveContext.scenesDiscovered[i] = gExtSaveData.scenesDiscovered[i];
+    }
+    for (size_t i = 0; i < SAVEFILE_ENTRANCES_DISCOVERED_IDX_COUNT; i++) {
+        mSaveContext.entrancesDiscovered[i] = gExtSaveData.entrancesDiscovered[i];
+    }
+}
+
+static void Multiplayer_Overwrite_gSaveContext(void) {
+    // SaveContext
+    gSaveContext.healthCapacity = mSaveContext.healthCapacity;
+    gSaveContext.health = mSaveContext.health;
+    gSaveContext.rupees = mSaveContext.rupees;
+    gSaveContext.magicLevel = mSaveContext.magicLevel;
+    gSaveContext.magic = mSaveContext.magic;
+    gSaveContext.bgsHitsLeft = mSaveContext.bgsHitsLeft;
+    gSaveContext.magicAcquired = mSaveContext.magicAcquired;
+    gSaveContext.doubleMagic = mSaveContext.doubleMagic;
+    gSaveContext.doubleDefense = mSaveContext.doubleDefense;
+    gSaveContext.bgsFlag = mSaveContext.bgsFlag;
+    gSaveContext.childEquips.buttonItems[0] = mSaveContext.childEquipsButtonB;
+    for (size_t i = 0; i < ARRAY_SIZE(gSaveContext.items); i++) {
+        gSaveContext.items[i] = mSaveContext.items[i];
+    }
+    for (size_t i = 0; i < ARRAY_SIZE(gSaveContext.ammo); i++) {
+        gSaveContext.ammo[i] = mSaveContext.ammo[i];
+    }
+    gSaveContext.magic_beans_available = mSaveContext.magic_beans_available;
+    gSaveContext.equipment = mSaveContext.equipment;
+    gSaveContext.upgrades = mSaveContext.upgrades;
+    gSaveContext.questItems = mSaveContext.questItems;
+    for (size_t i = 0; i < ARRAY_SIZE(gSaveContext.dungeonItems); i++) {
+        gSaveContext.dungeonItems[i] = mSaveContext.dungeonItems[i];
+    }
+    for (size_t i = 0; i < ARRAY_SIZE(gSaveContext.dungeonKeys); i++) {
+        gSaveContext.dungeonKeys[i] = mSaveContext.dungeonKeys[i];
+    }
+    gSaveContext.gsTokens = mSaveContext.gsTokens;
+    for (size_t i = 0; i < ARRAY_SIZE(gSaveContext.sceneFlags); i++) {
+        gSaveContext.sceneFlags[i] = mSaveContext.sceneFlags[i];
+    }
+    for (size_t i = 0; i < ARRAY_SIZE(gSaveContext.gsFlags); i++) {
+        gSaveContext.gsFlags[i] = mSaveContext.gsFlags[i];
+    }
+    gSaveContext.fishingStats.flags = mSaveContext.fishingFlags;
+    for (size_t i = 0; i < ARRAY_SIZE(gSaveContext.eventChkInf); i++) {
+        gSaveContext.eventChkInf[i] = mSaveContext.eventChkInf[i];
+    }
+    for (size_t i = 0; i < ARRAY_SIZE(gSaveContext.itemGetInf); i++) {
+        gSaveContext.itemGetInf[i] = mSaveContext.itemGetInf[i];
+    }
+    for (size_t i = 0; i < ARRAY_SIZE(gSaveContext.infTable); i++) {
+        gSaveContext.infTable[i] = mSaveContext.infTable[i];
+    }
+    gSaveContext.worldMapAreaData = mSaveContext.worldMapAreaData;
+    gSaveContext.magicMeterSize = mSaveContext.magicMeterSize;
+    // ExtData
+    gExtSaveData.biggoronTrades = mSaveContext.biggoronTrades;
+    for (size_t i = 0; i < SAVEFILE_SCENES_DISCOVERED_IDX_COUNT; i++) {
+        gExtSaveData.scenesDiscovered[i] = mSaveContext.scenesDiscovered[i];
+    }
+    for (size_t i = 0; i < SAVEFILE_ENTRANCES_DISCOVERED_IDX_COUNT; i++) {
+        gExtSaveData.entrancesDiscovered[i] = mSaveContext.entrancesDiscovered[i];
+    }
+}
+
+void Multiplayer_OnFileLoad(void) {
+    if (gSettingsContext.mp_Enabled == OFF || gSettingsContext.mp_SharedProgress == OFF) {
+        return;
+    }
+
+    if (!mSaveContextInit) {
+        mSaveContextInit = true;
+        Multiplayer_Overwrite_mSaveContext();
+    } else {
+        Multiplayer_Overwrite_gSaveContext();
+    }
+
+    // Clear Empty Slots
+    for (u8 i = 0; i < 0x18; ++i) {
+        if (gSaveContext.itemMenuChild[i] != SLOT_NONE && gSaveContext.items[gSaveContext.itemMenuChild[i]] == ITEM_NONE) {
+            gSaveContext.itemMenuChild[i] = SLOT_NONE;
+        }
+        if (gSaveContext.itemMenuAdult[i] != SLOT_NONE && gSaveContext.items[gSaveContext.itemMenuAdult[i]] == ITEM_NONE) {
+            gSaveContext.itemMenuAdult[i] = SLOT_NONE;
+        }
+    }
+    // Place Magic Arrows
+    static const u8 SLOT_MAGIC_ARROW[] = { SLOT_ARROW_FIRE, SLOT_ARROW_ICE, SLOT_ARROW_LIGHT };
+    for (size_t i = 0; i < ARRAY_SIZE(SLOT_MAGIC_ARROW); i++) {
+        if (gSaveContext.items[SLOT_BOW] == ITEM_NONE && gSaveContext.items[SLOT_MAGIC_ARROW[i]] != ITEM_NONE &&
+            !SaveFile_InventoryMenuHasSlot(0, SLOT_MAGIC_ARROW[i]) && !SaveFile_InventoryMenuHasSlot(1, SLOT_MAGIC_ARROW[i])) {
+            PushSlotIntoInventoryMenu(SLOT_MAGIC_ARROW[i]);
+        } else if (gSaveContext.items[SLOT_BOW] != ITEM_NONE || gSaveContext.items[SLOT_MAGIC_ARROW[i]] == ITEM_NONE) {
+            SaveFile_ResetItemSlotsIfMatchesID(SLOT_MAGIC_ARROW[i]);
+        }
+    }
+
+    Multiplayer_Sync_Init();
+}
+
+// Previous Values
+u16 prevHealthCapacity;
+u8 prevItems[26];
+s8 prevAmmo[15];
+u8 prevMagicBeansBought;
+u16 prevEquipment;
+u32 prevUpgrades;
+u32 prevQuestItem;
+u8 prevDungeonItems[20];
+s8 prevDungeonKeys[19];
+s16 prevGSTokens;
+u16 prevEventChkInf[14];
+u16 prevItemGetInf[4];
+u16 prevInfTable[30];
+ActorFlags prevActorFlags;
+SaveSceneFlags prevSaveSceneFlags[124];
+u8 prevGSFlags[22];
+u8 prevFishingFlags;
+u32 prevWorldMapAreaData;
+u32 prevAdultTrade;
+u8 prevBiggoronTrades;
+s16 prevHealth;
+s16 prevRupees;
+
+typedef enum {
+    // Ghost Data
+    PACKET_GHOSTPING,
+    PACKET_GHOSTDATA,
+    PACKET_LINKSFX,
+    // Shared Progress
+    PACKET_FULLSYNCREQUEST,
+    PACKET_BASESYNC,
+    PACKET_FULLSCENEFLAGSYNC,
+    PACKET_FULLENTRANCESYNC,
+    PACKET_ITEM,
+    PACKET_MAXHEALTH,
+    PACKET_KOKIRISWORDEQUIP,
+    PACKET_BGSFLAG,
+    PACKET_MAGICARROW,
+    PACKET_GREATFAIRYBUFF,
+    PACKET_MAGICBEANDIFF,
+    PACKET_MAGICBEANSBOUGHT,
+    PACKET_EQUIPMENT,
+    PACKET_UPGRADES,
+    PACKET_QUESTITEM,
+    PACKET_DUNGEONITEM,
+    PACKET_DUNGEONKEY,
+    PACKET_GSTOKENDIFF,
+    PACKET_EVENTCHKINF,
+    PACKET_ITEMGETINF,
+    PACKET_INFTABLE,
+    PACKET_ACTORFLAGS,
+    PACKET_SAVESCENEFLAG,
+    PACKET_GSFLAGS,
+    PACKET_FISHINGFLAG,
+    PACKET_WORLDMAPBIT,
+    PACKET_BIGGORONTRADE,
+    PACKET_DISCOVEREDSCENE,
+    PACKET_DISCOVEREDENTRANCE,
+    PACKET_ACTORUPDATE,
+    PACKET_ACTORSPAWN,
+    // Etc
+    PACKET_HEALTHCHANGE,
+    PACKET_RUPEESCHANGE,
+    PACKET_AMMOCHANGE,
+} PacketIdentifier;
+
+static u8 IsSendReceiveReady(void) {
+    return gSettingsContext.mp_Enabled != OFF && netStage >= 3;
+}
+
+void Multiplayer_Run(void) {
+    if (gSettingsContext.mp_Enabled == OFF) {
+        return;
+    }
+
+    Result result;
+    static bool shouldSendFullSyncRequest = false;
+    switch (netStage) {
+        case 0:
+            static u8 initTimer = 0;
+            initTimer++;
+            // Initializing too fast fails
+            if (initTimer >= 30) {
+                result = udsInit(0x3000, NULL);
+                if (R_FAILED(result)) {
+                    netStage = -1;
+                    return;
+                }
+                mBufSize = 0x4000;
+                mBuffer = SystemArena_Malloc(mBufSize);
+                netStage++;
+            }
+            break;
+        case 1:
+            const u32 wlancommID = 0x3656B7DA; // Unique ID set manually
+
+            // Connect or host: Scan for a bit before creating a network
+            static u8 netScanChecks = 0;
+            if (netScanChecks < (gSettingsContext.playOption == 0 ? 3 : 30)) {
+                netScanChecks++;
+
+                size_t total_networks = 0;
+                udsNetworkScanInfo* networks = NULL;
+                udsNetworkScanInfo* network = NULL;
+
+                memset(mBuffer, 0, sizeof(mBufSize));
+                result = udsScanBeacons(mBuffer, mBufSize, &networks, &total_networks, wlancommID, 0, NULL, false);
+                if (R_FAILED(result)) {
+                    return;
+                }
+
+                if (total_networks) {
+                    // Connect to first found
+                    network = &networks[0];
+
+                    // Try 10 times?
+                    for (size_t i = 0; i < 10; i++) {
+                        result = udsConnectNetwork(&network->network, "", 1, &bindctx, UDS_BROADCAST_NETWORKNODEID, UDSCONTYPE_Client, data_channel, UDS_DEFAULT_RECVBUFSIZE);
+                        if (R_SUCCEEDED(result)) {
+                            break;
+                        }
+                    }
+                    SystemArena_Free(networks);
+
+                    if (R_FAILED(result)) {
+                        return;
+                    }
+                    shouldSendFullSyncRequest = true;
+                    netStage++;
+                }
+            } else {
+                u8 max_players = UDS_MAXNODES;
+                // Citra crashes when allowing too many nodes
+                if (gSettingsContext.playOption == 1) {
+                    max_players /= 2;
+                }
+                udsNetworkStruct networkstruct;
+                udsGenerateDefaultNetworkStruct(&networkstruct, wlancommID, 0, max_players);
+                result = udsCreateNetwork(&networkstruct, "", 1, &bindctx, data_channel, UDS_DEFAULT_RECVBUFSIZE);
+                if (R_FAILED(result)) {
+                    netStage = -1;
+                    return;
+                }
+
+                netStage++;
+            }
+            break;
+        case 2:
+            // Free buffer
+            SystemArena_Free(mBuffer);
+            mBufSize = UDS_DATAFRAME_MAXSIZE;
+            mBuffer = SystemArena_Malloc(mBufSize);
+
+            netStage++;
+
+            if (shouldSendFullSyncRequest) {
+                Multiplayer_Send_FullSyncRequest();
+            }
+            break;
+        case 3:
+            // Ready to go! This update is only called in-game with the gfx menu closed
+            if (IsInGame()) {
+                Multiplayer_Update();
+                Multiplayer_Ghosts_DrawAll();
+            }
+            break;
+    }
+}
+
+void Multiplayer_Update(void) {
+    if (!IsSendReceiveReady()) {
+        return;
+    }
+    Multiplayer_ReceivePackets();
+    Multiplayer_Ghosts_Tick();
+    if (IsInGame()) {
+        Multiplayer_Send_GhostData();
+    } else {
+        Multiplayer_Send_GhostPing();
+    }
+}
+
+s8 Multiplayer_PlayerCount() {
+    udsConnectionStatus status;
+    if (R_SUCCEEDED(udsGetConnectionStatus(&status))) {
+        return status.total_nodes;
+    }
+    return -1;
+}
+
+static void Multiplayer_Sync_Init(void) {
+    // Max Health
+    prevHealthCapacity = gSaveContext.healthCapacity;
+
+    // Items
+    for (size_t i = 0; i < ARRAY_SIZE(gSaveContext.items); i++) {
+        prevItems[i] = gSaveContext.items[i];
+    }
+
+    // Ammo
+    for (size_t i = 0; i < ARRAY_SIZE(gSaveContext.ammo); i++) {
+        prevAmmo[i] = gSaveContext.ammo[i];
+    }
+
+    // Magic Beans Bought
+    prevMagicBeansBought = gSaveContext.magic_beans_available;
+
+    // Equipment
+    prevEquipment = gSaveContext.equipment;
+
+    // Upgrades
+    prevUpgrades = gSaveContext.upgrades;
+
+    // Quest Items
+    prevQuestItem = gSaveContext.questItems;
+
+    // Dungeon Items
+    for (size_t i = 0; i < ARRAY_SIZE(gSaveContext.dungeonItems); i++) {
+        prevDungeonItems[i] = gSaveContext.dungeonItems[i];
+    }
+
+    // Dungeon Keys
+    for (size_t i = 0; i < ARRAY_SIZE(gSaveContext.dungeonKeys); i++) {
+        prevDungeonKeys[i] = gSaveContext.dungeonKeys[i];
+    }
+
+    // GS Tokens
+    prevGSTokens = gSaveContext.gsTokens;
+
+    // Inf
+    for (size_t i = 0; i < ARRAY_SIZE(gSaveContext.eventChkInf); i++) {
+        prevEventChkInf[i] = gSaveContext.eventChkInf[i];
+    }
+    for (size_t i = 0; i < ARRAY_SIZE(gSaveContext.itemGetInf); i++) {
+        prevItemGetInf[i] = gSaveContext.itemGetInf[i];
+    }
+    for (size_t i = 0; i < ARRAY_SIZE(gSaveContext.infTable); i++) {
+        prevInfTable[i] = gSaveContext.infTable[i];
+    }
+
+    // Actor Flags
+    prevActorFlags = gGlobalContext->actorCtx.flags;
+
+    // Save Scene Flags
+    for (size_t i = 0; i < ARRAY_SIZE(gSaveContext.sceneFlags); i++) {
+        prevSaveSceneFlags[i] = gSaveContext.sceneFlags[i];
+    }
+
+    // GS Flags
+    for (size_t i = 0; i < ARRAY_SIZE(gSaveContext.gsFlags); i++) {
+        prevGSFlags[i] = gSaveContext.gsFlags[i];
+    }
+
+    // Fishing Flags
+    prevFishingFlags = gSaveContext.fishingStats.flags;
+
+    // World Map
+    prevWorldMapAreaData = gSaveContext.worldMapAreaData;
+
+    // Adult Trade
+    prevAdultTrade = gSaveContext.sceneFlags[0x60].unk;
+
+    // Biggoron Trades
+    prevBiggoronTrades = gExtSaveData.biggoronTrades;
+
+    // Health
+    prevHealth = gSaveContext.health;
+
+    // Rupees
+    prevRupees = gSaveContext.rupees;
+}
+
+void Multiplayer_Sync_Update(void) {
+    if (!IsSendReceiveReady() || !IsInGame()) {
+        return;
+    }
+
+    // Shared Progress
+    if (gSettingsContext.mp_SharedProgress == ON) {
+        Multiplayer_Sync_SharedProgress();
+    }
+
+    // Health
+    if (gSettingsContext.mp_SharedHealth == ON) {
+        if (prevHealth != gSaveContext.health) {
+            Multiplayer_Send_HealthChange(gSaveContext.health - prevHealth);
+        }
+        prevHealth = gSaveContext.health;
+    }
+
+    // Rupees
+    if (gSettingsContext.mp_SharedRupees == ON) {
+        if (prevRupees != gSaveContext.rupees) {
+            Multiplayer_Send_RupeeChange(gSaveContext.rupees - prevRupees);
+        }
+        prevRupees = gSaveContext.rupees;
+    }
+
+    // Ammo
+    if (gSettingsContext.mp_SharedAmmo == ON) {
+        for (size_t index = 0; index < ARRAY_SIZE(gSaveContext.ammo); index++) {
+            if (index == SLOT_BEAN) {
+                continue;
+            }
+            if (prevAmmo[index] != gSaveContext.ammo[index]) {
+                Multiplayer_Send_AmmoChange(index, gSaveContext.ammo[index] - prevAmmo[index]);
+            }
+            prevAmmo[index] = gSaveContext.ammo[index];
+        }
+    }
+}
+
+static void Multiplayer_Sync_SharedProgress(void) {
+    // Max Health
+    if (prevHealthCapacity != gSaveContext.healthCapacity) {
+        Multiplayer_Send_MaxHealth();
+    }
+    prevHealthCapacity = gSaveContext.healthCapacity;
+
+    // Items
+    for (size_t slot = 0; slot < ARRAY_SIZE(gSaveContext.items); slot++) {
+        if (prevItems[slot] != gSaveContext.items[slot] && slot != SLOT_TRADE_ADULT) {
+            Multiplayer_Send_Item(slot, gSaveContext.items[slot]);
+        }
+        prevItems[slot] = gSaveContext.items[slot];
+    }
+
+    // Magic Beans Ammo
+    if (prevAmmo[SLOT_BEAN] != gSaveContext.ammo[SLOT_BEAN]) {
+        Multiplayer_Send_MagicBeanDiff(gSaveContext.ammo[SLOT_BEAN] - prevAmmo[SLOT_BEAN]);
+    }
+    prevAmmo[SLOT_BEAN] = gSaveContext.ammo[SLOT_BEAN];
+
+    // Magic Beans Bought
+    if (prevMagicBeansBought != gSaveContext.magic_beans_available) {
+        Multiplayer_Send_MagicBeansBoughtUpdate();
+    }
+    prevMagicBeansBought = gSaveContext.magic_beans_available;
+
+    // Equipment
+    if (prevEquipment != gSaveContext.equipment) {
+        for (size_t bit = 0; bit < BIT_COUNT(gSaveContext.equipment); bit++) {
+            // Don't sync giant's knife's state
+            if (bit == 3) {
+                continue;
+            }
+            s8 result = BitCompare(gSaveContext.equipment, prevEquipment, bit);
+            if (result > 0) {
+                Multiplayer_Send_EquipmentBit(bit, 1);
+            } else if (result < 0) {
+                Multiplayer_Send_EquipmentBit(bit, 0);
+            }
+        }
+    }
+    prevEquipment = gSaveContext.equipment;
+
+    // Upgrades
+    if (prevUpgrades != gSaveContext.upgrades) {
+        for (size_t bit = 0; bit < BIT_COUNT(gSaveContext.upgrades); bit++) {
+            s8 result = BitCompare(gSaveContext.upgrades, prevUpgrades, bit);
+            if (result > 0) {
+                Multiplayer_Send_UpgradesBit(bit, 1);
+            } else if (result < 0) {
+                Multiplayer_Send_UpgradesBit(bit, 0);
+            }
+        }
+    }
+    prevUpgrades = gSaveContext.upgrades;
+
+    // Quest Items
+    if (prevQuestItem != gSaveContext.questItems) {
+        for (size_t bit = 0; bit < BIT_COUNT(gSaveContext.questItems); bit++) {
+            s8 result = BitCompare(gSaveContext.questItems, prevQuestItem, bit);
+            if (result > 0) {
+                Multiplayer_Send_QuestItemBit(bit, 1);
+            } else if (result < 0) {
+                Multiplayer_Send_QuestItemBit(bit, 0);
+            }
+        }
+    }
+    prevQuestItem = gSaveContext.questItems;
+
+    // Dungeon Items
+    for (size_t index = 0; index < ARRAY_SIZE(gSaveContext.dungeonItems); index++) {
+        if (prevDungeonItems[index] != gSaveContext.dungeonItems[index]) {
+            for (size_t bit = 0; bit < BIT_COUNT(gSaveContext.dungeonItems[index]); bit++) {
+                s8 result = BitCompare(gSaveContext.dungeonItems[index], prevDungeonItems[index], bit);
+                if (result > 0) {
+                    Multiplayer_Send_DungeonItemBit(index, bit, 1);
+                } else if (result < 0) {
+                    Multiplayer_Send_DungeonItemBit(index, bit, 0);
+                }
+            }
+        }
+        prevDungeonItems[index] = gSaveContext.dungeonItems[index];
+    }
+
+    // Dungeon Keys
+    for (size_t index = 0; index < ARRAY_SIZE(gSaveContext.dungeonKeys); index++) {
+        if (prevDungeonKeys[index] != gSaveContext.dungeonKeys[index]) {
+            Multiplayer_Send_DungeonKeyUpdate(index, gSaveContext.dungeonKeys[index] - prevDungeonKeys[index]);
+        }
+        prevDungeonKeys[index] = gSaveContext.dungeonKeys[index];
+    }
+
+    // GS Tokens
+    if (prevGSTokens != gSaveContext.gsTokens) {
+        Multiplayer_Send_GSTokenDiff(gSaveContext.gsTokens - prevGSTokens);
+    }
+    prevGSTokens = gSaveContext.gsTokens;
+
+    // EventChkInf
+    for (size_t index = 0; index < ARRAY_SIZE(gSaveContext.eventChkInf); index++) {
+        if (prevEventChkInf[index] != gSaveContext.eventChkInf[index]) {
+            for (size_t bit = 0; bit < BIT_COUNT(gSaveContext.eventChkInf[index]); bit++) {
+                s8 result = BitCompare(gSaveContext.eventChkInf[index], prevEventChkInf[index], bit);
+                if (result > 0) {
+                    Multiplayer_Send_EventChkInfBit(index, bit, 1);
+                } else if (result < 0) {
+                    Multiplayer_Send_EventChkInfBit(index, bit, 0);
+                }
+            }
+        }
+        prevEventChkInf[index] = gSaveContext.eventChkInf[index];
+    }
+
+    // ItemGetInf
+    for (size_t index = 0; index < ARRAY_SIZE(gSaveContext.itemGetInf); index++) {
+        if (prevItemGetInf[index] != gSaveContext.itemGetInf[index]) {
+            for (size_t bit = 0; bit < BIT_COUNT(gSaveContext.itemGetInf[index]); bit++) {
+                s8 result = BitCompare(gSaveContext.itemGetInf[index], prevItemGetInf[index], bit);
+                if (result > 0) {
+                    Multiplayer_Send_ItemGetInfBit(index, bit, 1);
+                } else if (result < 0) {
+                    Multiplayer_Send_ItemGetInfBit(index, bit, 0);
+                }
+            }
+        }
+        prevItemGetInf[index] = gSaveContext.itemGetInf[index];
+    }
+
+    // InfTable
+    for (size_t index = 0; index < ARRAY_SIZE(gSaveContext.infTable); index++) {
+        if (prevInfTable[index] != gSaveContext.infTable[index]) {
+            for (size_t bit = 0; bit < BIT_COUNT(gSaveContext.infTable[index]); bit++) {
+                s8 result = BitCompare(gSaveContext.infTable[index], prevInfTable[index], bit);
+                if (result > 0) {
+                    Multiplayer_Send_InfTableBit(index, bit, 1);
+                } else if (result < 0) {
+                    Multiplayer_Send_InfTableBit(index, bit, 0);
+                }
+            }
+        }
+        prevInfTable[index] = gSaveContext.infTable[index];
+    }
+
+    // Actor Flags
+    u32* actorFlagPtr[] = {
+        &gGlobalContext->actorCtx.flags.swch,
+        &gGlobalContext->actorCtx.flags.chest,
+        &gGlobalContext->actorCtx.flags.clear,
+        &gGlobalContext->actorCtx.flags.collect,
+    };
+    u32* prevActorFlagPtr[] = {
+        &prevActorFlags.swch,
+        &prevActorFlags.chest,
+        &prevActorFlags.clear,
+        &prevActorFlags.collect,
+    };
+    for (size_t member = 0; member < ARRAY_SIZE(actorFlagPtr); member++) {
+        if (*prevActorFlagPtr[member] != *actorFlagPtr[member]) {
+            for (size_t bit = 0; bit < BIT_COUNT(*actorFlagPtr[member]); bit++) {
+                s8 result = BitCompare(*actorFlagPtr[member], *prevActorFlagPtr[member], bit);
+                if (result > 0) {
+                    Multiplayer_Send_ActorFlagBit(member, bit, 1);
+                } else if (result < 0) {
+                    Multiplayer_Send_ActorFlagBit(member, bit, 0);
+                }
+            }
+        }
+        *prevActorFlagPtr[member] = *actorFlagPtr[member];
+    }
+
+    // Save Scene Flags
+    for (size_t scene = 0; scene < ARRAY_SIZE(gSaveContext.sceneFlags); scene++) {
+        u32* sceneFlagPtr[] = {
+            &gSaveContext.sceneFlags[scene].unk,
+            &gSaveContext.sceneFlags[scene].rooms1,
+            &gSaveContext.sceneFlags[scene].rooms2,
+        };
+        u32* prevSceneFlagPtr[] = {
+            &prevSaveSceneFlags[scene].unk,
+            &prevSaveSceneFlags[scene].rooms1,
+            &prevSaveSceneFlags[scene].rooms2,
+        };
+        for (size_t member = 0; member < ARRAY_SIZE(sceneFlagPtr); member++) {
+            if (*prevSceneFlagPtr[member] != *sceneFlagPtr[member]) {
+                for (size_t bit = 0; bit < BIT_COUNT(*sceneFlagPtr[member]); bit++) {
+                    s8 result = BitCompare(*sceneFlagPtr[member], *prevSceneFlagPtr[member], bit);
+                    if (result > 0) {
+                        Multiplayer_Send_SceneFlagBit(scene, member, bit, 1);
+                    } else if (result < 0) {
+                        Multiplayer_Send_SceneFlagBit(scene, member, bit, 0);
+                    }
+                }
+            }
+            *prevSceneFlagPtr[member] = *sceneFlagPtr[member];
+        }
+    }
+
+    // GS Flags
+    for (size_t index = 0; index < ARRAY_SIZE(gSaveContext.gsFlags); index++) {
+        if (prevGSFlags[index] != gSaveContext.gsFlags[index]) {
+            for (size_t bit = 0; bit < BIT_COUNT(gSaveContext.gsFlags[index]); bit++) {
+                s8 result = BitCompare(gSaveContext.gsFlags[index], prevGSFlags[index], bit);
+                if (result > 0) {
+                    Multiplayer_Send_GSFlagBit(index, bit, 1);
+                } else if (result < 0) {
+                    Multiplayer_Send_GSFlagBit(index, bit, 0);
+                }
+            }
+        }
+        prevGSFlags[index] = gSaveContext.gsFlags[index];
+    }
+
+    // Fishing Flags
+    if (prevFishingFlags != gSaveContext.fishingStats.flags) {
+        for (size_t bit = 0; bit < BIT_COUNT(gSaveContext.fishingStats.flags); bit++) {
+            s8 result = BitCompare(gSaveContext.fishingStats.flags, prevFishingFlags, bit);
+            if (result > 0) {
+                Multiplayer_Send_FishingFlag(bit, 1);
+            } else if (result < 0) {
+                Multiplayer_Send_FishingFlag(bit, 0);
+            }
+        }
+    }
+    prevFishingFlags = gSaveContext.fishingStats.flags;
+
+    // World Map
+    if (prevWorldMapAreaData != gSaveContext.worldMapAreaData) {
+        for (size_t bit = 0; bit < BIT_COUNT(gSaveContext.worldMapAreaData); bit++) {
+            s8 result = BitCompare(gSaveContext.worldMapAreaData, prevWorldMapAreaData, bit);
+            if (result > 0) {
+                Multiplayer_Send_WorldMapBit(bit, 1);
+            } else if (result < 0) {
+                Multiplayer_Send_WorldMapBit(bit, 0);
+            }
+        }
+    }
+    prevWorldMapAreaData = gSaveContext.worldMapAreaData;
+
+    // Adult Trade
+    if (prevAdultTrade != gSaveContext.sceneFlags[0x60].unk) {
+        if (!SaveFile_TradeItemIsOwned(gSaveContext.items[SLOT_TRADE_ADULT])) {
+            SaveFile_SetOwnedTradeItemEquipped();
+        }
+    }
+    prevAdultTrade = gSaveContext.sceneFlags[0x60].unk;
+
+    // Biggoron Trades
+    if (prevBiggoronTrades != gExtSaveData.biggoronTrades) {
+        for (size_t bit = 0; bit < BIT_COUNT(gExtSaveData.biggoronTrades); bit++) {
+            if (BitCompare(gExtSaveData.biggoronTrades, prevBiggoronTrades, bit) > 0) {
+                Multiplayer_Send_BiggoronTradeBit(bit);
+            }
+        }
+    }
+}
+
+void Multiplayer_Sync_UpdatePrevActorFlags(void) {
+    // Prevents redundant packets from being sent when switching scenes
+    if (gGlobalContext != NULL) {
+        prevActorFlags = gGlobalContext->actorCtx.flags;
+    }
+}
+
+static bool IsHashSame(u32* hashPtr) {
+    for (size_t i = 0; i < ARRAY_SIZE(gSettingsContext.hashIndexes); i++) {
+        if (hashPtr[i] != gSettingsContext.hashIndexes[i]) {
+            return false;
+        }
+    }
+    return true;
+}
+
+// Ghost Data
+
+void Multiplayer_Send_GhostPing(void) {
+    if (!IsSendReceiveReady()) {
+        return;
+    }
+    memset(mBuffer, 0, mBufSize);
+    u8 memSpacer = 0;
+    mBuffer[memSpacer++] = PACKET_GHOSTPING; // 0: Identifier
+    Multiplayer_SendPacket(memSpacer, UDS_BROADCAST_NETWORKNODEID);
+}
+
+void Multiplayer_Receive_GhostPing(u16 senderID) {
+    Multiplayer_Ghosts_UpdateGhost(senderID, NULL);
+}
+
+void Multiplayer_Send_GhostData(void) {
+    if (!IsSendReceiveReady()) {
+        return;
+    }
+    memset(mBuffer, 0, mBufSize);
+    u8 memSpacer = 0;
+    mBuffer[memSpacer++] = PACKET_GHOSTDATA; // 0: Identifier
+
+    GhostData ghostData;
+    ghostData.currentScene = gGlobalContext->sceneNum;
+    ghostData.age = gSaveContext.linkAge;
+    ghostData.position = PLAYER->actor.world.pos;
+
+    memcpy(&mBuffer[memSpacer], &ghostData, sizeof(GhostData));
+    memSpacer += sizeof(GhostData) / 4;
+
+    Multiplayer_SendPacket(memSpacer, UDS_BROADCAST_NETWORKNODEID);
+}
+
+void Multiplayer_Receive_GhostData(u16 senderID) {
+    GhostData ghostData;
+    memcpy(&ghostData, &mBuffer[1], sizeof(GhostData));
+
+    Multiplayer_Ghosts_UpdateGhost(senderID, &ghostData);
+}
+
+void Multiplayer_Send_LinkSFX(u32 sfxID_) {
+    if (!IsSendReceiveReady()) {
+        return;
+    }
+    memset(mBuffer, 0, mBufSize);
+    u8 memSpacer = 0;
+    mBuffer[memSpacer++] = PACKET_LINKSFX; // 0: Identifier
+    mBuffer[memSpacer++] = sfxID_;
+    Multiplayer_SendPacket(memSpacer, UDS_BROADCAST_NETWORKNODEID);
+}
+
+void Multiplayer_Receive_LinkSFX(u16 senderID) {
+    GhostData* ghostDataPtr = Multiplayer_Ghosts_GetGhostData(senderID);
+    if (ghostDataPtr == NULL || ghostDataPtr->currentScene != gGlobalContext->sceneNum) {
+        return;
+    }
+
+    duplicateSendProtection = true;
+    PlaySFX(mBuffer[1], &ghostDataPtr->position, 4, (f32*)0x54AC20, (f32*)0x54AC20, (s8*)0x54AC24);
+}
+
+// Shared Progress
+
+void Multiplayer_Send_FullSyncRequest(void) {
+    if (!IsSendReceiveReady() || gSettingsContext.mp_SharedProgress == OFF) {
+        return;
+    }
+    memset(mBuffer, 0, mBufSize);
+    u8 memSpacer = 0;
+    mBuffer[memSpacer++] = PACKET_FULLSYNCREQUEST; // 0: Identifier
+    for (size_t i = 0; i < ARRAY_SIZE(gSettingsContext.hashIndexes); i++) {
+        mBuffer[memSpacer++] = gSettingsContext.hashIndexes[i];
+    }
+    // Anyone who has the same hash will send a full sync, which will result in duplicate packets. Optimize?
+    Multiplayer_SendPacket(memSpacer, UDS_BROADCAST_NETWORKNODEID);
+}
+
+void Multiplayer_Receive_FullSyncRequest(u16 senderID) {
+    if (!IsHashSame(&mBuffer[1]) || gSettingsContext.mp_SharedProgress == OFF) {
+        return;
+    }
+
+    Multiplayer_Send_BaseSync(senderID);
+    Multiplayer_Send_FullSceneFlagSync(senderID, 0);
+    Multiplayer_Send_FullSceneFlagSync(senderID, 1);
+    Multiplayer_Send_FullSceneFlagSync(senderID, 2);
+    Multiplayer_Send_FullSceneFlagSync(senderID, 3);
+    Multiplayer_Send_FullEntranceSync(senderID, 0);
+    Multiplayer_Send_FullEntranceSync(senderID, 1);
+}
+
+void Multiplayer_Send_BaseSync(u16 targetID) {
+    if (!IsSendReceiveReady() || gSettingsContext.mp_SharedProgress == OFF) {
+        return;
+    }
+    memset(mBuffer, 0, mBufSize);
+    u8 memSpacer = 0;
+    mBuffer[memSpacer++] = PACKET_BASESYNC; // 0: Identifier
+    for (size_t i = 0; i < ARRAY_SIZE(gSettingsContext.hashIndexes); i++) {
+        mBuffer[memSpacer++] = gSettingsContext.hashIndexes[i];
+    }
+    mBuffer[memSpacer++] = mSaveContext.healthCapacity;
+    mBuffer[memSpacer++] = mSaveContext.doubleDefense;
+    mBuffer[memSpacer++] = mSaveContext.magicLevel;
+    mBuffer[memSpacer++] = mSaveContext.bgsHitsLeft;
+    mBuffer[memSpacer++] = mSaveContext.magicAcquired;
+    mBuffer[memSpacer++] = mSaveContext.doubleMagic;
+    mBuffer[memSpacer++] = mSaveContext.magicMeterSize;
+    mBuffer[memSpacer++] = mSaveContext.doubleDefense;
+    mBuffer[memSpacer++] = mSaveContext.bgsFlag;
+    mBuffer[memSpacer++] = mSaveContext.childEquipsButtonB;
+    for (size_t i = 0; i < ARRAY_SIZE(mSaveContext.items); i++) {
+        mBuffer[memSpacer++] = mSaveContext.items[i];
+    }
+    for (size_t i = 0; i < ARRAY_SIZE(mSaveContext.ammo); i++) {
+        mBuffer[memSpacer++] = mSaveContext.ammo[i];
+    }
+    mBuffer[memSpacer++] = mSaveContext.magic_beans_available;
+    mBuffer[memSpacer++] = mSaveContext.equipment;
+    mBuffer[memSpacer++] = mSaveContext.upgrades;
+    mBuffer[memSpacer++] = mSaveContext.questItems;
+    for (size_t i = 0; i < ARRAY_SIZE(mSaveContext.dungeonItems); i++) {
+        mBuffer[memSpacer++] = mSaveContext.dungeonItems[i];
+    }
+    for (size_t i = 0; i < ARRAY_SIZE(mSaveContext.dungeonKeys); i++) {
+        mBuffer[memSpacer++] = mSaveContext.dungeonKeys[i];
+    }
+    mBuffer[memSpacer++] = mSaveContext.gsTokens;
+    for (size_t i = 0; i < ARRAY_SIZE(mSaveContext.gsFlags); i++) {
+        mBuffer[memSpacer++] = mSaveContext.gsFlags[i];
+    }
+    mBuffer[memSpacer++] = mSaveContext.fishingFlags;
+    for (size_t i = 0; i < ARRAY_SIZE(mSaveContext.eventChkInf); i++) {
+        mBuffer[memSpacer++] = mSaveContext.eventChkInf[i];
+    }
+    for (size_t i = 0; i < ARRAY_SIZE(mSaveContext.itemGetInf); i++) {
+        mBuffer[memSpacer++] = mSaveContext.itemGetInf[i];
+    }
+    for (size_t i = 0; i < ARRAY_SIZE(mSaveContext.infTable); i++) {
+        mBuffer[memSpacer++] = mSaveContext.infTable[i];
+    }
+    mBuffer[memSpacer++] = mSaveContext.worldMapAreaData;
+    mBuffer[memSpacer++] = mSaveContext.biggoronTrades;
+    mBuffer[memSpacer++] = mSaveContext.health;
+    mBuffer[memSpacer++] = mSaveContext.rupees;
+    Multiplayer_SendPacket(memSpacer, targetID);
+}
+
+void Multiplayer_Receive_BaseSync(u16 senderID) {
+    if (!IsHashSame(&mBuffer[1]) || gSettingsContext.mp_SharedProgress == OFF) {
+        return;
+    }
+    mSaveContextInit = true;
+    u8 memSpacer = 1 + ARRAY_SIZE(gSettingsContext.hashIndexes);
+
+    mSaveContext.healthCapacity = mBuffer[memSpacer++];
+    mSaveContext.doubleDefense = mBuffer[memSpacer++];
+    mSaveContext.magicLevel = mBuffer[memSpacer++];
+    mSaveContext.magic = 0x30 * mSaveContext.magicLevel;
+    mSaveContext.bgsHitsLeft = mBuffer[memSpacer++];
+    mSaveContext.magicAcquired = mBuffer[memSpacer++];
+    mSaveContext.doubleMagic = mBuffer[memSpacer++];
+    mSaveContext.magicMeterSize = mBuffer[memSpacer++];
+    mSaveContext.doubleDefense = mBuffer[memSpacer++];
+    mSaveContext.bgsFlag = mBuffer[memSpacer++];
+    mSaveContext.childEquipsButtonB = mBuffer[memSpacer++];
+    for (size_t i = 0; i < ARRAY_SIZE(mSaveContext.items); i++) {
+        mSaveContext.items[i] = mBuffer[memSpacer++];
+    }
+    for (size_t i = 0; i < ARRAY_SIZE(mSaveContext.ammo); i++) {
+        mSaveContext.ammo[i] = mBuffer[memSpacer++];
+    }
+    mSaveContext.magic_beans_available = mBuffer[memSpacer++];
+    mSaveContext.equipment = mBuffer[memSpacer++];
+    mSaveContext.upgrades = mBuffer[memSpacer++];
+    mSaveContext.questItems = mBuffer[memSpacer++];
+    for (size_t i = 0; i < ARRAY_SIZE(mSaveContext.dungeonItems); i++) {
+        mSaveContext.dungeonItems[i] = mBuffer[memSpacer++];
+    }
+    for (size_t i = 0; i < ARRAY_SIZE(mSaveContext.dungeonKeys); i++) {
+        mSaveContext.dungeonKeys[i] = mBuffer[memSpacer++];
+    }
+    mSaveContext.gsTokens = mBuffer[memSpacer++];
+    for (size_t i = 0; i < ARRAY_SIZE(mSaveContext.gsFlags); i++) {
+        mSaveContext.gsFlags[i] = mBuffer[memSpacer++];
+    }
+    mSaveContext.fishingFlags = mBuffer[memSpacer++];
+    for (size_t i = 0; i < ARRAY_SIZE(mSaveContext.eventChkInf); i++) {
+        mSaveContext.eventChkInf[i] = mBuffer[memSpacer++];
+    }
+    for (size_t i = 0; i < ARRAY_SIZE(mSaveContext.itemGetInf); i++) {
+        mSaveContext.itemGetInf[i] = mBuffer[memSpacer++];
+    }
+    for (size_t i = 0; i < ARRAY_SIZE(mSaveContext.infTable); i++) {
+        mSaveContext.infTable[i] = mBuffer[memSpacer++];
+    }
+    mSaveContext.worldMapAreaData = mBuffer[memSpacer++];
+    mSaveContext.biggoronTrades = mBuffer[memSpacer++];
+    if (gSettingsContext.mp_SharedHealth) {
+        mSaveContext.health = mBuffer[memSpacer++];
+    } else {
+        mSaveContext.health = mSaveContext.healthCapacity;
+        memSpacer++;
+    }
+    if (gSettingsContext.mp_SharedRupees) {
+        mSaveContext.rupees = mBuffer[memSpacer++];
+    } else if (gSettingsContext.startingMaxRupees) {
+        static u16 maxRupees[] = { 99, 200, 500, 999 };
+        mSaveContext.rupees = maxRupees[mSaveContext.upgrades >> 12 & 0x3];
+        memSpacer++;
+    }
+}
+
+void Multiplayer_Send_FullSceneFlagSync(u16 targetID, u8 part) {
+    if (!IsSendReceiveReady() || gSettingsContext.mp_SharedProgress == OFF) {
+        return;
+    }
+    memset(mBuffer, 0, mBufSize);
+    u8 memSpacer = 0;
+    mBuffer[memSpacer++] = PACKET_FULLSCENEFLAGSYNC; // 0: Identifier
+    for (size_t i = 0; i < ARRAY_SIZE(gSettingsContext.hashIndexes); i++) {
+        mBuffer[memSpacer++] = gSettingsContext.hashIndexes[i];
+    }
+    mBuffer[memSpacer++] = part;
+    u8 start = 31 * part;
+    u8 end = start + 31;
+    for (size_t i = start; i < end; i++) {
+        mBuffer[memSpacer++] = mSaveContext.sceneFlags[i].chest;
+        mBuffer[memSpacer++] = mSaveContext.sceneFlags[i].swch;
+        mBuffer[memSpacer++] = mSaveContext.sceneFlags[i].clear;
+        mBuffer[memSpacer++] = mSaveContext.sceneFlags[i].collect;
+        mBuffer[memSpacer++] = mSaveContext.sceneFlags[i].unk;
+        mBuffer[memSpacer++] = mSaveContext.sceneFlags[i].rooms1;
+        mBuffer[memSpacer++] = mSaveContext.sceneFlags[i].rooms2;
+    }
+    Multiplayer_SendPacket(memSpacer, targetID);
+}
+
+void Multiplayer_Receive_FullSceneFlagSync(u16 senderID) {
+    if (!IsHashSame(&mBuffer[1]) || gSettingsContext.mp_SharedProgress == OFF) {
+        return;
+    }
+    u8 memSpacer = 1 + ARRAY_SIZE(gSettingsContext.hashIndexes);
+
+    u8 part = mBuffer[memSpacer++];
+    u8 start = 31 * part;
+    u8 end = start + 31;
+    for (size_t i = start; i < end; i++) {
+        mSaveContext.sceneFlags[i].chest = mBuffer[memSpacer++];
+        mSaveContext.sceneFlags[i].swch = mBuffer[memSpacer++];
+        mSaveContext.sceneFlags[i].clear = mBuffer[memSpacer++];
+        mSaveContext.sceneFlags[i].collect = mBuffer[memSpacer++];
+        mSaveContext.sceneFlags[i].unk = mBuffer[memSpacer++];
+        mSaveContext.sceneFlags[i].rooms1 = mBuffer[memSpacer++];
+        mSaveContext.sceneFlags[i].rooms2 = mBuffer[memSpacer++];
+    }
+}
+
+void Multiplayer_Send_FullEntranceSync(u16 targetID, u8 latterHalf) {
+    if (!IsSendReceiveReady() || gSettingsContext.mp_SharedProgress == OFF) {
+        return;
+    }
+    memset(mBuffer, 0, mBufSize);
+    u8 memSpacer = 0;
+    mBuffer[memSpacer++] = PACKET_FULLENTRANCESYNC; // 0: Identifier
+    for (size_t i = 0; i < ARRAY_SIZE(gSettingsContext.hashIndexes); i++) {
+        mBuffer[memSpacer++] = gSettingsContext.hashIndexes[i];
+    }
+    mBuffer[memSpacer++] = latterHalf;
+    if (!latterHalf) {
+        for (size_t i = 0; i < ARRAY_SIZE(mSaveContext.scenesDiscovered); i++) {
+            mBuffer[memSpacer++] = mSaveContext.scenesDiscovered[i];
+        }
+        for (size_t i = 0; i < ARRAY_SIZE(mSaveContext.entrancesDiscovered) / 2; i++) {
+            mBuffer[memSpacer++] = mSaveContext.entrancesDiscovered[i];
+        }
+    } else {
+        for (size_t i = ARRAY_SIZE(mSaveContext.entrancesDiscovered) / 2; i < ARRAY_SIZE(mSaveContext.entrancesDiscovered); i++) {
+            mBuffer[memSpacer++] = mSaveContext.entrancesDiscovered[i];
+        }
+    }
+    Multiplayer_SendPacket(memSpacer, targetID);
+}
+
+void Multiplayer_Receive_FullEntranceSync(u16 senderID) {
+    if (!IsHashSame(&mBuffer[1]) || gSettingsContext.mp_SharedProgress == OFF) {
+        return;
+    }
+    u8 memSpacer = 1 + ARRAY_SIZE(gSettingsContext.hashIndexes);
+
+    u8 latterHalf = mBuffer[memSpacer++];
+
+    if (!latterHalf) {
+        for (size_t i = 0; i < ARRAY_SIZE(mSaveContext.scenesDiscovered); i++) {
+            mSaveContext.scenesDiscovered[i] = mBuffer[memSpacer++];
+        }
+        for (size_t i = 0; i < ARRAY_SIZE(mSaveContext.entrancesDiscovered) / 2; i++) {
+            mSaveContext.entrancesDiscovered[i] = mBuffer[memSpacer++];
+        }
+    } else {
+        for (size_t i = ARRAY_SIZE(mSaveContext.entrancesDiscovered) / 2; i < ARRAY_SIZE(mSaveContext.entrancesDiscovered); i++) {
+            mSaveContext.entrancesDiscovered[i] = mBuffer[memSpacer++];
+        }
+    }
+}
+
+void Multiplayer_Send_Item(u8 slot, ItemID item) {
+    if (!IsSendReceiveReady() || gSettingsContext.mp_SharedProgress == OFF) {
+        return;
+    }
+    memset(mBuffer, 0, mBufSize);
+    u8 memSpacer = 0;
+    mBuffer[memSpacer++] = PACKET_ITEM; // 0: Identifier
+    for (size_t i = 0; i < ARRAY_SIZE(gSettingsContext.hashIndexes); i++) {
+        mBuffer[memSpacer++] = gSettingsContext.hashIndexes[i];
+    }
+    mBuffer[memSpacer++] = slot;
+    mBuffer[memSpacer++] = item;
+    Multiplayer_SendPacket(memSpacer, UDS_BROADCAST_NETWORKNODEID);
+}
+
+void Multiplayer_Receive_Item(u16 senderID) {
+    if (!IsHashSame(&mBuffer[1]) || gSettingsContext.mp_SharedProgress == OFF) {
+        return;
+    }
+    u8 memSpacer = 1 + ARRAY_SIZE(gSettingsContext.hashIndexes);
+
+    u8 slot = mBuffer[memSpacer++];
+    ItemID item = mBuffer[memSpacer++];
+
+    // Ignore arrow type changes
+    if (slot == SLOT_BOW && mSaveContext.items[slot] != ITEM_NONE) {
+        return;
+    }
+
+    // Skip bottle content syncing except for removing Big Poes and Rutos Letter
+    if (slot >= SLOT_BOTTLE_1 && slot <= SLOT_BOTTLE_4 && mSaveContext.items[slot] != ITEM_NONE &&
+        !(item == ITEM_BOTTLE && (mSaveContext.items[slot] == ITEM_BIG_POE || mSaveContext.items[slot] == ITEM_LETTER_RUTO))) {
+        return;
+    }
+    // Skip post-letter child trade syncing, aka masks/sold out
+    if (slot == SLOT_TRADE_CHILD && item != ITEM_NONE && item != ITEM_WEIRD_EGG && item != ITEM_CHICKEN && item != ITEM_LETTER_ZELDA) {
+        return;
+    }
+    // Adult trade slot/item syncing is handled in Multiplayer_Sync_SharedProgress
+    if (slot == SLOT_TRADE_ADULT) {
+        return;
+    }
+
+    mSaveContext.items[slot] = item;
+    prevItems[slot] = item;
+}
+
+void Multiplayer_Send_MaxHealth(void) {
+    if (!IsSendReceiveReady() || gSettingsContext.mp_SharedProgress == OFF) {
+        return;
+    }
+    memset(mBuffer, 0, mBufSize);
+    u8 memSpacer = 0;
+    mBuffer[memSpacer++] = PACKET_MAXHEALTH; // 0: Identifier
+    for (size_t i = 0; i < ARRAY_SIZE(gSettingsContext.hashIndexes); i++) {
+        mBuffer[memSpacer++] = gSettingsContext.hashIndexes[i];
+    }
+    mBuffer[memSpacer++] = gSaveContext.healthCapacity;
+    Multiplayer_SendPacket(memSpacer, UDS_BROADCAST_NETWORKNODEID);
+}
+
+void Multiplayer_Receive_MaxHealth(u16 senderID) {
+    if (!IsHashSame(&mBuffer[1]) || gSettingsContext.mp_SharedProgress == OFF) {
+        return;
+    }
+    u8 memSpacer = 1 + ARRAY_SIZE(gSettingsContext.hashIndexes);
+
+    u16 newMaxHealth = mBuffer[memSpacer++];
+
+    mSaveContext.healthCapacity = newMaxHealth;
+    prevHealthCapacity = newMaxHealth;
+}
+
+void Multiplayer_Send_KokiriSwordEquip(void) {
+    if (!IsSendReceiveReady() || gSettingsContext.mp_SharedProgress == OFF) {
+        return;
+    }
+    memset(mBuffer, 0, mBufSize);
+    u8 memSpacer = 0;
+    mBuffer[memSpacer++] = PACKET_KOKIRISWORDEQUIP; // 0: Identifier
+    for (size_t i = 0; i < ARRAY_SIZE(gSettingsContext.hashIndexes); i++) {
+        mBuffer[memSpacer++] = gSettingsContext.hashIndexes[i];
+    }
+    Multiplayer_SendPacket(memSpacer, UDS_BROADCAST_NETWORKNODEID);
+}
+
+void Multiplayer_Receive_KokiriSwordEquip(u16 senderID) {
+    if (!IsHashSame(&mBuffer[1]) || gSettingsContext.mp_SharedProgress == OFF) {
+        return;
+    }
+
+    mSaveContext.childEquipsButtonB = ITEM_SWORD_KOKIRI;
+}
+
+void Multiplayer_Send_BGSFlag(void) {
+    if (!IsSendReceiveReady() || gSettingsContext.mp_SharedProgress == OFF) {
+        return;
+    }
+    memset(mBuffer, 0, mBufSize);
+    u8 memSpacer = 0;
+    mBuffer[memSpacer++] = PACKET_BGSFLAG; // 0: Identifier
+    for (size_t i = 0; i < ARRAY_SIZE(gSettingsContext.hashIndexes); i++) {
+        mBuffer[memSpacer++] = gSettingsContext.hashIndexes[i];
+    }
+    Multiplayer_SendPacket(memSpacer, UDS_BROADCAST_NETWORKNODEID);
+}
+
+void Multiplayer_Receive_BGSFlag(u16 senderID) {
+    if (!IsHashSame(&mBuffer[1]) || gSettingsContext.mp_SharedProgress == OFF) {
+        return;
+    }
+
+    mSaveContext.bgsFlag = 1;
+    mSaveContext.bgsHitsLeft = GK_SetDurability();
+}
+
+void Multiplayer_Send_MagicArrow(u8 type) {
+    if (!IsSendReceiveReady() || gSettingsContext.mp_SharedProgress == OFF) {
+        return;
+    }
+    memset(mBuffer, 0, mBufSize);
+    u8 memSpacer = 0;
+    mBuffer[memSpacer++] = PACKET_MAGICARROW; // 0: Identifier
+    for (size_t i = 0; i < ARRAY_SIZE(gSettingsContext.hashIndexes); i++) {
+        mBuffer[memSpacer++] = gSettingsContext.hashIndexes[i];
+    }
+    mBuffer[memSpacer++] = type;
+    Multiplayer_SendPacket(memSpacer, UDS_BROADCAST_NETWORKNODEID);
+}
+
+void Multiplayer_Receive_MagicArrow(u16 senderID) {
+    if (!IsHashSame(&mBuffer[1]) || gSettingsContext.mp_SharedProgress == OFF || !IsInGame()) {
+        return;
+    }
+    u8 memSpacer = 1 + ARRAY_SIZE(gSettingsContext.hashIndexes);
+
+    u8 type = mBuffer[memSpacer++];
+
+    duplicateSendProtection = true;
+    ItemEffect_PlaceMagicArrowsInInventory(&gSaveContext, type, -1);
+}
+
+void Multiplayer_Send_GreatFairyBuff(u8 type) {
+    if (!IsSendReceiveReady() || gSettingsContext.mp_SharedProgress == OFF) {
+        return;
+    }
+    memset(mBuffer, 0, mBufSize);
+    u8 memSpacer = 0;
+    mBuffer[memSpacer++] = PACKET_GREATFAIRYBUFF; // 0: Identifier
+    for (size_t i = 0; i < ARRAY_SIZE(gSettingsContext.hashIndexes); i++) {
+        mBuffer[memSpacer++] = gSettingsContext.hashIndexes[i];
+    }
+    mBuffer[memSpacer++] = type;
+    Multiplayer_SendPacket(memSpacer, UDS_BROADCAST_NETWORKNODEID);
+}
+
+void Multiplayer_Receive_GreatFairyBuff(u16 senderID) {
+    if (!IsHashSame(&mBuffer[1]) || gSettingsContext.mp_SharedProgress == OFF) {
+        return;
+    }
+    u8 memSpacer = 1 + ARRAY_SIZE(gSettingsContext.hashIndexes);
+
+    u8 type = mBuffer[memSpacer++];
+
+    switch (type) {
+        case 0:
+            mSaveContext.doubleDefense = 1;
+            break;
+        case 1:
+            mSaveContext.magicLevel = 1;
+            mSaveContext.magicAcquired = 1;
+            mSaveContext.magicMeterSize = 0x30;
+            mSaveContext.magic = 0x30;
+            break;
+        case 2:
+            mSaveContext.magicLevel = 2;
+            mSaveContext.magicAcquired = 1;
+            mSaveContext.doubleMagic = 1;
+            mSaveContext.magicMeterSize = 0x60;
+            mSaveContext.magic = 0x60;
+            break;
+    }
+}
+
+void Multiplayer_Send_MagicBeanDiff(s8 diff) {
+    if (!IsSendReceiveReady() || gSettingsContext.mp_SharedProgress == OFF) {
+        return;
+    }
+    memset(mBuffer, 0, mBufSize);
+    u8 memSpacer = 0;
+    mBuffer[memSpacer++] = PACKET_MAGICBEANDIFF; // 0: Identifier
+    for (size_t i = 0; i < ARRAY_SIZE(gSettingsContext.hashIndexes); i++) {
+        mBuffer[memSpacer++] = gSettingsContext.hashIndexes[i];
+    }
+    mBuffer[memSpacer++] = diff;
+    Multiplayer_SendPacket(memSpacer, UDS_BROADCAST_NETWORKNODEID);
+}
+
+void Multiplayer_Receive_MagicBeanDiff(u16 senderID) {
+    if (!IsHashSame(&mBuffer[1]) || gSettingsContext.mp_SharedProgress == OFF) {
+        return;
+    }
+    u8 memSpacer = 1 + ARRAY_SIZE(gSettingsContext.hashIndexes);
+
+    u8 beanDiff = mBuffer[memSpacer++];
+
+    mSaveContext.ammo[SLOT_BEAN] += beanDiff;
+    prevAmmo[SLOT_BEAN] += beanDiff;
+}
+
+void Multiplayer_Send_MagicBeansBoughtUpdate(void) {
+    if (!IsSendReceiveReady() || gSettingsContext.mp_SharedProgress == OFF) {
+        return;
+    }
+    memset(mBuffer, 0, mBufSize);
+    u8 memSpacer = 0;
+    mBuffer[memSpacer++] = PACKET_MAGICBEANSBOUGHT; // 0: Identifier
+    for (size_t i = 0; i < ARRAY_SIZE(gSettingsContext.hashIndexes); i++) {
+        mBuffer[memSpacer++] = gSettingsContext.hashIndexes[i];
+    }
+    mBuffer[memSpacer++] = gSaveContext.magic_beans_available;
+    Multiplayer_SendPacket(memSpacer, UDS_BROADCAST_NETWORKNODEID);
+}
+
+void Multiplayer_Receive_MagicBeansBoughtUpdate(u16 senderID) {
+    if (!IsHashSame(&mBuffer[1]) || gSettingsContext.mp_SharedProgress == OFF) {
+        return;
+    }
+    u8 memSpacer = 1 + ARRAY_SIZE(gSettingsContext.hashIndexes);
+
+    u8 magic_beans_available = mBuffer[memSpacer++];
+
+    mSaveContext.magic_beans_available = magic_beans_available;
+    prevMagicBeansBought = magic_beans_available;
+}
+
+void Multiplayer_Send_EquipmentBit(u8 bit, u8 setOrUnset) {
+    if (!IsSendReceiveReady() || gSettingsContext.mp_SharedProgress == OFF) {
+        return;
+    }
+    memset(mBuffer, 0, mBufSize);
+    u8 memSpacer = 0;
+    mBuffer[memSpacer++] = PACKET_EQUIPMENT; // 0: Identifier
+    for (size_t i = 0; i < ARRAY_SIZE(gSettingsContext.hashIndexes); i++) {
+        mBuffer[memSpacer++] = gSettingsContext.hashIndexes[i];
+    }
+    mBuffer[memSpacer++] = bit;
+    mBuffer[memSpacer++] = setOrUnset;
+    Multiplayer_SendPacket(memSpacer, UDS_BROADCAST_NETWORKNODEID);
+}
+
+void Multiplayer_Receive_EquipmentBit(u16 senderID) {
+    if (!IsHashSame(&mBuffer[1]) || gSettingsContext.mp_SharedProgress == OFF) {
+        return;
+    }
+    u8 memSpacer = 1 + ARRAY_SIZE(gSettingsContext.hashIndexes);
+
+    u8 bit = mBuffer[memSpacer++];
+    u8 setOrUnset = mBuffer[memSpacer++];
+
+    // Giant's Knife / Biggoron Sword
+    if (setOrUnset && bit == 2) {
+        mSaveContext.bgsHitsLeft = GK_SetDurability();
+    }
+
+    // Don't remove losable shields or tunics
+    if (!setOrUnset && (bit == 4 || bit == 5 || bit == 9 || bit == 10)) {
+        return;
+    }
+
+    if (setOrUnset) {
+        mSaveContext.equipment |= (1 << bit);
+        prevEquipment |= (1 << bit);
+    } else {
+        mSaveContext.equipment &= ~(1 << bit);
+        prevEquipment &= ~(1 << bit);
+    }
+}
+
+void Multiplayer_Send_UpgradesBit(u8 bit, u8 setOrUnset) {
+    if (!IsSendReceiveReady() || gSettingsContext.mp_SharedProgress == OFF) {
+        return;
+    }
+    memset(mBuffer, 0, mBufSize);
+    u8 memSpacer = 0;
+    mBuffer[memSpacer++] = PACKET_UPGRADES; // 0: Identifier
+    for (size_t i = 0; i < ARRAY_SIZE(gSettingsContext.hashIndexes); i++) {
+        mBuffer[memSpacer++] = gSettingsContext.hashIndexes[i];
+    }
+    mBuffer[memSpacer++] = bit;
+    mBuffer[memSpacer++] = setOrUnset;
+    Multiplayer_SendPacket(memSpacer, UDS_BROADCAST_NETWORKNODEID);
+}
+
+void Multiplayer_Receive_UpgradesBit(u16 senderID) {
+    if (!IsHashSame(&mBuffer[1]) || gSettingsContext.mp_SharedProgress == OFF) {
+        return;
+    }
+    u8 memSpacer = 1 + ARRAY_SIZE(gSettingsContext.hashIndexes);
+
+    u8 bit = mBuffer[memSpacer++];
+    u8 setOrUnset = mBuffer[memSpacer++];
+
+    if (setOrUnset) {
+        mSaveContext.upgrades |= (1 << bit);
+        prevUpgrades |= (1 << bit);
+    } else {
+        mSaveContext.upgrades &= ~(1 << bit);
+        prevUpgrades &= ~(1 << bit);
+    }
+}
+
+void Multiplayer_Send_QuestItemBit(u8 bit, u8 setOrUnset) {
+    if (!IsSendReceiveReady() || gSettingsContext.mp_SharedProgress == OFF) {
+        return;
+    }
+    memset(mBuffer, 0, mBufSize);
+    u8 memSpacer = 0;
+    mBuffer[memSpacer++] = PACKET_QUESTITEM; // 0: Identifier
+    for (size_t i = 0; i < ARRAY_SIZE(gSettingsContext.hashIndexes); i++) {
+        mBuffer[memSpacer++] = gSettingsContext.hashIndexes[i];
+    }
+    mBuffer[memSpacer++] = bit;
+    mBuffer[memSpacer++] = setOrUnset;
+    Multiplayer_SendPacket(memSpacer, UDS_BROADCAST_NETWORKNODEID);
+}
+
+void Multiplayer_Receive_QuestItemBit(u16 senderID) {
+    if (!IsHashSame(&mBuffer[1]) || gSettingsContext.mp_SharedProgress == OFF) {
+        return;
+    }
+    u8 memSpacer = 1 + ARRAY_SIZE(gSettingsContext.hashIndexes);
+
+    u8 bit = mBuffer[memSpacer++];
+    u8 setOrUnset = mBuffer[memSpacer++];
+
+    if (setOrUnset) {
+        mSaveContext.questItems |= (1 << bit);
+        prevUpgrades |= (1 << bit);
+    } else {
+        mSaveContext.questItems &= ~(1 << bit);
+        prevUpgrades &= ~(1 << bit);
+    }
+}
+
+void Multiplayer_Send_DungeonItemBit(u8 index, u8 bit, u8 setOrUnset) {
+    if (!IsSendReceiveReady() || gSettingsContext.mp_SharedProgress == OFF) {
+        return;
+    }
+    memset(mBuffer, 0, mBufSize);
+    u8 memSpacer = 0;
+    mBuffer[memSpacer++] = PACKET_DUNGEONITEM; // 0: Identifier
+    for (size_t i = 0; i < ARRAY_SIZE(gSettingsContext.hashIndexes); i++) {
+        mBuffer[memSpacer++] = gSettingsContext.hashIndexes[i];
+    }
+    mBuffer[memSpacer++] = index;
+    mBuffer[memSpacer++] = bit;
+    mBuffer[memSpacer++] = setOrUnset;
+    Multiplayer_SendPacket(memSpacer, UDS_BROADCAST_NETWORKNODEID);
+}
+
+void Multiplayer_Receive_DungeonItemBit(u16 senderID) {
+    if (!IsHashSame(&mBuffer[1]) || gSettingsContext.mp_SharedProgress == OFF) {
+        return;
+    }
+    u8 memSpacer = 1 + ARRAY_SIZE(gSettingsContext.hashIndexes);
+
+    u8 index = mBuffer[memSpacer++];
+    u8 bit = mBuffer[memSpacer++];
+    u8 setOrUnset = mBuffer[memSpacer++];
+
+    if (setOrUnset) {
+        mSaveContext.dungeonItems[index] |= (1 << bit);
+        prevDungeonItems[index] |= (1 << bit);
+    } else {
+        mSaveContext.dungeonItems[index] &= ~(1 << bit);
+        prevDungeonItems[index] &= ~(1 << bit);
+    }
+}
+
+void Multiplayer_Send_DungeonKeyUpdate(u8 index, s8 diff) {
+    if (!IsSendReceiveReady() || gSettingsContext.mp_SharedProgress == OFF) {
+        return;
+    }
+    memset(mBuffer, 0, mBufSize);
+    u8 memSpacer = 0;
+    mBuffer[memSpacer++] = PACKET_DUNGEONKEY; // 0: Identifier
+    for (size_t i = 0; i < ARRAY_SIZE(gSettingsContext.hashIndexes); i++) {
+        mBuffer[memSpacer++] = gSettingsContext.hashIndexes[i];
+    }
+    mBuffer[memSpacer++] = index;
+    mBuffer[memSpacer++] = diff;
+    Multiplayer_SendPacket(memSpacer, UDS_BROADCAST_NETWORKNODEID);
+}
+
+void Multiplayer_Receive_DungeonKeyUpdate(u16 senderID) {
+    if (!IsHashSame(&mBuffer[1]) || gSettingsContext.mp_SharedProgress == OFF) {
+        return;
+    }
+    u8 memSpacer = 1 + ARRAY_SIZE(gSettingsContext.hashIndexes);
+
+    u8 index = mBuffer[memSpacer++];
+    s8 diff = mBuffer[memSpacer++];
+
+    mSaveContext.dungeonKeys[index] += diff;
+    prevDungeonKeys[index] += diff;
+}
+
+void Multiplayer_Send_GSTokenDiff(s16 diff) {
+    if (!IsSendReceiveReady() || gSettingsContext.mp_SharedProgress == OFF) {
+        return;
+    }
+    memset(mBuffer, 0, mBufSize);
+    u8 memSpacer = 0;
+    mBuffer[memSpacer++] = PACKET_GSTOKENDIFF; // 0: Identifier
+    for (size_t i = 0; i < ARRAY_SIZE(gSettingsContext.hashIndexes); i++) {
+        mBuffer[memSpacer++] = gSettingsContext.hashIndexes[i];
+    }
+    mBuffer[memSpacer++] = diff;
+    Multiplayer_SendPacket(memSpacer, UDS_BROADCAST_NETWORKNODEID);
+}
+
+void Multiplayer_Receive_GSTokenDiff(u16 senderID) {
+    if (!IsHashSame(&mBuffer[1]) || gSettingsContext.mp_SharedProgress == OFF) {
+        return;
+    }
+    u8 memSpacer = 1 + ARRAY_SIZE(gSettingsContext.hashIndexes);
+
+    s16 diff = mBuffer[memSpacer++];
+
+    mSaveContext.gsTokens += diff;
+    prevGSTokens += diff;
+}
+
+void Multiplayer_Send_EventChkInfBit(u8 index, u8 bit, u8 setOrUnset) {
+    if (!IsSendReceiveReady() || gSettingsContext.mp_SharedProgress == OFF) {
+        return;
+    }
+    memset(mBuffer, 0, mBufSize);
+    u8 memSpacer = 0;
+    mBuffer[memSpacer++] = PACKET_EVENTCHKINF; // 0: Identifier
+    for (size_t i = 0; i < ARRAY_SIZE(gSettingsContext.hashIndexes); i++) {
+        mBuffer[memSpacer++] = gSettingsContext.hashIndexes[i];
+    }
+    mBuffer[memSpacer++] = index;
+    mBuffer[memSpacer++] = bit;
+    mBuffer[memSpacer++] = setOrUnset;
+    Multiplayer_SendPacket(memSpacer, UDS_BROADCAST_NETWORKNODEID);
+}
+
+void Multiplayer_Receive_EventChkInfBit(u16 senderID) {
+    if (!IsHashSame(&mBuffer[1]) || gSettingsContext.mp_SharedProgress == OFF) {
+        return;
+    }
+    u8 memSpacer = 1 + ARRAY_SIZE(gSettingsContext.hashIndexes);
+
+    u8 index = mBuffer[memSpacer++];
+    u8 bit = mBuffer[memSpacer++];
+    u8 setOrUnset = mBuffer[memSpacer++];
+
+    // Ignore Lake Hylia water switch
+    if (index == 6 && bit == 9) {
+        return;
+    }
+
+    if (setOrUnset) {
+        mSaveContext.eventChkInf[index] |= (1 << bit);
+        prevEventChkInf[index] |= (1 << bit);
+    } else {
+        mSaveContext.eventChkInf[index] &= ~(1 << bit);
+        prevEventChkInf[index] &= ~(1 << bit);
+    }
+}
+
+void Multiplayer_Send_ItemGetInfBit(u8 index, u8 bit, u8 setOrUnset) {
+    if (!IsSendReceiveReady() || gSettingsContext.mp_SharedProgress == OFF) {
+        return;
+    }
+    memset(mBuffer, 0, mBufSize);
+    u8 memSpacer = 0;
+    mBuffer[memSpacer++] = PACKET_ITEMGETINF; // 0: Identifier
+    for (size_t i = 0; i < ARRAY_SIZE(gSettingsContext.hashIndexes); i++) {
+        mBuffer[memSpacer++] = gSettingsContext.hashIndexes[i];
+    }
+    mBuffer[memSpacer++] = index;
+    mBuffer[memSpacer++] = bit;
+    mBuffer[memSpacer++] = setOrUnset;
+    Multiplayer_SendPacket(memSpacer, UDS_BROADCAST_NETWORKNODEID);
+}
+
+void Multiplayer_Receive_ItemGetInfBit(u16 senderID) {
+    if (!IsHashSame(&mBuffer[1]) || gSettingsContext.mp_SharedProgress == OFF) {
+        return;
+    }
+    u8 memSpacer = 1 + ARRAY_SIZE(gSettingsContext.hashIndexes);
+
+    u8 index = mBuffer[memSpacer++];
+    u8 bit = mBuffer[memSpacer++];
+    u8 setOrUnset = mBuffer[memSpacer++];
+
+    if (setOrUnset) {
+        mSaveContext.itemGetInf[index] |= (1 << bit);
+        prevItemGetInf[index] |= (1 << bit);
+    } else {
+        mSaveContext.itemGetInf[index] &= ~(1 << bit);
+        prevItemGetInf[index] &= ~(1 << bit);
+    }
+}
+
+void Multiplayer_Send_InfTableBit(u8 index, u8 bit, u8 setOrUnset) {
+    if (!IsSendReceiveReady() || gSettingsContext.mp_SharedProgress == OFF) {
+        return;
+    }
+    memset(mBuffer, 0, mBufSize);
+    u8 memSpacer = 0;
+    mBuffer[memSpacer++] = PACKET_INFTABLE; // 0: Identifier
+    for (size_t i = 0; i < ARRAY_SIZE(gSettingsContext.hashIndexes); i++) {
+        mBuffer[memSpacer++] = gSettingsContext.hashIndexes[i];
+    }
+    mBuffer[memSpacer++] = index;
+    mBuffer[memSpacer++] = bit;
+    mBuffer[memSpacer++] = setOrUnset;
+    Multiplayer_SendPacket(memSpacer, UDS_BROADCAST_NETWORKNODEID);
+}
+
+void Multiplayer_Receive_InfTableBit(u16 senderID) {
+    if (!IsHashSame(&mBuffer[1]) || gSettingsContext.mp_SharedProgress == OFF) {
+        return;
+    }
+    u8 memSpacer = 1 + ARRAY_SIZE(gSettingsContext.hashIndexes);
+
+    u8 index = mBuffer[memSpacer++];
+    u8 bit = mBuffer[memSpacer++];
+    u8 setOrUnset = mBuffer[memSpacer++];
+
+    if (setOrUnset) {
+        mSaveContext.infTable[index] |= (1 << bit);
+        prevInfTable[index] |= (1 << bit);
+    } else {
+        mSaveContext.infTable[index] &= ~(1 << bit);
+        prevInfTable[index] &= ~(1 << bit);
+    }
+}
+
+void Multiplayer_Send_ActorFlagBit(u8 member, u8 bit, u8 setOrUnset) {
+    if (!IsSendReceiveReady() || gSettingsContext.mp_SharedProgress == OFF) {
+        return;
+    }
+    memset(mBuffer, 0, mBufSize);
+    u8 memSpacer = 0;
+    mBuffer[memSpacer++] = PACKET_ACTORFLAGS; // 0: Identifier
+    for (size_t i = 0; i < ARRAY_SIZE(gSettingsContext.hashIndexes); i++) {
+        mBuffer[memSpacer++] = gSettingsContext.hashIndexes[i];
+    }
+    mBuffer[memSpacer++] = gGlobalContext->sceneNum;
+    mBuffer[memSpacer++] = member;
+    mBuffer[memSpacer++] = bit;
+    mBuffer[memSpacer++] = setOrUnset;
+    Multiplayer_SendPacket(memSpacer, UDS_BROADCAST_NETWORKNODEID);
+}
+
+void Multiplayer_Receive_ActorFlagBit(u16 senderID) {
+    if (!IsHashSame(&mBuffer[1]) || gSettingsContext.mp_SharedProgress == OFF) {
+        return;
+    }
+    u8 memSpacer = 1 + ARRAY_SIZE(gSettingsContext.hashIndexes);
+
+    s16 scene = mBuffer[memSpacer++];
+    u8 member = mBuffer[memSpacer++];
+    u8 bit = mBuffer[memSpacer++];
+    u8 setOrUnset = mBuffer[memSpacer++];
+
+    switch (member) {
+        case 0: // swch
+            if (setOrUnset) {
+                mSaveContext.sceneFlags[scene].swch |= (1 << bit);
+                prevSaveSceneFlags[scene].swch |= (1 << bit);
+
+                if (gGlobalContext->sceneNum == scene) {
+                    gGlobalContext->actorCtx.flags.swch |= (1 << bit);
+                    prevActorFlags.swch |= (1 << bit);
+                }
+            } else {
+                mSaveContext.sceneFlags[scene].swch &= ~(1 << bit);
+                prevSaveSceneFlags[scene].swch &= ~(1 << bit);
+
+                if (gGlobalContext->sceneNum == scene) {
+                    gGlobalContext->actorCtx.flags.swch &= ~(1 << bit);
+                    prevActorFlags.swch &= ~(1 << bit);
+                }
+            }
+            break;
+        case 1: // chest
+            if (setOrUnset) {
+                mSaveContext.sceneFlags[scene].chest |= (1 << bit);
+                prevSaveSceneFlags[scene].chest |= (1 << bit);
+
+                if (gGlobalContext->sceneNum == scene) {
+                    gGlobalContext->actorCtx.flags.chest |= (1 << bit);
+                    prevActorFlags.chest |= (1 << bit);
+                }
+            } else {
+                mSaveContext.sceneFlags[scene].chest &= ~(1 << bit);
+                prevSaveSceneFlags[scene].chest &= ~(1 << bit);
+
+                if (gGlobalContext->sceneNum == scene) {
+                    gGlobalContext->actorCtx.flags.chest &= ~(1 << bit);
+                    prevActorFlags.chest &= ~(1 << bit);
+                }
+            }
+            break;
+        case 2: // clear
+            if (setOrUnset) {
+                mSaveContext.sceneFlags[scene].clear |= (1 << bit);
+                prevSaveSceneFlags[scene].clear |= (1 << bit);
+
+                if (gGlobalContext->sceneNum == scene) {
+                    gGlobalContext->actorCtx.flags.clear |= (1 << bit);
+                    prevActorFlags.clear |= (1 << bit);
+                }
+            } else {
+                mSaveContext.sceneFlags[scene].clear &= ~(1 << bit);
+                prevSaveSceneFlags[scene].clear &= ~(1 << bit);
+
+                if (gGlobalContext->sceneNum == scene) {
+                    gGlobalContext->actorCtx.flags.clear &= ~(1 << bit);
+                    prevActorFlags.clear &= ~(1 << bit);
+                }
+            }
+            break;
+        case 3: // collect
+            if (setOrUnset) {
+                mSaveContext.sceneFlags[scene].collect |= (1 << bit);
+                prevSaveSceneFlags[scene].collect |= (1 << bit);
+
+                if (gGlobalContext->sceneNum == scene) {
+                    gGlobalContext->actorCtx.flags.collect |= (1 << bit);
+                    prevActorFlags.collect |= (1 << bit);
+                }
+            } else {
+                mSaveContext.sceneFlags[scene].collect &= ~(1 << bit);
+                prevSaveSceneFlags[scene].collect &= ~(1 << bit);
+
+                if (gGlobalContext->sceneNum == scene) {
+                    gGlobalContext->actorCtx.flags.collect &= ~(1 << bit);
+                    prevActorFlags.collect &= ~(1 << bit);
+                }
+            }
+            break;
+    }
+}
+
+void Multiplayer_Send_SceneFlagBit(u8 scene, u8 member, u8 bit, u8 setOrUnset) {
+    if (!IsSendReceiveReady() || gSettingsContext.mp_SharedProgress == OFF) {
+        return;
+    }
+    memset(mBuffer, 0, mBufSize);
+    u8 memSpacer = 0;
+    mBuffer[memSpacer++] = PACKET_SAVESCENEFLAG; // 0: Identifier
+    for (size_t i = 0; i < ARRAY_SIZE(gSettingsContext.hashIndexes); i++) {
+        mBuffer[memSpacer++] = gSettingsContext.hashIndexes[i];
+    }
+    mBuffer[memSpacer++] = scene;
+    mBuffer[memSpacer++] = member;
+    mBuffer[memSpacer++] = bit;
+    mBuffer[memSpacer++] = setOrUnset;
+    Multiplayer_SendPacket(memSpacer, UDS_BROADCAST_NETWORKNODEID);
+}
+
+void Multiplayer_Receive_SceneFlagBit(u16 senderID) {
+    if (!IsHashSame(&mBuffer[1]) || gSettingsContext.mp_SharedProgress == OFF) {
+        return;
+    }
+    u8 memSpacer = 1 + ARRAY_SIZE(gSettingsContext.hashIndexes);
+
+    u8 scene = mBuffer[memSpacer++];
+    u8 member = mBuffer[memSpacer++];
+    u8 bit = mBuffer[memSpacer++];
+    u8 setOrUnset = mBuffer[memSpacer++];
+
+    switch (member) {
+        case 0:
+            if (setOrUnset) {
+                mSaveContext.sceneFlags[scene].unk |= (1 << bit);
+                prevSaveSceneFlags[scene].unk |= (1 << bit);
+            } else {
+                mSaveContext.sceneFlags[scene].unk &= ~(1 << bit);
+                prevSaveSceneFlags[scene].unk &= ~(1 << bit);
+            }
+            break;
+        case 1:
+            if (setOrUnset) {
+                mSaveContext.sceneFlags[scene].rooms1 |= (1 << bit);
+                prevSaveSceneFlags[scene].rooms1 |= (1 << bit);
+            } else {
+                mSaveContext.sceneFlags[scene].rooms1 &= ~(1 << bit);
+                prevSaveSceneFlags[scene].rooms1 &= ~(1 << bit);
+            }
+            break;
+        case 2:
+            if (setOrUnset) {
+                mSaveContext.sceneFlags[scene].rooms2 |= (1 << bit);
+                prevSaveSceneFlags[scene].rooms2 |= (1 << bit);
+            } else {
+                mSaveContext.sceneFlags[scene].rooms2 &= ~(1 << bit);
+                prevSaveSceneFlags[scene].rooms2 &= ~(1 << bit);
+            }
+            break;
+    }
+}
+
+void Multiplayer_Send_GSFlagBit(u8 index, u8 bit, u8 setOrUnset) {
+    if (!IsSendReceiveReady() || gSettingsContext.mp_SharedProgress == OFF) {
+        return;
+    }
+    memset(mBuffer, 0, mBufSize);
+    u8 memSpacer = 0;
+    mBuffer[memSpacer++] = PACKET_GSFLAGS; // 0: Identifier
+    for (size_t i = 0; i < ARRAY_SIZE(gSettingsContext.hashIndexes); i++) {
+        mBuffer[memSpacer++] = gSettingsContext.hashIndexes[i];
+    }
+    mBuffer[memSpacer++] = index;
+    mBuffer[memSpacer++] = bit;
+    mBuffer[memSpacer++] = setOrUnset;
+    Multiplayer_SendPacket(memSpacer, UDS_BROADCAST_NETWORKNODEID);
+}
+
+void Multiplayer_Receive_GSFlagBit(u16 senderID) {
+    if (!IsHashSame(&mBuffer[1]) || gSettingsContext.mp_SharedProgress == OFF) {
+        return;
+    }
+    u8 memSpacer = 1 + ARRAY_SIZE(gSettingsContext.hashIndexes);
+
+    u8 index = mBuffer[memSpacer++];
+    u8 bit = mBuffer[memSpacer++];
+    u8 setOrUnset = mBuffer[memSpacer++];
+
+    if (setOrUnset) {
+        mSaveContext.gsFlags[index] |= (1 << bit);
+        prevGSFlags[index] |= (1 << bit);
+    } else {
+        mSaveContext.gsFlags[index] &= ~(1 << bit);
+        prevGSFlags[index] &= ~(1 << bit);
+    }
+}
+
+void Multiplayer_Send_FishingFlag(u8 bit, u8 setOrUnset) {
+    if (!IsSendReceiveReady() || gSettingsContext.mp_SharedProgress == OFF) {
+        return;
+    }
+    memset(mBuffer, 0, mBufSize);
+    u8 memSpacer = 0;
+    mBuffer[memSpacer++] = PACKET_FISHINGFLAG; // 0: Identifier
+    for (size_t i = 0; i < ARRAY_SIZE(gSettingsContext.hashIndexes); i++) {
+        mBuffer[memSpacer++] = gSettingsContext.hashIndexes[i];
+    }
+    mBuffer[memSpacer++] = bit;
+    mBuffer[memSpacer++] = setOrUnset;
+    Multiplayer_SendPacket(memSpacer, UDS_BROADCAST_NETWORKNODEID);
+}
+
+void Multiplayer_Receive_FishingFlag(u16 senderID) {
+    if (!IsHashSame(&mBuffer[1]) || gSettingsContext.mp_SharedProgress == OFF) {
+        return;
+    }
+    u8 memSpacer = 1 + ARRAY_SIZE(gSettingsContext.hashIndexes);
+
+    u8 bit = mBuffer[memSpacer++];
+    u8 setOrUnset = mBuffer[memSpacer++];
+
+    if (setOrUnset) {
+        mSaveContext.fishingFlags |= (1 << bit);
+        prevFishingFlags |= (1 << bit);
+    } else {
+        mSaveContext.fishingFlags &= ~(1 << bit);
+        prevFishingFlags &= ~(1 << bit);
+    }
+}
+
+void Multiplayer_Send_WorldMapBit(u8 bit, u8 setOrUnset) {
+    if (!IsSendReceiveReady() || gSettingsContext.mp_SharedProgress == OFF) {
+        return;
+    }
+    memset(mBuffer, 0, mBufSize);
+    u8 memSpacer = 0;
+    mBuffer[memSpacer++] = PACKET_WORLDMAPBIT; // 0: Identifier
+    for (size_t i = 0; i < ARRAY_SIZE(gSettingsContext.hashIndexes); i++) {
+        mBuffer[memSpacer++] = gSettingsContext.hashIndexes[i];
+    }
+    mBuffer[memSpacer++] = bit;
+    mBuffer[memSpacer++] = setOrUnset;
+    Multiplayer_SendPacket(memSpacer, UDS_BROADCAST_NETWORKNODEID);
+}
+
+void Multiplayer_Receive_WorldMapBit(u16 senderID) {
+    if (!IsHashSame(&mBuffer[1]) || gSettingsContext.mp_SharedProgress == OFF) {
+        return;
+    }
+    u8 memSpacer = 1 + ARRAY_SIZE(gSettingsContext.hashIndexes);
+
+    u8 bit = mBuffer[memSpacer++];
+    u8 setOrUnset = mBuffer[memSpacer++];
+
+    if (setOrUnset) {
+        mSaveContext.worldMapAreaData |= (1 << bit);
+        prevWorldMapAreaData |= (1 << bit);
+    } else {
+        mSaveContext.worldMapAreaData &= ~(1 << bit);
+        prevWorldMapAreaData &= ~(1 << bit);
+    }
+}
+
+void Multiplayer_Send_BiggoronTradeBit(u8 bit) {
+    if (!IsSendReceiveReady() || gSettingsContext.mp_SharedProgress == OFF) {
+        return;
+    }
+    memset(mBuffer, 0, mBufSize);
+    u8 memSpacer = 0;
+    mBuffer[memSpacer++] = PACKET_BIGGORONTRADE; // 0: Identifier
+    for (size_t i = 0; i < ARRAY_SIZE(gSettingsContext.hashIndexes); i++) {
+        mBuffer[memSpacer++] = gSettingsContext.hashIndexes[i];
+    }
+    mBuffer[memSpacer++] = bit;
+    Multiplayer_SendPacket(memSpacer, UDS_BROADCAST_NETWORKNODEID);
+}
+
+void Multiplayer_Receive_BiggoronTradeBit(u16 senderID) {
+    if (!IsHashSame(&mBuffer[1]) || gSettingsContext.mp_SharedProgress == OFF) {
+        return;
+    }
+    u8 memSpacer = 1 + ARRAY_SIZE(gSettingsContext.hashIndexes);
+
+    u8 bit = mBuffer[memSpacer++];
+
+    mSaveContext.biggoronTrades |= (1 << bit);
+    prevBiggoronTrades |= (1 << bit);
+}
+
+void Multiplayer_Send_DiscoveredScene(u32 index, u32 bit) {
+    if (!IsSendReceiveReady() || gSettingsContext.mp_SharedProgress == OFF) {
+        return;
+    }
+    memset(mBuffer, 0, mBufSize);
+    u8 memSpacer = 0;
+    mBuffer[memSpacer++] = PACKET_DISCOVEREDSCENE; // 0: Identifier
+    for (size_t i = 0; i < ARRAY_SIZE(gSettingsContext.hashIndexes); i++) {
+        mBuffer[memSpacer++] = gSettingsContext.hashIndexes[i];
+    }
+    mBuffer[memSpacer++] = index;
+    mBuffer[memSpacer++] = bit;
+    Multiplayer_SendPacket(memSpacer, UDS_BROADCAST_NETWORKNODEID);
+}
+
+void Multiplayer_Receive_DiscoveredScene(u16 senderID) {
+    if (!IsHashSame(&mBuffer[1]) || gSettingsContext.mp_SharedProgress == OFF) {
+        return;
+    }
+    u8 memSpacer = 1 + ARRAY_SIZE(gSettingsContext.hashIndexes);
+
+    u32 index = mBuffer[memSpacer++];
+    u32 bit = mBuffer[memSpacer++];
+
+    mSaveContext.scenesDiscovered[index] |= bit;
+}
+
+void Multiplayer_Send_DiscoveredEntrance(u32 index, u32 bit) {
+    if (!IsSendReceiveReady() || gSettingsContext.mp_SharedProgress == OFF) {
+        return;
+    }
+    memset(mBuffer, 0, mBufSize);
+    u8 memSpacer = 0;
+    mBuffer[memSpacer++] = PACKET_DISCOVEREDENTRANCE; // 0: Identifier
+    for (size_t i = 0; i < ARRAY_SIZE(gSettingsContext.hashIndexes); i++) {
+        mBuffer[memSpacer++] = gSettingsContext.hashIndexes[i];
+    }
+    mBuffer[memSpacer++] = index;
+    mBuffer[memSpacer++] = bit;
+    Multiplayer_SendPacket(memSpacer, UDS_BROADCAST_NETWORKNODEID);
+}
+
+void Multiplayer_Receive_DiscoveredEntrance(u16 senderID) {
+    if (!IsHashSame(&mBuffer[1]) || gSettingsContext.mp_SharedProgress == OFF) {
+        return;
+    }
+    u8 memSpacer = 1 + ARRAY_SIZE(gSettingsContext.hashIndexes);
+
+    u32 index = mBuffer[memSpacer++];
+    u32 bit = mBuffer[memSpacer++];
+
+    mSaveContext.entrancesDiscovered[index] |= bit;
+}
+
+void Multiplayer_Send_ActorUpdate(Actor* actor, void* extraData, u32 extraDataSize) {
+    if (!IsSendReceiveReady() || gSettingsContext.mp_SharedProgress == OFF) {
+        return;
+    }
+    memset(mBuffer, 0, mBufSize);
+    u8 memSpacer = 0;
+    mBuffer[memSpacer++] = PACKET_ACTORUPDATE; // 0: Identifier
+    for (size_t i = 0; i < ARRAY_SIZE(gSettingsContext.hashIndexes); i++) {
+        mBuffer[memSpacer++] = gSettingsContext.hashIndexes[i];
+    }
+    mBuffer[memSpacer++] = gGlobalContext->sceneNum;
+    mBuffer[memSpacer++] = actor->id;
+    mBuffer[memSpacer++] = actor->type;
+    mBuffer[memSpacer++] = actor->params;
+    memcpy(&mBuffer[memSpacer], &actor->home, sizeof(PosRot));
+    memSpacer += sizeof(PosRot) / 4;
+    // Always keep extra data last
+    memcpy(&mBuffer[memSpacer], extraData, extraDataSize);
+    memSpacer += (extraDataSize / 4) + 1;
+    Multiplayer_SendPacket(memSpacer, UDS_BROADCAST_NETWORKNODEID);
+}
+
+void Multiplayer_Receive_ActorUpdate(u16 senderID) {
+    if (!IsHashSame(&mBuffer[1]) || gSettingsContext.mp_SharedProgress == OFF) {
+        return;
+    }
+    u8 memSpacer = 1 + ARRAY_SIZE(gSettingsContext.hashIndexes);
+
+    s16 sceneNum = mBuffer[memSpacer++];
+    if (sceneNum != gGlobalContext->sceneNum) {
+        return;
+    }
+
+    s16 actorId = mBuffer[memSpacer++];
+    u8 actorType = mBuffer[memSpacer++];
+    s16 actorParams = mBuffer[memSpacer++];
+    PosRot actorHome;
+    memcpy(&actorHome, &mBuffer[memSpacer], sizeof(PosRot));
+    memSpacer += sizeof(PosRot) / 4;
+
+    u8 amountWithSameParams = 0;
+    for (Actor* actor = gGlobalContext->actorCtx.actorList[actorType].first; actor != NULL; actor = actor->next) {
+        if (actor->id != actorId) {
+            continue;
+        }
+        if (actor->params == actorParams) {
+            amountWithSameParams++;
+            if (amountWithSameParams >= 2) {
+                // No need to search for more
+                break;
+            }
+        }
+    }
+    for (Actor* actor = gGlobalContext->actorCtx.actorList[actorType].first; actor != NULL; actor = actor->next) {
+        if (actor->id != actorId) {
+            continue;
+        }
+        // If only one actor has the same params, check for that. Otherwise use the home PosRot
+        if ((amountWithSameParams <= 1 && actor->params == actorParams) ||
+            (amountWithSameParams > 1 &&
+                (s32)actorHome.pos.x == (s32)actor->home.pos.x && actorHome.rot.x == actor->home.rot.x &&
+                (s32)actorHome.pos.y == (s32)actor->home.pos.y && actorHome.rot.y == actor->home.rot.y &&
+                (s32)actorHome.pos.z == (s32)actor->home.pos.z && actorHome.rot.z == actor->home.rot.z)) {
+            switch (actorId) {
+                case 0x4: // Shop Items
+                {
+                    u16 index = (u16)mBuffer[memSpacer];
+                    ShopsanityItem_SellOut(actor, index);
+                    break;
+                }
+                case 0x9: // Regular Doors
+                    EnDoor_Unlock((EnDoor*)actor);
+                    break;
+                case 0x2E: // Shutter Doors
+                    DoorShutter_Unlock((DoorShutter*)actor);
+                    break;
+                case 0x95: // Gold Skulltulas
+                    EnSw_Kill((EnSw*)actor, gGlobalContext);
+                    break;
+                case 0x9C: // Royal Grave
+                    BgSpot02Objects_ExplodeGrave((BgSpot02Objects*)actor);
+                    break;
+                case 0xFF: // Pushblocks
+                {
+                    Vec3f newPos;
+                    memcpy(&newPos, &mBuffer[memSpacer], sizeof(Vec3f));
+                    actor->world.pos = newPos;
+                    actor->home.pos = newPos;
+                    break;
+                }
+                case 0x11A: // Business Scrubs
+                    EnDns_StartBurrow((EnDns*)actor);
+                    break;
+                case 0x12C: // Collapsing Platforms
+                {
+                    void* new_action_fn = (void*)mBuffer[memSpacer];
+                    ObjLift_SetActionFn((ObjLift*)actor, new_action_fn);
+                    break;
+                }
+                case 0x133: // Carpenters
+                    EnDaiku_StartEscape((EnDaiku*)actor);
+                    break;
+                case 0x14E: // Silver Boulders
+                    Flags_SetSwitch(gGlobalContext, (actor->params >> 10 & 0x3C) | (actor->params << 0x18) >> 0x1E);
+                    Actor_Kill(actor);
+                    break;
+                case 0x172: // Theives' Hideout Cell Doors
+                    DoorGerudo_Unlock((DoorGerudo*)actor);
+                    break;
+                case 0x1D2: // Red Boulders
+                    ObjHamishi_Hit((ObjHamishi*)actor);
+                    break;
+            }
+        }
+    }
+
+    // Extra/Alternate actions
+    switch (actorId) {
+        case 0xF: // Spider Webs
+        {
+            BgYdanSp_SendData sendData;
+            memcpy(&sendData, &mBuffer[memSpacer], sizeof(BgYdanSp_SendData));
+            for (Actor* actor = gGlobalContext->actorCtx.actorList[actorType].first; actor != NULL; actor = actor->next) {
+                if (actor->id != actorId) {
+                    continue;
+                }
+                if ((s32)sendData.homePos.x == (s32)actor->home.pos.x &&
+                    (s32)sendData.homePos.y == (s32)actor->home.pos.y &&
+                    (s32)sendData.homePos.z == (s32)actor->home.pos.z) {
+                    BgYdanSp_SetActionFn((BgYdanSp*)actor, sendData.action_fn);
+                    break;
+                }
+            }
+            break;
+        }
+        case 0x107: // Milk Crates
+        {
+            BgSpot15Rrbox_SendData sendData;
+            memcpy(&sendData, &mBuffer[memSpacer], sizeof(BgSpot15Rrbox_SendData));
+            for (Actor* actor = gGlobalContext->actorCtx.actorList[actorType].first; actor != NULL; actor = actor->next) {
+                if (actor->id != actorId) {
+                    continue;
+                }
+                if ((s32)sendData.focusPos.x == (s32)actor->focus.pos.x &&
+                    (s32)sendData.focusPos.y == (s32)actor->focus.pos.y &&
+                    (s32)sendData.focusPos.z == (s32)actor->focus.pos.z) {
+                    actor->world.pos = sendData.worldPos;
+                    actor->home.pos = sendData.worldPos;
+                    break;
+                }
+            }
+            break;
+        }
+        case 0x11A: // Business Scrubs
+            for (Actor* actor = gGlobalContext->actorCtx.actorList[ACTORTYPE_ENEMY].first; actor != NULL; actor = actor->next) {
+                if (actor->id != 0x195) {
+                    continue;
+                }
+                if ((s32)actorHome.pos.x == (s32)actor->home.pos.x &&
+                    (s32)actorHome.pos.y == (s32)actor->home.pos.y &&
+                    (s32)actorHome.pos.z == (s32)actor->home.pos.z) {
+                    Actor_Kill(actor);
+                    break;
+                }
+            }
+            break;
+    }
+}
+
+void Multiplayer_Send_ActorSpawn(s16 actorId, PosRot posRot, s16 params) {
+    if (!IsSendReceiveReady() || gSettingsContext.mp_SharedProgress == OFF) {
+        return;
+    }
+    memset(mBuffer, 0, mBufSize);
+    u8 memSpacer = 0;
+    mBuffer[memSpacer++] = PACKET_ACTORSPAWN; // 0: Identifier
+    for (size_t i = 0; i < ARRAY_SIZE(gSettingsContext.hashIndexes); i++) {
+        mBuffer[memSpacer++] = gSettingsContext.hashIndexes[i];
+    }
+    mBuffer[memSpacer++] = gGlobalContext->sceneNum;
+    mBuffer[memSpacer++] = actorId;
+    memcpy(&mBuffer[memSpacer], &posRot, sizeof(PosRot));
+    memSpacer += sizeof(PosRot) / 4;
+    mBuffer[memSpacer++] = params;
+    Multiplayer_SendPacket(memSpacer, UDS_BROADCAST_NETWORKNODEID);
+}
+
+void Multiplayer_Receive_ActorSpawn(u16 senderID) {
+    if (!IsHashSame(&mBuffer[1]) || gSettingsContext.mp_SharedProgress == OFF) {
+        return;
+    }
+    u8 memSpacer = 1 + ARRAY_SIZE(gSettingsContext.hashIndexes);
+
+    s16 sceneNum = mBuffer[memSpacer++];
+    s16 actorId = mBuffer[memSpacer++];
+    PosRot rcvdPosRot;
+    memcpy(&rcvdPosRot, &mBuffer[memSpacer], sizeof(PosRot));
+    memSpacer += sizeof(PosRot) / 4;
+    s16 params = mBuffer[memSpacer++];
+
+    if (sceneNum != gGlobalContext->sceneNum || !IsInGame()) {
+        return;
+    }
+
+    Actor_Spawn(&gGlobalContext->actorCtx, gGlobalContext, actorId,
+        rcvdPosRot.pos.x, rcvdPosRot.pos.y, rcvdPosRot.pos.z,
+        rcvdPosRot.rot.x, rcvdPosRot.rot.y, rcvdPosRot.rot.z, params);
+}
+
+// Etc
+
+void Multiplayer_Send_HealthChange(s16 diff) {
+    if (!IsSendReceiveReady()) {
+        return;
+    }
+    memset(mBuffer, 0, mBufSize);
+    u8 memSpacer = 0;
+    mBuffer[memSpacer++] = PACKET_HEALTHCHANGE; // 0: Identifier
+    mBuffer[memSpacer++] = diff;
+    Multiplayer_SendPacket(memSpacer, UDS_BROADCAST_NETWORKNODEID);
+}
+
+void Multiplayer_Receive_HealthChange(u16 senderID) {
+    if (gSettingsContext.mp_SharedHealth == OFF) {
+        return;
+    }
+    s16 diff = mBuffer[1];
+
+    if (gSettingsContext.mp_SharedProgress == ON) {
+        mSaveContext.health += diff;
+
+        if (mSaveContext.health > mSaveContext.healthCapacity) {
+            mSaveContext.health = mSaveContext.healthCapacity;
+        } else if (mSaveContext.health < 0) {
+            mSaveContext.health = 0;
+        }
+
+        prevHealth = mSaveContext.health;
+    } else {
+        if (!IsInGame()) {
+            return;
+        }
+        gSaveContext.health += diff;
+
+        if (gSaveContext.health > gSaveContext.healthCapacity) {
+            gSaveContext.health = gSaveContext.healthCapacity;
+        } else if (gSaveContext.health < 0) {
+            gSaveContext.health = 0;
+        }
+
+        prevHealth = gSaveContext.health;
+    }
+}
+
+void Multiplayer_Send_RupeeChange(s16 diff) {
+    if (!IsSendReceiveReady()) {
+        return;
+    }
+    memset(mBuffer, 0, mBufSize);
+    u8 memSpacer = 0;
+    mBuffer[memSpacer++] = PACKET_RUPEESCHANGE; // 0: Identifier
+    mBuffer[memSpacer++] = diff;
+    Multiplayer_SendPacket(memSpacer, UDS_BROADCAST_NETWORKNODEID);
+}
+
+void Multiplayer_Receive_RupeeChange(u16 senderID) {
+    if (gSettingsContext.mp_SharedRupees == OFF) {
+        return;
+    }
+    s16 diff = mBuffer[1];
+
+    if (gSettingsContext.mp_SharedProgress == ON) {
+        mSaveContext.rupees += diff;
+
+        static u16 maxRupees[] = { 99, 200, 500, 999 };
+        u8 upgrade = mSaveContext.upgrades >> 12 & 0x3;
+        if (mSaveContext.rupees > maxRupees[upgrade]) {
+            mSaveContext.rupees = maxRupees[upgrade];
+        } else if (mSaveContext.rupees < 0) {
+            mSaveContext.rupees = 0;
+        }
+
+        prevRupees = mSaveContext.rupees;
+    } else {
+        if (!IsInGame()) {
+            return;
+        }
+        gSaveContext.rupees += diff;
+
+        static u16 maxRupees[] = { 99, 200, 500, 999 };
+        u8 upgrade = gSaveContext.upgrades >> 12 & 0x3;
+        if (gSaveContext.rupees > maxRupees[upgrade]) {
+            gSaveContext.rupees = maxRupees[upgrade];
+        } else if (gSaveContext.rupees < 0) {
+            gSaveContext.rupees = 0;
+        }
+
+        prevRupees = gSaveContext.rupees;
+    }
+}
+
+void Multiplayer_Send_AmmoChange(u8 slot, s8 diff) {
+    if (!IsSendReceiveReady()) {
+        return;
+    }
+    memset(mBuffer, 0, mBufSize);
+    u8 memSpacer = 0;
+    mBuffer[memSpacer++] = PACKET_AMMOCHANGE; // 0: Identifier
+    mBuffer[memSpacer++] = slot;
+    mBuffer[memSpacer++] = diff;
+    Multiplayer_SendPacket(memSpacer, UDS_BROADCAST_NETWORKNODEID);
+}
+
+void Multiplayer_Receive_AmmoChange(u16 senderID) {
+    if (gSettingsContext.mp_SharedAmmo == OFF) {
+        return;
+    }
+    u8 slot = mBuffer[1];
+    s8 diff = mBuffer[2];
+
+    // TODO: Don't go over max
+    if (gSettingsContext.mp_SharedProgress == ON) {
+        mSaveContext.ammo[slot] += diff;
+        if (mSaveContext.ammo[slot] < 0) {
+            mSaveContext.ammo[slot] = 0;
+        }
+        prevAmmo[slot] = mSaveContext.ammo[slot];
+    } else {
+        if (!IsInGame()) {
+            return;
+        }
+        gSaveContext.ammo[slot] += diff;
+        if (gSaveContext.ammo[slot] < 0) {
+            gSaveContext.ammo[slot] = 0;
+        }
+        prevAmmo[slot] = gSaveContext.ammo[slot];
+    }
+}
+
+// Send & Receive
+
+static void Multiplayer_SendPacket(u8 packageSize, u16 targetID) {
+    udsSendTo(targetID, data_channel, UDS_SENDFLAG_Default, mBuffer, packageSize * sizeof(mBuffer[0]));
+}
+
+void Multiplayer_ReceivePackets() {
+    if (!IsSendReceiveReady()) {
+        return;
+    }
+
+    if (gSettingsContext.mp_SharedProgress == ON && IsInGame()) {
+        gSaveContext.sceneFlags[gGlobalContext->sceneNum].swch = gGlobalContext->actorCtx.flags.swch;
+        gSaveContext.sceneFlags[gGlobalContext->sceneNum].chest = gGlobalContext->actorCtx.flags.chest;
+        gSaveContext.sceneFlags[gGlobalContext->sceneNum].clear = gGlobalContext->actorCtx.flags.clear;
+        gSaveContext.sceneFlags[gGlobalContext->sceneNum].collect = gGlobalContext->actorCtx.flags.collect;
+        Multiplayer_Overwrite_mSaveContext();
+    }
+
+    receivedPackets = 0;
+    size_t actual_size = 0;
+    do {
+        memset(mBuffer, 0, mBufSize);
+        u16 src_NetworkNodeID = 0;
+        udsPullPacket(&bindctx, mBuffer, mBufSize, &actual_size, &src_NetworkNodeID);
+        if (actual_size) {
+            Multiplayer_UnpackPacket(src_NetworkNodeID);
+        }
+    } while (actual_size);
+
+    if (gSettingsContext.mp_SharedProgress == ON && IsInGame()) {
+        Multiplayer_Overwrite_gSaveContext();
+    }
+}
+
+static void Multiplayer_UnpackPacket(u16 senderID) {
+    receivedPackets++;
+    PacketIdentifier identifier = mBuffer[0];
+
+    // Make sure these are lined up with the PacketIdentifier enum
+    static void (*receive_funcs[])(u16 senderID_) = {
+        // Ghost Data
+        Multiplayer_Receive_GhostPing,
+        Multiplayer_Receive_GhostData,
+        Multiplayer_Receive_LinkSFX,
+        // Shared Progress
+        Multiplayer_Receive_FullSyncRequest,
+        Multiplayer_Receive_BaseSync,
+        Multiplayer_Receive_FullSceneFlagSync,
+        Multiplayer_Receive_FullEntranceSync,
+        Multiplayer_Receive_Item,
+        Multiplayer_Receive_MaxHealth,
+        Multiplayer_Receive_KokiriSwordEquip,
+        Multiplayer_Receive_BGSFlag,
+        Multiplayer_Receive_MagicArrow,
+        Multiplayer_Receive_GreatFairyBuff,
+        Multiplayer_Receive_MagicBeanDiff,
+        Multiplayer_Receive_MagicBeansBoughtUpdate,
+        Multiplayer_Receive_EquipmentBit,
+        Multiplayer_Receive_UpgradesBit,
+        Multiplayer_Receive_QuestItemBit,
+        Multiplayer_Receive_DungeonItemBit,
+        Multiplayer_Receive_DungeonKeyUpdate,
+        Multiplayer_Receive_GSTokenDiff,
+        Multiplayer_Receive_EventChkInfBit,
+        Multiplayer_Receive_ItemGetInfBit,
+        Multiplayer_Receive_InfTableBit,
+        Multiplayer_Receive_ActorFlagBit,
+        Multiplayer_Receive_SceneFlagBit,
+        Multiplayer_Receive_GSFlagBit,
+        Multiplayer_Receive_FishingFlag,
+        Multiplayer_Receive_WorldMapBit,
+        Multiplayer_Receive_BiggoronTradeBit,
+        Multiplayer_Receive_DiscoveredScene,
+        Multiplayer_Receive_DiscoveredEntrance,
+        Multiplayer_Receive_ActorUpdate,
+        Multiplayer_Receive_ActorSpawn,
+        // Etc
+        Multiplayer_Receive_HealthChange,
+        Multiplayer_Receive_RupeeChange,
+        Multiplayer_Receive_AmmoChange,
+    };
+
+    receive_funcs[identifier](senderID);
+}

--- a/code/src/multiplayer.h
+++ b/code/src/multiplayer.h
@@ -1,0 +1,57 @@
+#ifndef _MULTIPLAYER_H_
+#define _MULTIPLAYER_H_
+
+#include "3ds/types.h"
+#include "z3D/z3D.h"
+
+extern u32 receivedPackets;
+extern bool duplicateSendProtection;
+
+void Multiplayer_Run(void);
+void Multiplayer_Update(void);
+s8 Multiplayer_PlayerCount();
+void Multiplayer_Sync_Update(void);
+void Multiplayer_ReceivePackets();
+
+// Ghost Data
+void Multiplayer_Send_GhostPing(void);
+void Multiplayer_Send_GhostData(void);
+void Multiplayer_Send_LinkSFX(u32 sfxID);
+// Shared Progress
+void Multiplayer_Send_FullSyncRequest();
+void Multiplayer_Send_BaseSync(u16 targetID);
+void Multiplayer_Send_FullSceneFlagSync(u16 targetID, u8 part);
+void Multiplayer_Send_Item(u8 slot, ItemID item);
+void Multiplayer_Send_KokiriSwordEquip(void);
+void Multiplayer_Send_MaxHealth(void);
+void Multiplayer_Send_BGSFlag(void);
+void Multiplayer_Send_MagicArrow(u8 type);
+void Multiplayer_Send_GreatFairyBuff(u8 type);
+void Multiplayer_Send_MagicBeanDiff(s8 diff);
+void Multiplayer_Send_MagicBeansBoughtUpdate();
+void Multiplayer_Send_EquipmentBit(u8 bit, u8 setOrUnset);
+void Multiplayer_Send_UpgradesBit(u8 bit, u8 setOrUnset);
+void Multiplayer_Send_QuestItemBit(u8 bit, u8 setOrUnset);
+void Multiplayer_Send_DungeonItemBit(u8 index, u8 bit, u8 setOrUnset);
+void Multiplayer_Send_DungeonKeyUpdate(u8 index, s8 diff);
+void Multiplayer_Send_GSTokenDiff(s16 diff);
+void Multiplayer_Send_EventChkInfBit(u8 index, u8 bit, u8 setOrUnset);
+void Multiplayer_Send_ItemGetInfBit(u8 index, u8 bit, u8 setOrUnset);
+void Multiplayer_Send_InfTableBit(u8 index, u8 bit, u8 setOrUnset);
+void Multiplayer_Send_ActorFlagBit(u8 index, u8 bit, u8 setOrUnset);
+void Multiplayer_Send_SceneFlagBit(u8 scene, u8 member, u8 bit, u8 setOrUnset);
+void Multiplayer_Send_GSFlagBit(u8 index, u8 bit, u8 setOrUnset);
+void Multiplayer_Send_FishingFlag(u8 bit, u8 setOrUnset);
+void Multiplayer_Send_WorldMapBit(u8 bit, u8 setOrUnset);
+void Multiplayer_Send_BiggoronTradeBit(u8 bit);
+void Multiplayer_Send_FullEntranceSync(u16 targetID, u8 latterHalf);
+void Multiplayer_Send_DiscoveredScene(u32 index, u32 bit);
+void Multiplayer_Send_DiscoveredEntrance(u32 index, u32 bit);
+void Multiplayer_Send_ActorUpdate(Actor* actor, void* extraData, u32 extraDataSize);
+void Multiplayer_Send_ActorSpawn(s16 actorId, PosRot posRot, s16 params);
+// Etc
+void Multiplayer_Send_HealthChange(s16 diff);
+void Multiplayer_Send_RupeeChange(s16 diff);
+void Multiplayer_Send_AmmoChange(u8 index, s8 diff);
+
+#endif //_MULTIPLAYER_H_

--- a/code/src/multiplayer_ghosts.c
+++ b/code/src/multiplayer_ghosts.c
@@ -1,0 +1,97 @@
+#include "multiplayer_ghosts.h"
+#include "3ds/svc.h"
+#include "common.h"
+
+typedef struct {
+    bool inUse;
+    u64 lastTick;
+    u16 networkID;
+    GhostData ghostData;
+} LinkGhost;
+
+static LinkGhost ghosts[16];
+
+#define INACTIVE_TIME_LIMIT (TICKS_PER_SEC * 3)
+
+void Multiplayer_Ghosts_Tick(void) {
+    u64 currentTick = svcGetSystemTick();
+    for (size_t i = 0; i < ARRAY_SIZE(ghosts); i++) {
+        LinkGhost* ghost = &ghosts[i];
+        if (ghost->inUse && currentTick - ghost->lastTick > INACTIVE_TIME_LIMIT) {
+            ghost->inUse = false;
+        }
+    }
+}
+
+void Multiplayer_Ghosts_UpdateGhost(u16 networkID, GhostData* ghostData) {
+    LinkGhost* ghostX = NULL;
+    // Find existing ghost
+    for (size_t i = 0; i < ARRAY_SIZE(ghosts); i++) {
+        LinkGhost* ghost = &ghosts[i];
+        if (ghost->inUse && ghost->networkID == networkID) {
+            ghostX = ghost;
+            break;
+        }
+    }
+    // Assign new ghost
+    if (ghostX == NULL) {
+        for (size_t i = 0; i < ARRAY_SIZE(ghosts); i++) {
+            LinkGhost* ghost = &ghosts[i];
+            if (!ghost->inUse) {
+                ghost->inUse = true;
+                ghost->networkID = networkID;
+                ghostX = ghost;
+                break;
+            }
+        }
+    }
+    // Failsafe in case all spots are taken
+    if (ghostX == NULL) {
+        return;
+    }
+    // Set vars
+    ghostX->lastTick = svcGetSystemTick();
+    if (ghostData != NULL) {
+        ghostX->ghostData.currentScene = ghostData->currentScene;
+        ghostX->ghostData.age = ghostData->age;
+        ghostX->ghostData.position = ghostData->position;
+        // Temporary offset for effect
+        ghostX->ghostData.position.y += (ghostData->age == 0 ? 50 : 35);
+    }
+}
+
+GhostData* Multiplayer_Ghosts_GetGhostData(u16 networkID) {
+    for (size_t i = 0; i < ARRAY_SIZE(ghosts); i++) {
+        LinkGhost* ghost = &ghosts[i];
+        if (ghost->inUse && ghost->networkID == networkID) {
+            return &ghost->ghostData;
+        }
+    }
+    return NULL;
+}
+
+typedef void(*EffectSsDeadDb_Spawn_proc)(GlobalContext* globalCtx, Vec3f* position, Vec3f* velocity, Vec3f* acceleration,
+    s16 scale, s16 scale_step,
+    s16 prim_r, s16 prim_g, s16 prim_b, s16 prim_a,
+    s16 env_r, s16 env_g, s16 env_b,
+    s16 unused, s32 param_15, s16 play_sound);
+#define EffectSsDeadDb_Spawn_addr 0x3642F4
+#define EffectSsDeadDb_Spawn ((EffectSsDeadDb_Spawn_proc)EffectSsDeadDb_Spawn_addr)
+
+void Multiplayer_Ghosts_DrawAll(void) {
+    for (size_t i = 0; i < ARRAY_SIZE(ghosts); i++) {
+        LinkGhost* ghost = &ghosts[i];
+        if (ghost->inUse && ghost->ghostData.currentScene == gGlobalContext->sceneNum) {
+            // Temporary effect
+            static Vec3f vecEmpty;
+            static f32 colorR[] = { 1.0, 0.0, 0.0, 1.0, 0.0, 1.0, 1.0 };
+            static f32 colorG[] = { 0.0, 1.0, 0.0, 1.0, 1.0, 0.0, 0.5 };
+            static f32 colorB[] = { 0.0, 0.0, 1.0, 0.0, 1.0, 1.0, 0.0 };
+            EffectSsDeadDb_Spawn(gGlobalContext, &ghost->ghostData.position, &vecEmpty, &vecEmpty,
+                ghost->ghostData.age == 0 ? 100 : 70, 0,
+                0x64, 0x64, 0x64, 0x64,
+                0x64 * colorR[(ghost->networkID - 1) % ARRAY_SIZE(colorR)], 0x64 * colorG[(ghost->networkID - 1) % ARRAY_SIZE(colorG)], 0x64 * colorB[(ghost->networkID - 1) % ARRAY_SIZE(colorB)],
+                1, 0xB, 0);
+        }
+    }
+}

--- a/code/src/multiplayer_ghosts.h
+++ b/code/src/multiplayer_ghosts.h
@@ -1,0 +1,19 @@
+#ifndef _MULTIPLAYER_GHOSTS_H_
+#define _MULTIPLAYER_GHOSTS_H_
+
+#include "3ds/types.h"
+#include "z3D/z3D.h"
+
+typedef struct {
+    s16 currentScene;
+    s32 age;
+    Vec3f position;
+    // Animation vars here
+} GhostData;
+
+void Multiplayer_Ghosts_Tick(void);
+void Multiplayer_Ghosts_UpdateGhost(u16 networkID, GhostData* ghostData);
+GhostData* Multiplayer_Ghosts_GetGhostData(u16 networkID);
+void Multiplayer_Ghosts_DrawAll(void);
+
+#endif //_MULTIPLAYER_GHOSTS_H_

--- a/code/src/ndm.c
+++ b/code/src/ndm.c
@@ -1,0 +1,259 @@
+#include <string.h>
+#include <stdlib.h>
+#include <malloc.h>
+#include <unistd.h>
+#include <3ds/types.h>
+#include <3ds/result.h>
+#include <3ds/svc.h>
+#include <3ds/srv.h>
+#include <3ds/synchronization.h>
+#include <3ds/services/ndm.h>
+#include <3ds/ipc.h>
+
+Handle ndmuHandle;
+static int ndmuRefCount;
+
+Result ndmuInit(void)
+{
+	Result ret=0;
+
+	if (AtomicPostIncrement(&ndmuRefCount)) return 0;
+
+	ret = srvGetServiceHandle(&ndmuHandle, "ndm:u");
+	if (R_FAILED(ret)) AtomicDecrement(&ndmuRefCount);
+
+	return ret;
+}
+
+void ndmuExit(void)
+{
+	if (AtomicDecrement(&ndmuRefCount)) return;
+
+	svcCloseHandle(ndmuHandle);
+	ndmuHandle = 0;
+}
+
+Result NDMU_EnterExclusiveState(ndmExclusiveState state)
+{
+	u32* cmdbuf=getThreadCommandBuffer();
+
+	cmdbuf[0]=IPC_MakeHeader(0x1,1,2); // 0x10042
+	cmdbuf[1]=state;
+	cmdbuf[2]=IPC_Desc_CurProcessId();
+
+	Result ret=0;
+	if(R_FAILED(ret=svcSendSyncRequest(ndmuHandle)))return ret;
+
+	return (Result)cmdbuf[1];
+}
+
+Result NDMU_LeaveExclusiveState(void)
+{
+	u32* cmdbuf=getThreadCommandBuffer();
+
+	cmdbuf[0]=IPC_MakeHeader(0x2,0,2); // 0x20002
+	cmdbuf[1]=IPC_Desc_CurProcessId();
+
+	Result ret=0;
+	if(R_FAILED(ret=svcSendSyncRequest(ndmuHandle)))return ret;
+
+	return (Result)cmdbuf[1];
+}
+
+Result NDMU_GetExclusiveState(ndmExclusiveState *state)
+{
+	u32* cmdbuf=getThreadCommandBuffer();
+
+	cmdbuf[0]=IPC_MakeHeader(0x3,0,0); // 0x30000
+
+	Result ret=0;
+	if(R_FAILED(ret=svcSendSyncRequest(ndmuHandle)))return ret;
+
+	*state = cmdbuf[2];
+
+	return (Result)cmdbuf[1];
+}
+
+Result NDMU_LockState(void)
+{
+	u32* cmdbuf=getThreadCommandBuffer();
+
+	cmdbuf[0]=IPC_MakeHeader(0x4,0,2); // 0x40002
+	cmdbuf[1]=IPC_Desc_CurProcessId();
+
+	Result ret=0;
+	if(R_FAILED(ret=svcSendSyncRequest(ndmuHandle)))return ret;
+
+	return (Result)cmdbuf[1];
+}
+
+Result NDMU_UnlockState(void)
+{
+	u32* cmdbuf=getThreadCommandBuffer();
+
+	cmdbuf[0]=IPC_MakeHeader(0x5,0,2); // 0x50002
+	cmdbuf[1]=IPC_Desc_CurProcessId();
+
+	Result ret=0;
+	if(R_FAILED(ret=svcSendSyncRequest(ndmuHandle)))return ret;
+
+	return (Result)cmdbuf[1];
+}
+
+Result NDMU_SuspendDaemons(ndmDaemonMask mask)
+{
+	u32* cmdbuf=getThreadCommandBuffer();
+
+	cmdbuf[0]=IPC_MakeHeader(0x6,1,0); // 0x60040
+	cmdbuf[1]=mask;
+
+	Result ret=0;
+	if(R_FAILED(ret=svcSendSyncRequest(ndmuHandle)))return ret;
+
+	return (Result)cmdbuf[1];
+}
+
+Result NDMU_ResumeDaemons(ndmDaemonMask mask)
+{
+	u32* cmdbuf=getThreadCommandBuffer();
+
+	cmdbuf[0]=IPC_MakeHeader(0x7,1,0); // 0x70040
+	cmdbuf[1]=mask;
+
+	Result ret=0;
+	if(R_FAILED(ret=svcSendSyncRequest(ndmuHandle)))return ret;
+
+	return (Result)cmdbuf[1];
+}
+
+Result NDMU_SuspendScheduler(u32 flag)
+{
+	u32* cmdbuf=getThreadCommandBuffer();
+
+	cmdbuf[0]=IPC_MakeHeader(0x8,1,0); // 0x80040
+	cmdbuf[1]=flag;
+
+	Result ret=0;
+	if(R_FAILED(ret=svcSendSyncRequest(ndmuHandle)))return ret;
+
+	return (Result)cmdbuf[1];
+}
+
+Result NDMU_ResumeScheduler(void)
+{
+	u32* cmdbuf=getThreadCommandBuffer();
+
+	cmdbuf[0]=IPC_MakeHeader(0x9,0,0); // 0x90000
+
+	Result ret=0;
+	if(R_FAILED(ret=svcSendSyncRequest(ndmuHandle)))return ret;
+
+	return (Result)cmdbuf[1];
+}
+
+Result NDMU_GetCurrentState(ndmState *state)
+{
+	u32* cmdbuf=getThreadCommandBuffer();
+
+	cmdbuf[0]=IPC_MakeHeader(0xA,0,0); // 0xA0000
+
+	Result ret=0;
+	if(R_FAILED(ret=svcSendSyncRequest(ndmuHandle)))return ret;
+
+	*state = cmdbuf[2];
+
+	return (Result)cmdbuf[1];
+}
+
+Result NDMU_QueryStatus(ndmDaemonStatus *status)
+{
+	u32* cmdbuf=getThreadCommandBuffer();
+
+	cmdbuf[0]=IPC_MakeHeader(0xD,1,0); // 0xD0000
+
+	Result ret=0;
+	if(R_FAILED(ret=svcSendSyncRequest(ndmuHandle)))return ret;
+
+	*status = cmdbuf[2];
+
+	return (Result)cmdbuf[1];
+}
+
+Result NDMU_SetScanInterval(u32 interval)
+{
+	u32* cmdbuf=getThreadCommandBuffer();
+
+	cmdbuf[0]=IPC_MakeHeader(0x10,1,0); // 0x10040
+	cmdbuf[1]=interval;
+
+	Result ret=0;
+	if(R_FAILED(ret=svcSendSyncRequest(ndmuHandle)))return ret;
+
+	return (Result)cmdbuf[1];
+}
+
+Result NDMU_GetScanInterval(u32 *interval)
+{
+	u32* cmdbuf=getThreadCommandBuffer();
+
+	cmdbuf[0]=IPC_MakeHeader(0x11,0,0); // 0x110000
+
+	Result ret=0;
+	if(R_FAILED(ret=svcSendSyncRequest(ndmuHandle)))return ret;
+
+	*interval = cmdbuf[2];
+
+	return (Result)cmdbuf[1];
+}
+
+Result NDMU_GetRetryInterval(u32 *interval)
+{
+	u32* cmdbuf=getThreadCommandBuffer();
+
+	cmdbuf[0]=IPC_MakeHeader(0x13,0,0); // 0x130000
+
+	Result ret=0;
+	if(R_FAILED(ret=svcSendSyncRequest(ndmuHandle)))return ret;
+
+	*interval = cmdbuf[2];
+
+	return (Result)cmdbuf[1];
+}
+
+Result NDMU_ResetDaemons(void)
+{
+	u32* cmdbuf=getThreadCommandBuffer();
+
+	cmdbuf[0]=IPC_MakeHeader(0x15,0,0); // 0x150000
+
+	Result ret=0;
+	if(R_FAILED(ret=svcSendSyncRequest(ndmuHandle)))return ret;
+
+	return (Result)cmdbuf[1];
+}
+
+Result NDMU_GetDefaultDaemons(ndmDaemonMask *mask)
+{
+	u32* cmdbuf=getThreadCommandBuffer();
+
+	cmdbuf[0]=IPC_MakeHeader(0x16,0,0); // 0x160000
+
+	Result ret=0;
+	if(R_FAILED(ret=svcSendSyncRequest(ndmuHandle)))return ret;
+
+	*mask = cmdbuf[2];
+
+	return (Result)cmdbuf[1];
+}
+
+Result NDMU_ClearMacFilter(void)
+{
+	u32* cmdbuf=getThreadCommandBuffer();
+
+	cmdbuf[0]=IPC_MakeHeader(0x17,0,0); // 0x170000
+
+	Result ret=0;
+	if(R_FAILED(ret=svcSendSyncRequest(ndmuHandle)))return ret;
+
+	return (Result)cmdbuf[1];
+}

--- a/code/src/oot_malloc.h
+++ b/code/src/oot_malloc.h
@@ -1,0 +1,14 @@
+#ifndef _OOT_MALLOC_H_
+#define _OOT_MALLOC_H_
+
+#include "3ds/types.h"
+
+typedef void* (*SystemArena_Malloc_proc)(u32 size);
+#define SystemArena_Malloc_addr 0x35010C
+#define SystemArena_Malloc ((SystemArena_Malloc_proc)SystemArena_Malloc_addr)
+
+typedef void (*SystemArena_Free_proc)(void* ptr);
+#define SystemArena_Free_addr 0x34FC6C
+#define SystemArena_Free ((SystemArena_Free_proc)SystemArena_Free_addr)
+
+#endif //_OOT_MALLOC_H_

--- a/code/src/patches.s
+++ b/code/src/patches.s
@@ -1755,6 +1755,31 @@ OverrideGrottoActorEntrance_patch:
 ReturnFWSetupGrottoInfo_patch:
     bl hook_ReturnFWSetupGrottoInfo
 
+.section .patch_BrownBoulderExplode
+.global BrownBoulderExplode_patch
+BrownBoulderExplode_patch:
+    bl hook_BrownBoulderExplode
+
+.section .patch_RedBoulderExplode
+.global RedBoulderExplode_patch
+RedBoulderExplode_patch:
+    b hook_RedBoulderExplode
+
+.section .patch_Multiplayer_UpdatePrevActorFlags
+.global Multiplayer_UpdatePrevActorFlags_patch
+Multiplayer_UpdatePrevActorFlags_patch:
+    bl hook_Multiplayer_UpdatePrevActorFlags
+
+.section .patch_Multiplayer_OnLoadFile
+.global Multiplayer_OnLoadFile_patch
+Multiplayer_OnLoadFile_patch:
+    b hook_Multiplayer_OnLoadFile
+
+.section .patch_SendDroppedBottleContents
+.global SendDroppedBottleContents_patch
+SendDroppedBottleContents_patch:
+    bl hook_SendDroppedBottleContents
+
 .section .patch_loader
 .global loader_patch
 

--- a/code/src/pushblock.c
+++ b/code/src/pushblock.c
@@ -1,0 +1,33 @@
+#include "pushblock.h"
+#include "multiplayer.h"
+
+#define ObjOshihiki_Update_addr 0x286520
+#define ObjOshihiki_Update ((ActorFunc)ObjOshihiki_Update_addr)
+
+void ObjOshihiki_rUpdate(Actor* thisx, GlobalContext* globalCtx) {
+    Vec3f prevPos = thisx->world.pos;
+
+    ObjOshihiki_Update(thisx, globalCtx);
+
+    if ((s32)thisx->world.pos.x != (s32)prevPos.x ||
+        (s32)thisx->world.pos.y != (s32)prevPos.y ||
+        (s32)thisx->world.pos.z != (s32)prevPos.z) {
+        Multiplayer_Send_ActorUpdate(thisx, &thisx->world.pos, sizeof(Vec3f));
+    }
+}
+
+#define BgSpot15Rrbox_Update_addr 0x2AD484
+#define BgSpot15Rrbox_Update ((ActorFunc)BgSpot15Rrbox_Update_addr)
+
+void BgSpot15Rrbox_rUpdate(Actor* thisx, GlobalContext* globalCtx) {
+    Vec3f prevPos = thisx->world.pos;
+
+    BgSpot15Rrbox_Update(thisx, globalCtx);
+
+    if ((s32)thisx->world.pos.x != (s32)prevPos.x ||
+        (s32)thisx->world.pos.y != (s32)prevPos.y ||
+        (s32)thisx->world.pos.z != (s32)prevPos.z) {
+        BgSpot15Rrbox_SendData sendData = { thisx->focus.pos, thisx->world.pos };
+        Multiplayer_Send_ActorUpdate(thisx, &sendData, sizeof(BgSpot15Rrbox_SendData));
+    }
+}

--- a/code/src/pushblock.h
+++ b/code/src/pushblock.h
@@ -1,0 +1,15 @@
+#ifndef _PUSHBLOCK_H_
+#define _PUSHBLOCK_H_
+
+#include "z3D/z3D.h"
+
+void ObjOshihiki_rUpdate(Actor* thisx, GlobalContext* globalCtx);
+
+typedef struct {
+    Vec3f focusPos;
+    Vec3f worldPos;
+} BgSpot15Rrbox_SendData;
+
+void BgSpot15Rrbox_rUpdate(Actor* thisx, GlobalContext* globalCtx);
+
+#endif //_PUSHBLOCK_H_

--- a/code/src/savefile.c
+++ b/code/src/savefile.c
@@ -6,6 +6,7 @@
 #include "3ds/extdata.h"
 #include <string.h>
 #include "entrance.h"
+#include "multiplayer.h"
 
 #define DECLARE_EXTSAVEDATA
 #include "savefile.h"
@@ -243,11 +244,16 @@ u8 SaveFile_GetIsSceneDiscovered(u8 sceneNum) {
 }
 
 void SaveFile_SetSceneDiscovered(u8 sceneNum) {
+    if (SaveFile_GetIsSceneDiscovered(sceneNum)) {
+        return;
+    }
+
     u16 numBits = sizeof(u32) * 8;
     u32 idx = sceneNum / numBits;
     if (idx < SAVEFILE_SCENES_DISCOVERED_IDX_COUNT) {
         u32 sceneBit = 1 << (sceneNum - (idx * numBits));
         gExtSaveData.scenesDiscovered[idx] |= sceneBit;
+        Multiplayer_Send_DiscoveredScene(idx, sceneBit);
     }
 }
 
@@ -274,6 +280,7 @@ void SaveFile_SetEntranceDiscovered(u16 entranceIndex) {
     if (idx < SAVEFILE_ENTRANCES_DISCOVERED_IDX_COUNT) {
         u32 entranceBit = 1 << (entranceIndex - (idx * numBits));
         gExtSaveData.entrancesDiscovered[idx] |= entranceBit;
+        Multiplayer_Send_DiscoveredEntrance(idx, entranceBit);
         // Set connected
         for (size_t i = 0; i < ENTRANCE_OVERRIDES_MAX_COUNT; i++) {
             if (entranceIndex == rEntranceOverrides[i].index) {
@@ -556,6 +563,16 @@ void SaveFile_ResetItemSlotsIfMatchesID(u8 itemSlot) {
             gSaveContext.itemMenuAdult[i] = 0xFF;
         }
     }
+}
+
+u8 SaveFile_InventoryMenuHasSlot(u8 adult, u8 itemSlot) {
+    u8* itemMenu = adult ? gSaveContext.itemMenuAdult : gSaveContext.itemMenuChild;
+    for (size_t i = 0; i < 0x18; i++) {
+        if (itemMenu[i] == itemSlot) {
+            return 1;
+        }
+    }
+    return 0;
 }
 
 void SaveFile_SetOwnedTradeItemEquipped(void) {

--- a/code/src/savefile.h
+++ b/code/src/savefile.h
@@ -19,6 +19,7 @@ void SaveFile_UnsetTradeItemAsOwned(u8 itemId);
 u32 SaveFile_TradeItemIsOwned(u8 itemId);
 void SaveFile_SetOwnedTradeItemEquipped(void);
 void SaveFile_ResetItemSlotsIfMatchesID(u8 itemSlot);
+u8 SaveFile_InventoryMenuHasSlot(u8 adult, u8 itemSlot);
 void SaveFile_InitExtSaveData(u32 fileBaseIndex);
 void SaveFile_LoadExtSaveData(u32 saveNumber);
 void SaveFile_SaveExtSaveData(u32 saveNumber);

--- a/code/src/settings.h
+++ b/code/src/settings.h
@@ -3,10 +3,6 @@
 
 #include "../include/z3D/z3D.h"
 
-typedef void (*Health_ChangeBy_proc)(GlobalContext* arg1, u32 arg2);
-#define Health_ChangeBy_addr 0x352dbc
-#define Health_ChangeBy ((Health_ChangeBy_proc)Health_ChangeBy_addr)
-
 typedef enum {
   OFF,
   ON,
@@ -423,6 +419,12 @@ typedef struct {
   u8 itemPoolValue;
   u8 iceTrapValue;
   u8 progressiveGoronSword;
+
+  u8 mp_Enabled;
+  u8 mp_SharedProgress;
+  u8 mp_SharedHealth;
+  u8 mp_SharedRupees;
+  u8 mp_SharedAmmo;
 
   u8 zTargeting;
   u8 cameraControl;

--- a/code/src/sfx.c
+++ b/code/src/sfx.c
@@ -3,12 +3,21 @@
 #include "sfx.h"
 #include "savefile.h"
 #include "common.h"
+#include "multiplayer.h"
 
 SFXData rSfxData = {0};
 
 u32 SetSFX(u32 original) {
     u16 sfxID = original - SFX_BASE;
     SeqType type = rSfxData.rSeqTypesSFX[sfxID];
+
+    // Send SFX
+    if (!duplicateSendProtection) {
+        if (IsInGame() && sfxID >= 1258 && sfxID <= 1321) {
+            Multiplayer_Send_LinkSFX(original);
+        }
+    }
+    duplicateSendProtection = false;
 
     static const u16 GET_BOXITEM_ID = 1205; // Treat GET_BOXITEM as a fanfare
     if (IsInGame() && ((!gExtSaveData.option_EnableSFX && sfxID != GET_BOXITEM_ID) || (!gExtSaveData.option_EnableBGM && sfxID == GET_BOXITEM_ID))) {

--- a/code/src/shops.h
+++ b/code/src/shops.h
@@ -143,4 +143,5 @@ typedef struct {
 #define EnGirlA_ShopItemEntries ((ShopItemEntry*)0x524F50)
 
 void ShopsanityItem_Init(Actor* itemx, GlobalContext* globalCtx);
+void ShopsanityItem_SellOut(Actor* itemx, u16 index); // Used for multiplayer
 void EnOssan_rDestroy(Actor* shopkeeperx, GlobalContext* globalCtx);

--- a/code/src/skulltula.c
+++ b/code/src/skulltula.c
@@ -1,0 +1,45 @@
+#include "skulltula.h"
+#include "multiplayer.h"
+
+#define EnSw_Update_addr 0x1BB110
+#define EnSw_Update ((ActorFunc)EnSw_Update_addr)
+
+#define EnSw_GoldSkulltulaDeath (void*)0x3B91BC
+
+void EnSw_rUpdate(EnSw* thisx, GlobalContext* globalCtx) {
+    // Remove when token picked up by other player to prevent duplicates
+    if (thisx->base.params & 0xE000) {
+        u8 idx = (thisx->base.params >> 8) & 0x1F;
+        if (gSaveContext.gsFlags[idx] & (thisx->base.params & 0xFF)) {
+            Actor_Kill((Actor*)thisx);
+            return;
+        }
+    }
+
+    void* prev_action_fn = thisx->action_fn;
+
+    EnSw_Update((Actor*)thisx, globalCtx);
+
+    if (prev_action_fn != thisx->action_fn && thisx->action_fn == EnSw_GoldSkulltulaDeath) {
+        Multiplayer_Send_ActorUpdate((Actor*)thisx, NULL, 0);
+    }
+}
+
+typedef void(*FUN_00375B70_proc)(GlobalContext* globalCtx, Actor* actor);
+#define FUN_00375B70_addr 0x375B70
+#define FUN_00375B70 ((FUN_00375B70_proc)FUN_00375B70_addr)
+
+void EnSw_Kill(EnSw* thisx, GlobalContext* globalCtx) {
+    if (thisx->action_fn == EnSw_GoldSkulltulaDeath || (thisx->base.params & 0x4000 && !gSaveContext.nightFlag)) {
+        return;
+    }
+    // TODO: Fix spin speed
+    thisx->unk_word2 = 24;
+    FUN_00375B70(globalCtx, &thisx->base); // Not needed?
+    thisx->base.colChkInfo.health = 0;
+    //thisx->anime.play_speed = 8.0; // Doesn't seem to matter
+    thisx->unk_float1 = 16.0;
+    thisx->deathTimer_maybe = 15;
+    thisx->unk_word1 = 1;
+    thisx->action_fn = EnSw_GoldSkulltulaDeath;
+}

--- a/code/src/skulltula.h
+++ b/code/src/skulltula.h
@@ -1,0 +1,34 @@
+#ifndef _SKULLTULA_H_
+#define _SKULLTULA_H_
+
+#include "z3D/z3D.h"
+
+/* Bit usage of "params" for Gold Skulltula:
+ *   0-7: Bit in gsFlags
+ *  8-12: Index of gsFlags
+ * 13-15: Attributes? If any is set, the Skulltula is Gold
+ *        13: ?
+ *        14: Hides during day, appears at night
+ *        15: Plays the correct chime when spawned
+ */
+
+typedef struct {
+    Actor base;
+    SkelAnime anime;
+    char unk_228[1144];
+    void* action_fn;
+    char collider[32];
+    char jnt_sph_element[80];
+    char unk_714[46];
+    s16 unk_word1;
+    char unk_744[6];
+    s16 unk_word2;
+    s16 deathTimer_maybe;
+    char unk_74E[106];
+    f32 unk_float1;
+} EnSw;
+
+void EnSw_rUpdate(EnSw* thisx, GlobalContext* globalCtx);
+void EnSw_Kill(EnSw* thisx, GlobalContext* globalCtx);
+
+#endif //_SKULLTULA_H_

--- a/code/src/token.c
+++ b/code/src/token.c
@@ -8,10 +8,15 @@
 #define EnSi_Destroy_addr 0x168C3C
 #define EnSi_Destroy ((ActorFunc)EnSi_Destroy_addr)
 
+#define EnSi_Update_addr 0x1BA0C8
+#define EnSi_Update ((ActorFunc)EnSi_Update_addr)
+
 #define EnSi_Draw_addr 0x1BA050
 #define EnSi_Draw ((ActorFunc)EnSi_Draw_addr)
 
 #define THIS ((EnSi*)thisx)
+
+#define EnSi_DestroyAfterText (void*)0x3D0544
 
 void EnSi_rInit(Actor* thisx, GlobalContext* globalCtx) {
     EnSi* token = THIS;
@@ -25,6 +30,19 @@ void EnSi_rDestroy(Actor* thisx, GlobalContext* globalCtx) {
 
     Model_DestroyByActor(&token->actor);
     EnSi_Destroy(&token->actor, globalCtx);
+}
+
+void EnSi_rUpdate(Actor* thisx, GlobalContext* globalCtx) {
+    EnSi* token = THIS;
+
+    // Remove when token picked up by other player to prevent duplicates
+    u8 idx = (token->actor.params >> 8) & 0x1F;
+    if (token->actionFunc != EnSi_DestroyAfterText && gSaveContext.gsFlags[idx] & (token->actor.params & 0xFF)) {
+        Actor_Kill((Actor*)token);
+        return;
+    }
+
+    EnSi_Update(&token->actor, globalCtx);
 }
 
 typedef u32 (*EnSi_Draw_GetData_proc)(void);

--- a/code/src/token.h
+++ b/code/src/token.h
@@ -6,6 +6,7 @@
 
 void EnSi_rInit(Actor* token, GlobalContext* globalCtx);
 void EnSi_rDestroy(Actor* token, GlobalContext* globalCtx);
+void EnSi_rUpdate(Actor* token, GlobalContext* globalCtx);
 void EnSi_rDraw(Actor* token, GlobalContext* globalCtx);
 
 #endif //_TOKEN_H_

--- a/code/src/uds.c
+++ b/code/src/uds.c
@@ -1,0 +1,1021 @@
+/* Edited from https://github.com/devkitPro/libctru/blob/846b79e5a652dd00df38bd23bf9e99d519e3171a/libctru/source/services/uds.c */
+
+#include <string.h>
+#include <stdlib.h>
+#include "oot_malloc.h"
+#include <unistd.h>
+#include <stdio.h>
+#include <arpa/inet.h>
+#include <3ds/types.h>
+#include <3ds/result.h>
+#include <3ds/svc.h>
+#include <3ds/srv.h>
+#include <3ds/synchronization.h>
+#include <3ds/services/uds.h>
+#include <3ds/services/cfgu.h>
+#include <3ds/services/ndm.h>
+#include <3ds/ipc.h>
+#include <3ds/util/utf.h>
+
+Handle __uds_servhandle;
+static int __uds_refcount;
+
+u32 *__uds_sharedmem_addr;
+static u32 __uds_sharedmem_size;
+static Handle __uds_sharedmem_handle;
+
+static Handle __uds_connectionstatus_event;
+
+static u32 bind_allocbitmask;
+
+static Result uds_Initialize(u32 sharedmem_size, const char *username);
+static Result udsipc_InitializeWithVersion(udsNodeInfo *nodeinfo, Handle sharedmem_handle, u32 sharedmem_size, Handle *eventhandle);
+static Result udsipc_Shutdown(void);
+
+static Result udsipc_BeginHostingNetwork(const udsNetworkStruct *network, const void *passphrase, size_t passphrase_size);
+static Result udsipc_ConnectToNetwork(const udsNetworkStruct *network, const void *passphrase, size_t passphrase_size, udsConnectionType connection_type);
+static Result udsipc_SetProbeResponseParam(u32 oui, s8 data);
+
+static Result udsipc_RecvBeaconBroadcastData(u8 *outbuf, u32 maxsize, nwmScanInputStruct *scaninput, u32 wlancommID, u8 id8, Handle event);
+static Result udsipc_ScanOnConnection(u8 *outbuf, u32 maxsize, nwmScanInputStruct *scaninput, u32 wlancommID, u8 id8);
+
+static Result udsipc_Bind(udsBindContext *bindcontext, u32 input0, u8 data_channel, u16 NetworkNodeID);
+static Result udsipc_Unbind(udsBindContext *bindcontext);
+
+static Result udsipc_DecryptBeaconData(udsNetworkStruct *network, u8 *tag0, u8 *tag1, udsNodeInfo *out);
+
+static Result usd_parsebeacon(u8 *buf, u32 size, udsNetworkScanInfo *networkscan);
+
+Result udsInit(size_t sharedmem_size, const char *username)
+{
+	Result ret=0;
+	u32 ndm_state = 0;
+
+	if (AtomicPostIncrement(&__uds_refcount)) return 0;
+
+	ret = ndmuInit();
+	if(R_SUCCEEDED(ret))
+	{
+		ndm_state = 1;
+		ret = NDMU_EnterExclusiveState(NDM_EXCLUSIVE_STATE_LOCAL_COMMUNICATIONS);
+		if(R_SUCCEEDED(ret))
+		{
+			ndm_state = 2;
+		}
+	}
+
+	if(R_SUCCEEDED(ret))
+	{
+		ret = srvGetServiceHandle(&__uds_servhandle, "nwm::UDS");
+		if(R_SUCCEEDED(ret))
+		{
+			ret = uds_Initialize(sharedmem_size, username);
+			if (R_FAILED(ret))
+			{
+				svcCloseHandle(__uds_servhandle);
+				__uds_servhandle = 0;
+			}
+		}
+	}
+
+	if (R_FAILED(ret))
+	{
+		if(ndm_state)
+		{
+			if(ndm_state==2)NDMU_LeaveExclusiveState();
+			ndmuExit();
+		}
+
+		AtomicDecrement(&__uds_refcount);
+	}
+
+	bind_allocbitmask = 0;
+
+	return ret;
+}
+
+void udsExit(void)
+{
+	if (AtomicDecrement(&__uds_refcount)) return;
+
+	udsipc_Shutdown();
+
+	svcCloseHandle(__uds_servhandle);
+	__uds_servhandle = 0;
+
+	svcCloseHandle(__uds_sharedmem_handle);
+	__uds_sharedmem_handle = 0;
+	__uds_sharedmem_size = 0;
+
+	SystemArena_Free(__uds_sharedmem_addr);
+	__uds_sharedmem_addr = NULL;
+
+	svcCloseHandle(__uds_connectionstatus_event);
+	__uds_connectionstatus_event = 0;
+
+	NDMU_LeaveExclusiveState();
+	ndmuExit();
+}
+
+Result udsGenerateNodeInfo(udsNodeInfo *nodeinfo, const char *username)
+{
+	Result ret=0;
+	ssize_t units=0;
+	size_t len;
+	u8 tmp[0x1c];
+
+	memset(nodeinfo, 0, sizeof(udsNodeInfo));
+	memset(tmp, 0, sizeof(tmp));
+
+	ret = cfguInit();
+	if (R_FAILED(ret))return ret;
+
+	ret = CFGU_GetConfigInfoBlk2(sizeof(nodeinfo->uds_friendcodeseed), 0x00090000, &nodeinfo->uds_friendcodeseed);
+	if (R_FAILED(ret))
+	{
+		cfguExit();
+		return ret;
+	}
+
+	ret = CFGU_GetConfigInfoBlk2(sizeof(tmp), 0x000A0000, tmp);
+	if (R_FAILED(ret))
+	{
+		cfguExit();
+		return ret;
+	}
+
+	memcpy(nodeinfo->usercfg, tmp, sizeof(nodeinfo->usercfg));
+
+	if(username)
+	{
+		len = 10;
+
+		memset(nodeinfo->username, 0, sizeof(nodeinfo->username));
+
+		units = utf8_to_utf16((uint16_t*)nodeinfo->username, (uint8_t*)username, len);
+
+		if(units < 0 || units > len)ret = -2;
+	}
+
+	cfguExit();
+
+	return ret;
+}
+
+Result udsGetNodeInfoUsername(const udsNodeInfo *nodeinfo, char *username)
+{
+	ssize_t units=0;
+	size_t len = 10;
+
+	units = utf16_to_utf8((uint8_t*)username, (uint16_t*)nodeinfo->username, len);
+
+	if(units < 0 || units > len)return -2;
+	return 0;
+}
+
+bool udsCheckNodeInfoInitialized(const udsNodeInfo *nodeinfo)
+{
+	if(nodeinfo->NetworkNodeID)return true;
+	return false;
+}
+
+void udsGenerateDefaultNetworkStruct(udsNetworkStruct *network, u32 wlancommID, u8 id8, u8 max_nodes)
+{
+	u8 oui_value[3] = {0x00, 0x1f, 0x32};
+
+	memset(network, 0, sizeof(udsNetworkStruct));
+
+	network->initialized_flag = 1;
+
+	memcpy(network->oui_value, oui_value, 3);
+	network->oui_type = 21;
+
+	network->wlancommID = htonl(wlancommID);
+	network->id8 = id8;
+
+	network->attributes = htons(UDSNETATTR_Default);
+
+	if(max_nodes > UDS_MAXNODES)max_nodes = UDS_MAXNODES;
+	network->max_nodes = max_nodes;
+
+	network->unk_x1f = 1;
+}
+
+static Result uds_Initialize(u32 sharedmem_size, const char *username)
+{
+	Result ret=0;
+	udsNodeInfo nodeinfo;
+
+	ret = udsGenerateNodeInfo(&nodeinfo, username);
+	if (R_FAILED(ret))return ret;
+
+	__uds_sharedmem_size = sharedmem_size;
+	__uds_sharedmem_handle = 0;
+
+	// memalign replacement solution from: https://stackoverflow.com/a/227900/16545369
+	void* mem = SystemArena_Malloc(__uds_sharedmem_size + 0xFFF);
+	void* ptr = (void*)(((uintptr_t)mem + 0xFFF) & ~(uintptr_t)0xFFF);
+	__uds_sharedmem_addr = ptr;
+
+	if(__uds_sharedmem_addr==NULL)ret = -1;
+
+	if (R_SUCCEEDED(ret))
+	{
+		memset(__uds_sharedmem_addr, 0, __uds_sharedmem_size);
+		ret = svcCreateMemoryBlock(&__uds_sharedmem_handle, (u32)__uds_sharedmem_addr, __uds_sharedmem_size, 0x0, MEMPERM_READ | MEMPERM_WRITE);
+	}
+
+	if (R_SUCCEEDED(ret))ret = udsipc_InitializeWithVersion(&nodeinfo, __uds_sharedmem_handle, __uds_sharedmem_size, &__uds_connectionstatus_event);
+
+	if (R_FAILED(ret) && __uds_sharedmem_handle)
+	{
+		svcCloseHandle(__uds_sharedmem_handle);
+		__uds_sharedmem_handle = 0;
+		__uds_sharedmem_size = 0;
+	}
+
+	if(R_FAILED(ret) && __uds_sharedmem_addr)
+	{
+		SystemArena_Free(__uds_sharedmem_addr);
+		__uds_sharedmem_addr = NULL;
+	}
+
+	if(R_FAILED(ret) && __uds_connectionstatus_event)
+	{
+		svcCloseHandle(__uds_connectionstatus_event);
+		__uds_connectionstatus_event = 0;
+	}
+
+	return ret;
+}
+
+Result udsCreateNetwork(const udsNetworkStruct *network, const void *passphrase, size_t passphrase_size, udsBindContext *context, u8 data_channel, u32 recv_buffer_size)
+{
+	Result ret=0;
+
+	if(context)ret = udsBind(context, UDS_BROADCAST_NETWORKNODEID, false, data_channel, recv_buffer_size);
+	if(R_FAILED(ret))return ret;
+
+	ret = udsipc_SetProbeResponseParam(0x00210080, 0);
+	if(R_FAILED(ret))
+	{
+		if(context)udsUnbind(context);
+		return ret;
+	}
+
+	ret = udsipc_BeginHostingNetwork(network, passphrase, passphrase_size);
+	if(R_FAILED(ret))
+	{
+		if(context)udsUnbind(context);
+		return ret;
+	}
+
+	return ret;
+}
+
+Result udsConnectNetwork(const udsNetworkStruct *network, const void *passphrase, size_t passphrase_size, udsBindContext *context, u16 recv_NetworkNodeID, udsConnectionType connection_type, u8 data_channel, u32 recv_buffer_size)
+{
+	Result ret=0;
+	bool spectator=false;
+
+	if(connection_type==UDSCONTYPE_Spectator)spectator=true;
+
+	if(context)ret = udsBind(context, recv_NetworkNodeID, spectator, data_channel, recv_buffer_size);
+	if(R_FAILED(ret))return ret;
+
+	ret = udsipc_ConnectToNetwork(network, passphrase, passphrase_size, connection_type);
+	if(R_FAILED(ret))
+	{
+		udsDisconnectNetwork();
+		if(context)udsUnbind(context);
+	}
+
+	return ret;
+}
+
+static Result udsipc_InitializeWithVersion(udsNodeInfo *nodeinfo, Handle sharedmem_handle, u32 sharedmem_size, Handle *eventhandle)
+{
+	u32* cmdbuf=getThreadCommandBuffer();
+
+	cmdbuf[0]=IPC_MakeHeader(0x1B,12,2); // 0x1B0302
+	cmdbuf[1]=sharedmem_size;
+	memcpy(&cmdbuf[2], nodeinfo, sizeof(udsNodeInfo));
+	cmdbuf[12] = 0x400;//version
+	cmdbuf[13] = IPC_Desc_SharedHandles(1);
+	cmdbuf[14] = sharedmem_handle;
+
+	Result ret=0;
+	if(R_FAILED(ret=svcSendSyncRequest(__uds_servhandle)))return ret;
+	ret = cmdbuf[1];
+
+	if(R_SUCCEEDED(ret))
+	{
+		if(eventhandle)*eventhandle = cmdbuf[3];
+	}
+
+	return ret;
+}
+
+static Result udsipc_Shutdown(void)
+{
+	u32* cmdbuf=getThreadCommandBuffer();
+
+	cmdbuf[0]=IPC_MakeHeader(0x3,0,0); // 0x30000
+
+	Result ret=0;
+	if(R_FAILED(ret=svcSendSyncRequest(__uds_servhandle)))return ret;
+
+	return cmdbuf[1];
+}
+
+Result udsEjectClient(u16 NetworkNodeID)
+{
+	u32* cmdbuf=getThreadCommandBuffer();
+
+	cmdbuf[0]=IPC_MakeHeader(0x5,1,0); // 0x50040
+	cmdbuf[1]=NetworkNodeID;
+
+	Result ret=0;
+	if(R_FAILED(ret=svcSendSyncRequest(__uds_servhandle)))return ret;
+
+	return cmdbuf[1];
+}
+
+Result udsEjectSpectator(void)
+{
+	u32* cmdbuf=getThreadCommandBuffer();
+
+	cmdbuf[0]=IPC_MakeHeader(0x6,0,0); // 0x60000
+
+	Result ret=0;
+	if(R_FAILED(ret=svcSendSyncRequest(__uds_servhandle)))return ret;
+
+	return cmdbuf[1];
+}
+
+Result udsUpdateNetworkAttribute(u16 bitmask, bool flag)
+{
+	u32* cmdbuf=getThreadCommandBuffer();
+
+	if(flag)flag = 1;
+
+	cmdbuf[0]=IPC_MakeHeader(0x7,2,0); // 0x70080
+	cmdbuf[1]=bitmask;
+	cmdbuf[2]=flag;
+
+	Result ret=0;
+	if(R_FAILED(ret=svcSendSyncRequest(__uds_servhandle)))return ret;
+
+	return cmdbuf[1];
+}
+
+Result udsSetNewConnectionsBlocked(bool block, bool clients, bool flag)
+{
+	u16 bitmask = 0;
+
+	if(clients)bitmask |= UDSNETATTR_DisableConnectClients;
+	if(flag)bitmask |= UDSNETATTR_x4;
+
+	return udsUpdateNetworkAttribute(bitmask, block);
+}
+
+Result udsAllowSpectators(void)
+{
+	return udsUpdateNetworkAttribute(UDSNETATTR_DisableConnectSpectators, false);
+}
+
+Result udsDestroyNetwork(void)
+{
+	u32* cmdbuf=getThreadCommandBuffer();
+
+	cmdbuf[0]=IPC_MakeHeader(0x8,0,0); // 0x80000
+
+	Result ret=0;
+	if(R_FAILED(ret=svcSendSyncRequest(__uds_servhandle)))return ret;
+
+	return cmdbuf[1];
+}
+
+Result udsDisconnectNetwork(void)
+{
+	u32* cmdbuf=getThreadCommandBuffer();
+
+	cmdbuf[0]=IPC_MakeHeader(0xA,0,0); // 0xA0000
+
+	Result ret=0;
+	if(R_FAILED(ret=svcSendSyncRequest(__uds_servhandle)))return ret;
+
+	return cmdbuf[1];
+}
+
+Result udsGetConnectionStatus(udsConnectionStatus *output)
+{
+	u32* cmdbuf=getThreadCommandBuffer();
+
+	cmdbuf[0]=IPC_MakeHeader(0xB,0,0); // 0xB0000
+
+	Result ret=0;
+	if(R_FAILED(ret=svcSendSyncRequest(__uds_servhandle)))return ret;
+	ret = cmdbuf[1];
+
+	if(R_SUCCEEDED(ret))
+	{
+		if(output)memcpy(output, &cmdbuf[2], sizeof(udsConnectionStatus));
+	}
+
+	return ret;
+}
+
+bool udsWaitConnectionStatusEvent(bool nextEvent, bool wait)
+{
+	bool ret = true;
+	u64 delayvalue = U64_MAX;
+
+	if(!wait)delayvalue = 0;
+
+	if(nextEvent)svcClearEvent(__uds_connectionstatus_event);
+
+	if(svcWaitSynchronization(__uds_connectionstatus_event, delayvalue)!=0 && !wait)ret = false;
+
+	if(!nextEvent)svcClearEvent(__uds_connectionstatus_event);
+
+	return ret;
+}
+
+Result udsGetNodeInformation(u16 NetworkNodeID, udsNodeInfo *output)
+{
+	u32* cmdbuf=getThreadCommandBuffer();
+
+	cmdbuf[0]=IPC_MakeHeader(0xD,1,0); // 0xD0040
+	cmdbuf[1]=NetworkNodeID;
+
+	Result ret=0;
+	if(R_FAILED(ret=svcSendSyncRequest(__uds_servhandle)))return ret;
+	ret = cmdbuf[1];
+
+	if(R_SUCCEEDED(ret))
+	{
+		if(output)memcpy(output, &cmdbuf[2], sizeof(udsNodeInfo));
+	}
+
+	return ret;
+}
+
+Result udsScanBeacons(void *buf, size_t maxsize, udsNetworkScanInfo **networks, size_t *total_networks, u32 wlancommID, u8 id8, const u8 *host_macaddress, bool connected)
+{
+	Result ret=0;
+	Handle event=0;
+	u8 *outbuf = (u8*)buf;
+	u32 entpos, curpos;
+	nwmScanInputStruct scaninput;
+	nwmBeaconDataReplyHeader *hdr;
+	nwmBeaconDataReplyEntry *entry;
+	udsNetworkScanInfo *networks_ptr;
+
+	if(total_networks)*total_networks = 0;
+	if(networks)*networks = NULL;
+
+	memset(&scaninput, 0, sizeof(nwmScanInputStruct));
+
+	scaninput.unk_x0 = 0x1;
+	scaninput.unk_x2 = 0x2;
+	scaninput.unk_x4 = 0x0421;
+	scaninput.unk_x6 = 0x6e;
+
+	memset(scaninput.mac_address, 0xff, sizeof(scaninput.mac_address));
+	if(host_macaddress)memcpy(scaninput.mac_address, host_macaddress, sizeof(scaninput.mac_address));
+
+	if(maxsize < sizeof(nwmBeaconDataReplyHeader))return -2;
+
+	ret = svcCreateEvent(&event, RESET_ONESHOT);
+	if(R_FAILED(ret))return ret;
+
+	if(!connected)ret = udsipc_RecvBeaconBroadcastData(outbuf, maxsize, &scaninput, wlancommID, id8, event);
+	if(connected)ret = udsipc_ScanOnConnection(outbuf, maxsize, &scaninput, wlancommID, id8);
+	svcCloseHandle(event);
+	if(R_FAILED(ret))return ret;
+
+	hdr = (nwmBeaconDataReplyHeader*)outbuf;
+	curpos = sizeof(nwmBeaconDataReplyHeader);
+
+	if(hdr->maxsize != maxsize)return -2;
+	if(hdr->size > maxsize)return -2;
+
+	if(hdr->total_entries)
+	{
+		if(networks)
+		{
+			networks_ptr = SystemArena_Malloc(sizeof(udsNetworkScanInfo) * hdr->total_entries);
+			if(networks_ptr == NULL)return -1;
+			if(total_networks)*total_networks = hdr->total_entries;
+			memset(networks_ptr, 0, sizeof(udsNetworkScanInfo) * hdr->total_entries);
+			*networks = networks_ptr;
+
+			for(entpos=0; entpos<hdr->total_entries; entpos++)
+			{
+				if(curpos >= hdr->size)
+				{
+					ret = -2;
+					break;
+				}
+
+				entry = (nwmBeaconDataReplyEntry*)&outbuf[curpos];
+				if(entry->size > hdr->size || curpos + entry->size > hdr->size || entry->size <= sizeof(nwmBeaconDataReplyEntry))
+				{
+					ret = -2;
+					break;
+				}
+
+				memcpy(&networks_ptr[entpos].datareply_entry, entry, sizeof(nwmBeaconDataReplyEntry));
+
+				ret = usd_parsebeacon(&outbuf[curpos + sizeof(nwmBeaconDataReplyEntry)], entry->size - sizeof(nwmBeaconDataReplyEntry), &networks_ptr[entpos]);
+				if(R_FAILED(ret))break;
+
+				curpos+= entry->size;
+			}
+		}
+
+		if(R_FAILED(ret))
+		{
+			if(networks)
+			{
+				SystemArena_Free(*networks);
+				*networks = NULL;
+			}
+			if(total_networks)*total_networks = 0;
+		}
+	}
+
+	return ret;
+}
+
+Result udsBind(udsBindContext *bindcontext, u16 NetworkNodeID, bool spectator, u8 data_channel, u32 recv_buffer_size)
+{
+	u32 pos;
+
+	memset(bindcontext, 0, sizeof(udsBindContext));
+
+	if(spectator)
+	{
+		pos = 0;
+		if((bind_allocbitmask & BIT(pos)))return -1;
+	}
+	else
+	{
+		for(pos=1; pos<UDS_MAXNODES+1; pos++)
+		{
+			if((bind_allocbitmask & BIT(pos)) == 0)break;
+		}
+		if(pos==UDS_MAXNODES)return -1;
+	}
+
+	bind_allocbitmask |= BIT(pos);
+
+	bindcontext->BindNodeID = (pos<<1);
+	if(spectator)bindcontext->BindNodeID |= spectator;
+
+	bindcontext->spectator = spectator;
+
+	return udsipc_Bind(bindcontext, recv_buffer_size, data_channel, NetworkNodeID);
+}
+
+Result udsUnbind(udsBindContext *bindcontext)
+{
+	Result ret=0;
+	u32 bitpos = 0;
+
+	if(bindcontext->event)
+	{
+		svcCloseHandle(bindcontext->event);
+	}
+
+	ret = udsipc_Unbind(bindcontext);
+
+	if(!bindcontext->spectator)bitpos = bindcontext->BindNodeID>>1;
+	bind_allocbitmask &= ~BIT(bitpos);
+
+	memset(bindcontext, 0, sizeof(udsBindContext));
+
+	return ret;
+}
+
+bool udsWaitDataAvailable(const udsBindContext *bindcontext, bool nextEvent, bool wait)
+{
+	bool ret = true;
+	u64 delayvalue = U64_MAX;
+
+	if(!wait)delayvalue = 0;
+
+	if(nextEvent)svcClearEvent(bindcontext->event);
+
+	if(svcWaitSynchronization(bindcontext->event, delayvalue)!=0 && !wait)ret = false;
+
+	if(!nextEvent)svcClearEvent(bindcontext->event);
+
+	return ret;
+}
+
+static Result usd_parsebeacon(u8 *buf, u32 size, udsNetworkScanInfo *networkscan)
+{
+	Result ret=0;
+
+	u8 tagid, tag_datalen;
+	u8 *tagptr;
+	u8 oui[3] = {0x00, 0x1f, 0x32};
+	u8 oui_type;
+	u8 appdata_size;
+
+	//Index0 = 21(0x15), index1=24(0x18), index2=25(0x19).
+	u8 *tags_data[3] = {0};
+	u32 tags_sizes[3] = {0};
+	int tagindex;
+
+	u8 tmp_tagdata[0xfe*2];
+
+	if(size < 0xc)return -3;
+
+	buf+=0xc;//Skip down to the tagged parameters in the beacon.
+	size-=0xc;
+
+	while(size)//Locate each of the Nintendo vendor tags which this code uses.
+	{
+		if(size < 2)return -3;
+
+		tagid = buf[0];
+		tag_datalen = buf[1];
+
+		buf+= 0x2;
+		size-= 0x2;
+
+		if(tag_datalen > size)return -3;
+
+		if(tagid==0xdd)//Vendor tag
+		{
+			if(tag_datalen < 4)return -3;
+
+			if(memcmp(buf, oui, sizeof(oui))==0)
+			{
+				oui_type = buf[3];
+
+				tagindex = -1;
+
+				if(oui_type==21)
+				{
+					tagindex = 0;
+				}
+				else if(oui_type==24)
+				{
+					tagindex = 1;
+				}
+				else if(oui_type==25)
+				{
+					tagindex = 2;
+				}
+
+				if(tagindex>=0)
+				{
+					tags_data[tagindex] = buf;
+					tags_sizes[tagindex] = tag_datalen;
+				}
+			}
+		}
+
+		buf+= tag_datalen;
+		size-= tag_datalen;
+	}
+
+	for(tagindex=0; tagindex<3; tagindex++)//Verify that the required tags exist and have valid sizes.
+	{
+		if(tagindex!=2 && (tags_data[tagindex]==NULL || tags_sizes[tagindex]==0))return -3;
+
+		if(tagindex && tags_sizes[tagindex] > 0xFE)return -3;
+		if(tagindex==1 && tags_sizes[tagindex] < 0x12)return -3;
+
+		if(tagindex==0 && ((tags_sizes[tagindex]<0x34) || (tags_sizes[tagindex]>0x34+0xC8)))return -3;
+	}
+
+	//Tag type21
+	tagindex = 0;
+	{
+		tagptr = tags_data[tagindex];
+		tag_datalen = tags_sizes[tagindex];
+
+		appdata_size = tagptr[0x33];
+		if((appdata_size > 0xC8) || (appdata_size > tag_datalen-0x34))return -3;//Verify the appdata size.
+
+		memset(&networkscan->network, 0, sizeof(udsNetworkStruct));
+
+		memcpy(&networkscan->network.oui_value, tagptr, 0x1F);
+
+		networkscan->network.appdata_size = appdata_size;
+		if(appdata_size)memcpy(networkscan->network.appdata, &tagptr[0x34], appdata_size);
+
+		networkscan->network.initialized_flag = 1;
+		networkscan->network.channel = networkscan->datareply_entry.channel;
+		memcpy(networkscan->network.host_macaddress, networkscan->datareply_entry.mac_address, sizeof(networkscan->network.host_macaddress));
+	}
+
+	memset(tmp_tagdata, 0, sizeof(tmp_tagdata));
+	for(tagindex=1; tagindex<3; tagindex++)
+	{
+		if(tags_data[tagindex])memcpy(&tmp_tagdata[0xfe * (tagindex-1)], tags_data[tagindex], tags_sizes[tagindex]);
+	}
+
+	ret = udsipc_DecryptBeaconData(&networkscan->network, tmp_tagdata, &tmp_tagdata[0xfe], networkscan->nodes);
+	if(R_FAILED(ret))return ret;
+
+	return 0;
+}
+
+static Result udsipc_RecvBeaconBroadcastData(u8 *outbuf, u32 maxsize, nwmScanInputStruct *scaninput, u32 wlancommID, u8 id8, Handle event)
+{
+	u32* cmdbuf=getThreadCommandBuffer();
+
+	cmdbuf[0]=IPC_MakeHeader(0xF,16,4); // 0xF0404
+	cmdbuf[1]=maxsize;
+	memcpy(&cmdbuf[2], scaninput, sizeof(nwmScanInputStruct));
+	cmdbuf[15]=wlancommID;
+	cmdbuf[16]=id8;
+	cmdbuf[17]=IPC_Desc_SharedHandles(1);
+	cmdbuf[18]=event;
+	cmdbuf[19]=IPC_Desc_Buffer(maxsize, IPC_BUFFER_W);
+	cmdbuf[20]=(u32)outbuf;
+
+	Result ret=0;
+	if(R_FAILED(ret=svcSendSyncRequest(__uds_servhandle)))return ret;
+
+	return cmdbuf[1];
+}
+
+Result udsSetApplicationData(const void *buf, size_t size)
+{
+	u32* cmdbuf=getThreadCommandBuffer();
+
+	cmdbuf[0]=IPC_MakeHeader(0x10,1,2); // 0x100042
+	cmdbuf[1]=size;
+	cmdbuf[2]=IPC_Desc_StaticBuffer(size, 4);
+	cmdbuf[3]=(u32)buf;
+
+	Result ret=0;
+	if(R_FAILED(ret=svcSendSyncRequest(__uds_servhandle)))return ret;
+
+	return cmdbuf[1];
+}
+
+Result udsGetApplicationData(void *buf, size_t size, size_t *actual_size)
+{
+	u32* cmdbuf=getThreadCommandBuffer();
+	u32 saved_threadstorage[2];
+
+	cmdbuf[0]=IPC_MakeHeader(0x11,1,0); // 0x110040
+	cmdbuf[1]=size;
+
+	u32 * staticbufs = getThreadStaticBuffers();
+	saved_threadstorage[0] = staticbufs[0];
+	saved_threadstorage[1] = staticbufs[1];
+
+	staticbufs[0] = IPC_Desc_StaticBuffer(size,0);
+	staticbufs[1] = (u32)buf;
+
+	Result ret=0;
+	ret=svcSendSyncRequest(__uds_servhandle);
+
+	staticbufs[0] = saved_threadstorage[0];
+	staticbufs[1] = saved_threadstorage[1];
+
+	if(R_FAILED(ret))return ret;
+
+	ret = cmdbuf[1];
+
+	if(R_SUCCEEDED(ret))
+	{
+		if(actual_size)*actual_size = cmdbuf[2];
+	}
+
+	return ret;
+}
+
+Result udsGetNetworkStructApplicationData(const udsNetworkStruct *network, void *buf, size_t size, size_t *actual_size)
+{
+	if(network->appdata_size > sizeof(network->appdata))return -1;
+	if(size > network->appdata_size)size = network->appdata_size;
+
+	if(buf)memcpy(buf, network->appdata, size);
+
+	if(actual_size)*actual_size = size;
+
+	return 0;
+}
+
+static Result udsipc_Bind(udsBindContext *bindcontext, u32 input0, u8 data_channel, u16 NetworkNodeID)
+{
+	u32* cmdbuf=getThreadCommandBuffer();
+
+	cmdbuf[0]=IPC_MakeHeader(0x12,4,0); // 0x120100
+	cmdbuf[1]=bindcontext->BindNodeID;
+	cmdbuf[2]=input0;
+	cmdbuf[3]=data_channel;
+	cmdbuf[4]=NetworkNodeID;
+
+	Result ret=0;
+	if(R_FAILED(ret=svcSendSyncRequest(__uds_servhandle)))return ret;
+	ret = cmdbuf[1];
+
+	if(R_SUCCEEDED(ret))
+	{
+		bindcontext->event = cmdbuf[3];
+	}
+
+	return ret;
+}
+
+static Result udsipc_Unbind(udsBindContext *bindcontext)
+{
+	u32* cmdbuf=getThreadCommandBuffer();
+
+	cmdbuf[0]=IPC_MakeHeader(0x13,1,0); // 0x130040
+	cmdbuf[1]=bindcontext->BindNodeID;
+
+	Result ret=0;
+	if(R_FAILED(ret=svcSendSyncRequest(__uds_servhandle)))return ret;
+
+	return cmdbuf[1];
+}
+
+Result udsPullPacket(const udsBindContext *bindcontext, void *buf, size_t size, size_t *actual_size, u16 *src_NetworkNodeID)
+{
+	u32* cmdbuf=getThreadCommandBuffer();
+	u32 saved_threadstorage[2];
+
+	u32 aligned_size = (size+0x3) & ~0x3;
+
+	cmdbuf[0]=IPC_MakeHeader(0x14,3,0); // 0x1400C0
+	cmdbuf[1]=bindcontext->BindNodeID;
+	cmdbuf[2]=aligned_size>>2;
+	cmdbuf[3]=size;
+
+	u32 * staticbufs = getThreadStaticBuffers();
+	saved_threadstorage[0] = staticbufs[0];
+	saved_threadstorage[1] = staticbufs[1];
+
+	staticbufs[0] = IPC_Desc_StaticBuffer(aligned_size,0);
+	staticbufs[1] = (u32)buf;
+
+	Result ret=0;
+	ret=svcSendSyncRequest(__uds_servhandle);
+
+	staticbufs[0] = saved_threadstorage[0];
+	staticbufs[1] = saved_threadstorage[1];
+
+	if(R_FAILED(ret))return ret;
+
+	ret = cmdbuf[1];
+
+	if(R_SUCCEEDED(ret))
+	{
+		if(actual_size)*actual_size = cmdbuf[2];
+		if(src_NetworkNodeID)*src_NetworkNodeID = cmdbuf[3];
+	}
+
+	return ret;
+}
+
+Result udsSendTo(u16 dst_NetworkNodeID, u8 data_channel, u8 flags, const void *buf, size_t size)
+{
+	u32* cmdbuf=getThreadCommandBuffer();
+
+	u32 aligned_size = (size+0x3) & ~0x3;
+
+	cmdbuf[0]=IPC_MakeHeader(0x17,6,2); // 0x170182
+	cmdbuf[1]=0x1;//Unused
+	cmdbuf[2]=dst_NetworkNodeID;
+	cmdbuf[3]=data_channel;
+	cmdbuf[4]=aligned_size>>2;
+	cmdbuf[5]=size;
+	cmdbuf[6]=flags;
+	cmdbuf[7]=IPC_Desc_StaticBuffer(aligned_size, 5);
+	cmdbuf[8]=(u32)buf;
+
+	Result ret=0;
+	if(R_FAILED(ret=svcSendSyncRequest(__uds_servhandle)))return ret;
+
+	return cmdbuf[1];
+}
+
+Result udsGetChannel(u8 *channel)
+{
+	u32* cmdbuf=getThreadCommandBuffer();
+
+	cmdbuf[0]=IPC_MakeHeader(0x1A,0,0); // 0x1A0000
+
+	Result ret=0;
+	if(R_FAILED(ret=svcSendSyncRequest(__uds_servhandle)))return ret;
+	ret = cmdbuf[1];
+
+	if(R_SUCCEEDED(ret))
+	{
+		*channel = cmdbuf[2];
+	}
+
+	return ret;
+}
+
+static Result udsipc_BeginHostingNetwork(const udsNetworkStruct *network, const void *passphrase, size_t passphrase_size)
+{
+	u32* cmdbuf=getThreadCommandBuffer();
+
+	cmdbuf[0]=IPC_MakeHeader(0x1D,1,4); // 0x1D0044
+	cmdbuf[1]=passphrase_size;
+	cmdbuf[2]=IPC_Desc_StaticBuffer(sizeof(udsNetworkStruct), 1);
+	cmdbuf[3]=(u32)network;
+	cmdbuf[4]=IPC_Desc_StaticBuffer(passphrase_size, 0);
+	cmdbuf[5]=(u32)passphrase;
+
+	Result ret=0;
+	if(R_FAILED(ret=svcSendSyncRequest(__uds_servhandle)))return ret;
+
+	return cmdbuf[1];
+}
+
+static Result udsipc_ConnectToNetwork(const udsNetworkStruct *network, const void *passphrase, size_t passphrase_size, udsConnectionType connection_type)
+{
+	u32* cmdbuf=getThreadCommandBuffer();
+
+	cmdbuf[0]=IPC_MakeHeader(0x1E,2,4); // 0x1E0084
+	cmdbuf[1]=connection_type;
+	cmdbuf[2]=passphrase_size;
+	cmdbuf[3]=IPC_Desc_StaticBuffer(sizeof(udsNetworkStruct), 1);
+	cmdbuf[4]=(u32)network;
+	cmdbuf[5]=IPC_Desc_StaticBuffer(passphrase_size, 0);
+	cmdbuf[6]=(u32)passphrase;
+
+	Result ret=0;
+	if(R_FAILED(ret=svcSendSyncRequest(__uds_servhandle)))return ret;
+
+	return cmdbuf[1];
+}
+
+static Result udsipc_DecryptBeaconData(udsNetworkStruct *network, u8 *tag0, u8 *tag1, udsNodeInfo *out)
+{
+	u32* cmdbuf=getThreadCommandBuffer();
+	u32 tagsize = 0xfe;
+
+	u32 saved_threadstorage[2];
+
+	cmdbuf[0]=IPC_MakeHeader(0x1F,0,6); // 0x1F0006
+	cmdbuf[1]=IPC_Desc_StaticBuffer(sizeof(udsNetworkStruct), 1);
+	cmdbuf[2]=(u32)network;
+	cmdbuf[3]=IPC_Desc_StaticBuffer(tagsize, 2);
+	cmdbuf[4]=(u32)tag0;
+	cmdbuf[5]=IPC_Desc_StaticBuffer(tagsize, 3);
+	cmdbuf[6]=(u32)tag1;
+
+	u32 * staticbufs = getThreadStaticBuffers();
+	saved_threadstorage[0] = staticbufs[0];
+	saved_threadstorage[1] = staticbufs[1];
+
+	staticbufs[0] = IPC_Desc_StaticBuffer(0x280,0);
+	staticbufs[1] = (u32)out;
+
+	Result ret=0;
+	ret=svcSendSyncRequest(__uds_servhandle);
+
+	staticbufs[0] = saved_threadstorage[0];
+	staticbufs[1] = saved_threadstorage[1];
+
+	if(R_FAILED(ret))return ret;
+
+	return cmdbuf[1];
+}
+
+static Result udsipc_SetProbeResponseParam(u32 oui, s8 data)
+{
+	u32* cmdbuf=getThreadCommandBuffer();
+
+	cmdbuf[0]=IPC_MakeHeader(0x21,2,0); // 0x210080
+	cmdbuf[1]=oui;
+	cmdbuf[2]=data;
+
+	Result ret=0;
+	if(R_FAILED(ret=svcSendSyncRequest(__uds_servhandle)))return ret;
+
+	return cmdbuf[1];
+}
+
+static Result udsipc_ScanOnConnection(u8 *outbuf, u32 maxsize, nwmScanInputStruct *scaninput, u32 wlancommID, u8 id8)
+{
+	u32* cmdbuf=getThreadCommandBuffer();
+
+	cmdbuf[0]=IPC_MakeHeader(0x22,16,2); // 0x220402
+	cmdbuf[1]=maxsize;
+	memcpy(&cmdbuf[2], scaninput, sizeof(nwmScanInputStruct));
+	cmdbuf[15]=wlancommID;
+	cmdbuf[16]=id8;
+	cmdbuf[17]=IPC_Desc_Buffer(maxsize, IPC_BUFFER_W);
+	cmdbuf[18]=(u32)outbuf;
+
+	Result ret=0;
+	if(R_FAILED(ret=svcSendSyncRequest(__uds_servhandle)))return ret;
+
+	return cmdbuf[1];
+}

--- a/code/src/utf16_to_utf8.c
+++ b/code/src/utf16_to_utf8.c
@@ -1,0 +1,50 @@
+#include "3ds/types.h"
+#include "3ds/util/utf.h"
+
+ssize_t
+utf16_to_utf8(uint8_t        *out,
+              const uint16_t *in,
+              size_t         len)
+{
+  ssize_t  rc = 0;
+  ssize_t  units;
+  uint32_t code;
+  uint8_t  encoded[4];
+
+  do
+  {
+    units = decode_utf16(&code, in);
+    if(units == -1)
+      return -1;
+
+    if(code > 0)
+    {
+      in += units;
+
+      units = encode_utf8(encoded, code);
+      if(units == -1)
+        return -1;
+
+      if(out != NULL)
+      {
+        if(rc + units <= len)
+        {
+          *out++ = encoded[0];
+          if(units > 1)
+            *out++ = encoded[1];
+          if(units > 2)
+            *out++ = encoded[2];
+          if(units > 3)
+            *out++ = encoded[3];
+        }
+      }
+
+      if(SSIZE_MAX - units >= rc)
+        rc += units;
+      else
+        return -1;
+    }
+  } while(code > 0);
+
+  return rc;
+}

--- a/code/src/utf8_to_utf16.c
+++ b/code/src/utf8_to_utf16.c
@@ -1,0 +1,46 @@
+#include "3ds/types.h"
+#include "3ds/util/utf.h"
+
+ssize_t
+utf8_to_utf16(uint16_t      *out,
+              const uint8_t *in,
+              size_t        len)
+{
+  ssize_t  rc = 0;
+  ssize_t  units;
+  uint32_t code;
+  uint16_t encoded[2];
+
+  do
+  {
+    units = decode_utf8(&code, in);
+    if(units == -1)
+      return -1;
+
+    if(code > 0)
+    {
+      in += units;
+
+      units = encode_utf16(encoded, code);
+      if(units == -1)
+        return -1;
+
+      if(out != NULL)
+      {
+        if(rc + units <= len)
+        {
+          *out++ = encoded[0];
+          if(units > 1)
+            *out++ = encoded[1];
+        }
+      }
+
+      if(SSIZE_MAX - units >= rc)
+        rc += units;
+      else
+        return -1;
+    }
+  } while(code > 0);
+
+  return rc;
+}

--- a/code/src/web.c
+++ b/code/src/web.c
@@ -1,0 +1,39 @@
+#include "web.h"
+#include "multiplayer.h"
+
+#define BgYdanSp_Update_addr 0x241EF8
+#define BgYdanSp_Update ((ActorFunc)BgYdanSp_Update_addr)
+
+#define BgYdanSp_FloorWebIdle (void*)0x19A8EC
+#define BgYdanSp_WallWebIdle (void*)0x181C88
+#define BgYdanSp_BurnFloorWeb (void*)0x19A52C
+#define BgYdanSp_BurnWallWeb (void*)0x181878
+#define BgYdanSp_FloorWebBreaking (void*)0x1E8438
+
+void BgYdanSp_rUpdate(BgYdanSp* thisx, GlobalContext* globalCtx) {
+    void* prev_action_fn = thisx->action_fn;
+    // home.pos gets changed when the action_fn updates, so the previous has to be used.
+    Vec3f prevHomePos = thisx->base.home.pos;
+
+    BgYdanSp_Update((Actor*)thisx, globalCtx);
+
+    if (prev_action_fn != thisx->action_fn && (prev_action_fn == BgYdanSp_FloorWebIdle || prev_action_fn == BgYdanSp_WallWebIdle)) {
+        BgYdanSp_SendData sendData = { prevHomePos, thisx->action_fn };
+        Multiplayer_Send_ActorUpdate((Actor*)thisx, &sendData, sizeof(BgYdanSp_SendData));
+    }
+}
+
+void BgYdanSp_SetActionFn(BgYdanSp* thisx, void* new_action_fn) {
+    if (thisx->action_fn != BgYdanSp_FloorWebIdle && thisx->action_fn != BgYdanSp_WallWebIdle) {
+        return;
+    }
+    if (new_action_fn == BgYdanSp_BurnFloorWeb || new_action_fn == BgYdanSp_BurnWallWeb) {
+        thisx->timer = 45;
+    } else if (new_action_fn == BgYdanSp_FloorWebBreaking) {
+        thisx->some_float = 200.0;
+        thisx->base.room = 0xFF;
+        thisx->base.flags |= 0x10;
+        thisx->timer = 60;
+    }
+    thisx->action_fn = new_action_fn;
+}

--- a/code/src/web.h
+++ b/code/src/web.h
@@ -1,0 +1,24 @@
+#ifndef _WEB_H_
+#define _WEB_H_
+
+#include "z3D/z3D.h"
+
+typedef struct {
+    Actor base;
+    char dyna[24];
+    void* action_fn;
+    char unk_1C0[36];
+    f32 some_float;
+    char unk_1E8[222];
+    u8 timer;
+} BgYdanSp;
+
+typedef struct {
+    Vec3f homePos;
+    void* action_fn;
+} BgYdanSp_SendData;
+
+void BgYdanSp_rUpdate(BgYdanSp* thisx, GlobalContext* globalCtx);
+void BgYdanSp_SetActionFn(BgYdanSp* thisx, void* new_action_fn);
+
+#endif //_WEB_H_

--- a/source/setting_descriptions.cpp
+++ b/source/setting_descriptions.cpp
@@ -813,6 +813,19 @@ string_view gkDurabilityRandomSafe    = "Each Giant's Knife will get a random du
                                         "between 10 and 50, with an average of 30.";       //
                                                                                            //
 /*------------------------------                                                           //
+|         MULTIPLAYER          |                                                           //
+------------------------------*/                                                           //
+string_view mp_EnabledDesc            = "Enables multiplayer.\n"                           //
+                                        "Other players will always be seen and heard\n"    //
+                                        "regardless of the other settings.";               //
+string_view mp_SharedProgressDesc     = "Progress and certain actors will be synced\n"     //
+                                        "between everyone who has this option on and the\n"//
+                                        "same seed hash.";                                 //
+string_view mp_SharedHealthDesc       = "Damage and recovery will be synced.";             //
+string_view mp_SharedRupeesDesc       = "Rupee gain and loss will be synced.";             //
+string_view mp_SharedAmmoDesc         = "Ammo gain and loss will be synced.";              //
+                                                                                           //
+/*------------------------------                                                           //
 |       INGAME DEFAULTS        |                                                           //
 ------------------------------*/                                                           //
 string_view zTargetingDesc            = "Sets L-Targeting to start as switch or hold.";    //

--- a/source/setting_descriptions.hpp
+++ b/source/setting_descriptions.hpp
@@ -266,6 +266,12 @@ extern string_view gkDurabilityVanilla;
 extern string_view gkDurabilityRandomRisk;
 extern string_view gkDurabilityRandomSafe;
 
+extern string_view mp_EnabledDesc;
+extern string_view mp_SharedProgressDesc;
+extern string_view mp_SharedHealthDesc;
+extern string_view mp_SharedRupeesDesc;
+extern string_view mp_SharedAmmoDesc;
+
 extern string_view zTargetingDesc;
 extern string_view cameraControlDesc;
 extern string_view motionControlDesc;

--- a/source/settings.cpp
+++ b/source/settings.cpp
@@ -725,6 +725,19 @@ namespace Settings {
     &GlitchTripleSlashClip,
   };
 
+  Option MP_Enabled        = Option::U8  ("Multiplayer",     {"Off", "On (Local)"}, {mp_EnabledDesc});
+  Option MP_SharedProgress = Option::Bool("Shared Progress", {"Off", "On"},         {mp_SharedProgressDesc});
+  Option MP_SharedHealth   = Option::Bool("Shared Health",   {"Off", "On"},         {mp_SharedHealthDesc});
+  Option MP_SharedRupees   = Option::Bool("Shared Rupees",   {"Off", "On"},         {mp_SharedRupeesDesc});
+  Option MP_SharedAmmo     = Option::Bool("Shared Ammo",     {"Off", "On"},         {mp_SharedAmmoDesc});
+  std::vector<Option*> multiplayerOptions = {
+    &MP_Enabled,
+    &MP_SharedProgress,
+    &MP_SharedHealth,
+    &MP_SharedRupees,
+    &MP_SharedAmmo,
+  };
+
   Option ZTargeting      = Option::U8("L-Targeting",        {"Switch", "Hold"},          {zTargetingDesc},      OptionCategory::Cosmetic, 1);
   Option CameraControl   = Option::U8("Camera Control",     {"Normal", "Invert Y-axis"}, {cameraControlDesc},   OptionCategory::Cosmetic);
   Option MotionControl   = Option::U8("Motion Control",     {"On", "Off"},               {motionControlDesc},   OptionCategory::Cosmetic);
@@ -880,6 +893,7 @@ namespace Settings {
   Menu miscSettings             = Menu::SubMenu("Misc Settings",              &miscOptions);
   Menu itemPoolSettings         = Menu::SubMenu("Item Pool Settings",         &itemPoolOptions);
   Menu itemUsabilitySettings    = Menu::SubMenu("Item Usability Settings",    &itemUsabilityOptions);
+  Menu multiplayerSettings      = Menu::SubMenu("Multiplayer Settings",       &multiplayerOptions);
   Menu ingameDefaults           = Menu::SubMenu("Ingame Defaults",            &ingameDefaultOptions);
   Menu cosmetics                = Menu::SubMenu("Cosmetic Settings",          &cosmeticOptions);
   Menu settingsPresets          = Menu::SubMenu("Settings Presets",           &settingsPresetItems);
@@ -897,6 +911,7 @@ namespace Settings {
     &miscSettings,
     &itemPoolSettings,
     &itemUsabilitySettings,
+    &multiplayerSettings,
     &ingameDefaults,
     &cosmetics,
     &settingsPresets,
@@ -1016,6 +1031,12 @@ namespace Settings {
     ctx.itemPoolValue        = ItemPoolValue.Value<u8>();
     ctx.iceTrapValue         = IceTrapValue.Value<u8>();
     ctx.progressiveGoronSword = (ProgressiveGoronSword) ? 1 : 0;
+
+    ctx.mp_Enabled           = MP_Enabled.Value<u8>();
+    ctx.mp_SharedProgress    = (MP_SharedProgress) ? 1 : 0;
+    ctx.mp_SharedAmmo        = (MP_SharedAmmo) ? 1 : 0;
+    ctx.mp_SharedHealth      = (MP_SharedHealth) ? 1 : 0;
+    ctx.mp_SharedRupees      = (MP_SharedRupees) ? 1 : 0;
 
     ctx.zTargeting           = ZTargeting.Value<u8>();
     ctx.cameraControl        = CameraControl.Value<u8>();
@@ -1220,6 +1241,9 @@ namespace Settings {
       op->SetToDefault();
     }
     for (auto op : glitchOptions) {
+      op->SetToDefault();
+    }
+    for (auto op : multiplayerOptions) {
       op->SetToDefault();
     }
 
@@ -1722,6 +1746,19 @@ namespace Settings {
           LogicShadowUmbrella.SetSelectedIndex(1);
           LogicGtgWithoutHookshot.SetSelectedIndex(1);
         }
+      }
+    }
+
+    // Multiplayer
+    for (auto op : multiplayerOptions) {
+      if (op == &MP_Enabled) {
+        continue;
+      }
+      if (MP_Enabled) {
+        op->Unhide();
+      } else {
+        op->Hide();
+        op->SetSelectedIndex(0);
       }
     }
 

--- a/source/settings.hpp
+++ b/source/settings.hpp
@@ -554,6 +554,13 @@ namespace Settings {
   extern Option GlitchLedgeClip;
   extern Option GlitchTripleSlashClip;
 
+  //Multiplayer Settings
+  extern Option MP_Enabled;
+  extern Option MP_SharedProgress;
+  extern Option MP_SharedHealth;
+  extern Option MP_SharedRupees;
+  extern Option MP_SharedAmmo;
+
   //Ingame Default Settings
   extern Option ZTargeting;
   extern Option CameraControl;


### PR DESCRIPTION
Uses the UDS service. Temporarily uses a special effect to show where other players are.

**How to use:**
To use, first enable the options in the app. When launching the game, it looks for any existing hosts. If none are found it creates a lobby itself. 
If shared progress is on, whoever is the first to join with a unique seed should load into their savefile first. 
It's possible for two groups of players, each group with their own seed, to see each other while only sharing progress with those with the same seed.

These are the options:
![image](https://user-images.githubusercontent.com/5352197/153521755-d24a1232-d523-4130-99ed-2fd6afe938d8.png)

Here's a clip that shows the temporary "soul" like effect, and how the web actor is synced between players:

https://user-images.githubusercontent.com/5352197/153521213-564c00ed-d730-4c26-a5d4-083f891c281f.mp4

 **Issues:**
More actors can be synced, but other than that...
- Items can be duplicated if they're collected from a location at the exact same time. Fixing this may take a lot of effort, but at least this isn't something that will make runs unbeatable.
- Citra has some issues: When a player quits the game they still count as connected, so rejoining won't work. There is a temporary workaround though, which is to rejoin the Citra lobby. This will however not reduce the connected player count, so this trick is only possible until the max count is reached.
- Another Citra issue is that it crashes when allowing too many players. The max should be 16, which it is on console, but this has been reduced to 8 on emulator.

Special thanks to the devkitPro team for the easy access to the service functions!