### PR TITLE
Multiplayer: Improve health/rupee/ammo syncing

### DIFF
--- a/source/setting_descriptions.cpp
+++ b/source/setting_descriptions.cpp
@@ -821,9 +821,12 @@ string_view mp_EnabledDesc            = "Enables multiplayer.\n"                
 string_view mp_SharedProgressDesc     = "Progress and certain actors will be synced\n"     //
                                         "between everyone who has this option on and the\n"//
                                         "same seed hash.";                                 //
-string_view mp_SharedHealthDesc       = "Damage and recovery will be synced.";             //
-string_view mp_SharedRupeesDesc       = "Rupee gain and loss will be synced.";             //
-string_view mp_SharedAmmoDesc         = "Ammo gain and loss will be synced.";              //
+string_view mp_SharedHealthDesc       = "Syncs health when shared progress is on,\n"       //
+                                        "otherwise just shares the damage and recovery.";  //
+string_view mp_SharedRupeesDesc       = "Syncs rupees when shared progress is on,\n"       //
+                                        "otherwise just shares the gain and loss.";        //
+string_view mp_SharedAmmoDesc         = "Syncs ammo when shared progress is on,\n"         //
+                                        "otherwise just shares the gain and loss.";        //
                                                                                            //
 /*------------------------------                                                           //
 |       INGAME DEFAULTS        |                                                           //


### PR DESCRIPTION
Directly syncs the new value instead of adding the diff when shared progress is on and receiving from a player in the same world.