### PR TITLE
Destroy the hintstones on Citra as they cause huge lag

### DIFF
--- a/code/src/actor.c
+++ b/code/src/actor.c
@@ -204,6 +204,8 @@ void Actor_Init() {
 
     gActorOverlayTable[0x1D2].initInfo->update = (ActorFunc)ObjHamishi_rUpdate;
 
+    gActorOverlayTable[0x1D9].initInfo->update = EnHintstone_rUpdate;
+
     // Define object 4 to be by default the same as object 189
     strncpy(gObjectTable[OBJECT_CUSTOM_DOUBLE_DEFENSE].filename, gObjectTable[OBJECT_GI_HEARTS].filename, 0x40);
 

--- a/code/src/gossip_stone.c
+++ b/code/src/gossip_stone.c
@@ -1,5 +1,6 @@
 #include "gossip_stone.h"
 #include "z3D/z3D.h"
+#include "settings.h"
 
 #define EnGs_Init_addr 0x16461C
 #define EnGs_Init ((ActorFunc)EnGs_Init_addr)
@@ -18,4 +19,16 @@ void EnGs_rInit(Actor* thisx, GlobalContext* globalCtx) {
     }
 
     EnGs_Init(thisx, globalCtx);
+}
+
+#define EnHintstone_Update_addr 0x281834
+#define EnHintstone_Update ((ActorFunc)EnHintstone_Update_addr)
+
+void EnHintstone_rUpdate(Actor* thisx, GlobalContext* globalCtx) {
+    // Destroy the hintstones on Citra as they cause huge lag when entered
+    if (gSettingsContext.playOption == 1) {
+        Actor_Kill(thisx);
+        return;
+    }
+    EnHintstone_Update(thisx, globalCtx);
 }

--- a/code/src/gossip_stone.h
+++ b/code/src/gossip_stone.h
@@ -5,4 +5,6 @@
 
 void EnGs_rInit(Actor* thisx, GlobalContext* globalCtx);
 
+void EnHintstone_rUpdate(Actor* thisx, GlobalContext* globalCtx);
+
 #endif //_GOSSIP_STONE_H_


### PR DESCRIPTION
Users on weaker computers may think the game freezes completely, thinking they've lost a bunch of progress if they haven't saved for a while. Similar with multiplayer, users may have to restart if someone enters.

https://user-images.githubusercontent.com/5352197/165103867-b8c897ae-056f-4583-a147-f4c71c5491e5.mp4

