### PR TITLE
Add ingame "Ignore Mask Reaction" option

### DIFF
--- a/code/oot.ld
+++ b/code/oot.ld
@@ -816,6 +816,10 @@ SECTIONS
 		*(.patch_ModelSpawnGetObjectStatus)
 	}
 
+	.patch_IgnoreMaskReaction 0x36BBC4 : {
+		*(.patch_IgnoreMaskReaction)
+	}
+
 	.patch_SetBGMEvent 0x36EC40 : {
 		*(.patch_SetBGMEvent)
 	}

--- a/code/src/gfx_options.c
+++ b/code/src/gfx_options.c
@@ -4,6 +4,7 @@
 #include "savefile.h"
 #include "draw.h"
 #include "input.h"
+#include "common.h"
 
 #define BORDER_WIDTH 2
 #define CHOICE_COLUMN 240
@@ -17,7 +18,7 @@ typedef struct {
 } Option;
 
 s8 selectedOption;
-Option options[3];
+Option options[4];
 
 void InitOptions(void) {
     // BGM
@@ -40,13 +41,20 @@ void InitOptions(void) {
     strcpy(options[2].alternatives[1], "On");
     strcpy(options[2].description, "Prevents Navi from alerting you about advice.");
     options[2].optionPointer = &gExtSaveData.option_SilenceNavi;
+
+    // Ignore Mask Reaction
+    strcpy(options[3].name, "Ignore Mask Reaction");
+    strcpy(options[3].alternatives[0], "Off");
+    strcpy(options[3].alternatives[1], "On");
+    strcpy(options[3].description, "Causes NPCs to respond normally when wearing\nmasks. Does not apply to trade quest dialouges.");
+    options[3].optionPointer = &gExtSaveData.option_IgnoreMaskReaction;
 }
 
 void Gfx_DrawOptions(void) {
     Draw_DrawString(10, 16, COLOR_TITLE, "Options");
 
     // Options
-    for (u8 i = 0; i < sizeof(options) / sizeof(Option); i++) {
+    for (u8 i = 0; i < ARRAY_SIZE(options); i++) {
         Draw_DrawString(10, 16 + SPACING_Y + SPACING_Y * i, (i == selectedOption) ? COLOR_GREEN : COLOR_WHITE, options[i].name);
         Draw_DrawString(CHOICE_COLUMN, 16 + SPACING_Y + SPACING_Y * i, (i == selectedOption) ? COLOR_GREEN : COLOR_WHITE, options[i].alternatives[*options[i].optionPointer]);
     }
@@ -57,22 +65,22 @@ void Gfx_DrawOptions(void) {
     Draw_DrawString(10, DESCRIPTION_ROW, COLOR_WHITE, options[selectedOption].description);
 }
 
-void NextOption(const Option* option_) {
+void NextOption(const Option* option) {
     do {
-        *option_->optionPointer += 1;
-        if (*option_->optionPointer > (s8)(sizeof(option_->alternatives) / sizeof(option_->alternatives[0])) - 1) {
-            *option_->optionPointer = 0;
+        (*option->optionPointer)++;
+        if (*option->optionPointer > ARRAY_SIZE(option->alternatives) - 1) {
+            *option->optionPointer = 0;
         }
-    } while (strlen(option_->alternatives[*option_->optionPointer]) == 0);
+    } while (strlen(option->alternatives[*option->optionPointer]) == 0);
 }
 
-void PrevOption(const Option* option_) {
+void PrevOption(const Option* option) {
     do {
-        *option_->optionPointer -= 1;
-        if (*option_->optionPointer < 0) {
-            *option_->optionPointer = (s8)(sizeof(option_->alternatives) / sizeof(option_->alternatives[0])) - 1;
+        (*option->optionPointer)--;
+        if (*option->optionPointer < 0) {
+            *option->optionPointer = ARRAY_SIZE(option->alternatives) - 1;
         }
-    } while (strlen(option_->alternatives[*option_->optionPointer]) == 0);
+    } while (strlen(option->alternatives[*option->optionPointer]) == 0);
 }
 
 void Gfx_OptionsUpdate(void) {
@@ -85,9 +93,9 @@ void Gfx_OptionsUpdate(void) {
     }
 
     if (selectedOption < 0) {
+        selectedOption = ARRAY_SIZE(options) - 1;
+    } else if (selectedOption > ARRAY_SIZE(options) - 1) {
         selectedOption = 0;
-    } else if (selectedOption > (s8)(sizeof(options) / sizeof(Option)) - 1) {
-        selectedOption = (s8)(sizeof(options) / sizeof(Option)) - 1;
     }
 
     if (pressed & BUTTON_RIGHT) {

--- a/code/src/hooks.s
+++ b/code/src/hooks.s
@@ -1295,6 +1295,17 @@ hook_SendDroppedBottleContents:
     pop {r0-r12, lr}
     bx lr
 
+.global hook_IgnoreMaskReaction
+hook_IgnoreMaskReaction:
+    ldrh r0,[r0,#0x0]
+    push {r0-r12, lr}
+    cpy r0,r4
+    bl SaveFile_GetIgnoreMaskReactionOption
+    cmp r0,#0x1
+    pop {r0-r12, lr}
+    moveq r0,#0x0
+    b 0x36BBC8
+
 .section .loader
 .global hook_into_loader
 hook_into_loader:

--- a/code/src/patches.s
+++ b/code/src/patches.s
@@ -1780,6 +1780,11 @@ Multiplayer_OnLoadFile_patch:
 SendDroppedBottleContents_patch:
     bl hook_SendDroppedBottleContents
 
+.section .patch_IgnoreMaskReaction
+.global IgnoreMaskReaction_patch
+IgnoreMaskReaction_patch:
+    b hook_IgnoreMaskReaction
+
 .section .patch_loader
 .global loader_patch
 

--- a/code/src/savefile.c
+++ b/code/src/savefile.c
@@ -589,6 +589,14 @@ void SaveFile_SetOwnedTradeItemEquipped(void) {
     }
 }
 
+s8 SaveFile_GetIgnoreMaskReactionOption(u32 reactionSet) {
+    // This option somehow breaks talking to the Kakariko Mountain Gate guard, so use a workaround
+    if (reactionSet == 0x3C && PLAYER->currentMask == 1 && (gSaveContext.infTable[7] & 0x80) == 0) {
+        return 0;
+    }
+    return gExtSaveData.option_IgnoreMaskReaction;
+}
+
 void SaveFile_InitExtSaveData(u32 saveNumber) {
     gExtSaveData.version = EXTSAVEDATA_VERSION; // Do not change this line
     gExtSaveData.biggoronTrades = 0;
@@ -601,6 +609,7 @@ void SaveFile_InitExtSaveData(u32 saveNumber) {
     gExtSaveData.option_EnableBGM = gSettingsContext.playMusic;
     gExtSaveData.option_EnableSFX = gSettingsContext.playSFX;
     gExtSaveData.option_SilenceNavi = gSettingsContext.silenceNavi;
+    gExtSaveData.option_IgnoreMaskReaction = gSettingsContext.ignoreMaskReaction;
 }
 
 void SaveFile_LoadExtSaveData(u32 saveNumber) {

--- a/code/src/savefile.h
+++ b/code/src/savefile.h
@@ -25,7 +25,7 @@ void SaveFile_LoadExtSaveData(u32 saveNumber);
 void SaveFile_SaveExtSaveData(u32 saveNumber);
 
 // Increment the version number whenever the ExtSaveData structure is changed
-#define EXTSAVEDATA_VERSION 8
+#define EXTSAVEDATA_VERSION 9
 
 typedef struct {
     u32 version;            // Needs to always be the first field of the structure
@@ -48,6 +48,7 @@ typedef struct {
     s8 option_EnableBGM;
     s8 option_EnableSFX;
     s8 option_SilenceNavi;
+    s8 option_IgnoreMaskReaction;
 } ExtSaveData;
 
 #ifdef DECLARE_EXTSAVEDATA

--- a/code/src/settings.h
+++ b/code/src/settings.h
@@ -432,6 +432,7 @@ typedef struct {
   u8 playMusic;
   u8 playSFX;
   u8 silenceNavi;
+  u8 ignoreMaskReaction;
 
   u8 customTunicColors;
   u8 coloredKeys;

--- a/source/setting_descriptions.cpp
+++ b/source/setting_descriptions.cpp
@@ -835,6 +835,8 @@ string_view motionControlDesc         = "Sets the motion controls to start on or
 string_view togglePlayMusicDesc       = "Starts the game with the music on or off.";       //
 string_view togglePlaySFXDesc         = "Starts the game with the sound effects on or off.";
 string_view silenceNaviDesc           = "Sets whether Navi should start silenced or not."; //
+string_view ignoreMaskReactionDesc    = "Sets whether NPCs ignore the worn mask or not.\n" //
+                                        "Does not apply when trading masks.";              //
                                                                                            //
 /*------------------------------                                                           //
 |         COLORED KEYS         |                                                           //

--- a/source/setting_descriptions.hpp
+++ b/source/setting_descriptions.hpp
@@ -278,6 +278,7 @@ extern string_view motionControlDesc;
 extern string_view togglePlayMusicDesc;
 extern string_view togglePlaySFXDesc;
 extern string_view silenceNaviDesc;
+extern string_view ignoreMaskReactionDesc;
 
 extern string_view coloredKeysDesc;
 extern string_view coloredBossKeysDesc;

--- a/source/settings.cpp
+++ b/source/settings.cpp
@@ -738,12 +738,13 @@ namespace Settings {
     &MP_SharedAmmo,
   };
 
-  Option ZTargeting      = Option::U8("L-Targeting",        {"Switch", "Hold"},          {zTargetingDesc},      OptionCategory::Cosmetic, 1);
-  Option CameraControl   = Option::U8("Camera Control",     {"Normal", "Invert Y-axis"}, {cameraControlDesc},   OptionCategory::Cosmetic);
-  Option MotionControl   = Option::U8("Motion Control",     {"On", "Off"},               {motionControlDesc},   OptionCategory::Cosmetic);
-  Option TogglePlayMusic = Option::U8("Play Music",         {"Off", "On"},               {togglePlayMusicDesc}, OptionCategory::Cosmetic, 1);
-  Option TogglePlaySFX   = Option::U8("Play Sound Effects", {"Off", "On"},               {togglePlaySFXDesc},   OptionCategory::Cosmetic, 1);
-  Option SilenceNavi     = Option::U8("Silence Navi",       {"Off", "On"},               {silenceNaviDesc},     OptionCategory::Cosmetic);
+  Option ZTargeting         = Option::U8("L-Targeting",          {"Switch", "Hold"},          {zTargetingDesc},         OptionCategory::Cosmetic, 1);
+  Option CameraControl      = Option::U8("Camera Control",       {"Normal", "Invert Y-axis"}, {cameraControlDesc},      OptionCategory::Cosmetic);
+  Option MotionControl      = Option::U8("Motion Control",       {"On", "Off"},               {motionControlDesc},      OptionCategory::Cosmetic);
+  Option TogglePlayMusic    = Option::U8("Play Music",           {"Off", "On"},               {togglePlayMusicDesc},    OptionCategory::Cosmetic, 1);
+  Option TogglePlaySFX      = Option::U8("Play Sound Effects",   {"Off", "On"},               {togglePlaySFXDesc},      OptionCategory::Cosmetic, 1);
+  Option SilenceNavi        = Option::U8("Silence Navi",         {"Off", "On"},               {silenceNaviDesc},        OptionCategory::Cosmetic);
+  Option IgnoreMaskReaction = Option::U8("Ignore Mask Reaction", {"Off", "On"},               {ignoreMaskReactionDesc}, OptionCategory::Cosmetic);
   std::vector<Option*> ingameDefaultOptions = {
     &ZTargeting,
     &CameraControl,
@@ -751,6 +752,7 @@ namespace Settings {
     &TogglePlayMusic,
     &TogglePlaySFX,
     &SilenceNavi,
+    &IgnoreMaskReaction,
   };
 
   static std::vector<std::string> gauntletOptions = {
@@ -1044,6 +1046,7 @@ namespace Settings {
     ctx.playMusic            = TogglePlayMusic.Value<u8>();
     ctx.playSFX              = TogglePlaySFX.Value<u8>();
     ctx.silenceNavi          = SilenceNavi.Value<u8>();
+    ctx.ignoreMaskReaction   = IgnoreMaskReaction.Value<u8>();
 
     ctx.customTunicColors    = (CustomTunicColors) ? 1 : 0;
     ctx.mirrorWorld          = (MirrorWorld) ? 1 : 0;

--- a/source/settings.hpp
+++ b/source/settings.hpp
@@ -568,6 +568,7 @@ namespace Settings {
   extern Option TogglePlayMusic;
   extern Option TogglePlaySFX;
   extern Option SilenceNavi;
+  extern Option IgnoreMaskReaction;
 
   //Cosmetic Settings
   extern Option CustomTunicColors;


### PR DESCRIPTION
Causes NPCs to respond normally when wearing a mask. Does not apply when trading masks.

https://user-images.githubusercontent.com/5352197/165096330-9d6ea1d5-902a-4a00-a170-6ad315f25f2c.mp4

Also has some code improvements in `gfx_options.c`.