### PR TITLE
Multiplayer: Fix key loss

### DIFF
--- a/code/include/z3D/z3D.h
+++ b/code/include/z3D/z3D.h
@@ -409,7 +409,9 @@ typedef struct GlobalContext {
     /* 0x3230 */ u32                   lightSettingsList_addr;
     /* 0x3234 */ char                  unk_3234[0x0824];
     /* 0x3A58 */ ObjectContext         objectCtx;
-    /* 0x43DC */ char                  unk_43DC[0x1824];
+    /* 0x43DC */ char                  unk_43DC[0x0854];
+    /* 0x4C30 */ u8                    roomNum;
+    /* 0x4C31 */ char                  unk_4C31[0x0FCF];
     /* 0x5C00 */ u8                    linkAgeOnLoad;
     /* 0x5C01 */ char                  unk_5C01[0x001B];
     /* 0x5C1C */ s16*                  setupExitList;

--- a/code/src/door.c
+++ b/code/src/door.c
@@ -31,6 +31,7 @@ void EnDoor_rUpdate(EnDoor* thisx, GlobalContext* globalCtx) {
     EnDoor_Update((Actor*)thisx, globalCtx);
 
     if (thisx->lock_timer != 0 && prev_action_fn == EnDoor_Idle && thisx->action_fn == EnDoor_Open) {
+        Multiplayer_Send_UnlockedDoor(thisx->base.params & 0x3F);
         Multiplayer_Send_ActorUpdate((Actor*)thisx, NULL, 0);
     }
 }
@@ -77,7 +78,15 @@ void DoorShutter_rUpdate(DoorShutter* thisx, GlobalContext* globalCtx) {
 
     DoorShutter_Update((Actor*)thisx, globalCtx);
 
+    // Don't sync chest minigame doors when the setting is off
+    if (globalCtx->sceneNum == 16 && gSettingsContext.shuffleChestMinigame == SHUFFLECHESTMINIGAME_OFF) {
+        return;
+    }
+
     if (thisx->lock_timer != 0 && prev_action_fn == DoorShutter_SlidingDoor_Idle && thisx->action_fn == DoorShutter_SlidingDoor_Open) {
+        if (thisx->door_type_maybe != 5) {
+            Multiplayer_Send_UnlockedDoor(thisx->base.params & 0x3F);
+        }
         Multiplayer_Send_ActorUpdate((Actor*)thisx, NULL, 0);
     }
 }
@@ -114,6 +123,7 @@ void DoorGerudo_rUpdate(DoorGerudo* thisx, GlobalContext* globalCtx) {
     DoorGerudo_Update((Actor*)thisx, globalCtx);
 
     if (thisx->lock_timer != 0 && prev_action_fn == DoorGerudo_Idle && thisx->action_fn == DoorGerudo_Unlocking) {
+        Multiplayer_Send_UnlockedDoor(thisx->base.params & 0x3F);
         Multiplayer_Send_ActorUpdate((Actor*)thisx, NULL, 0);
     }
 }

--- a/code/src/multiplayer.h
+++ b/code/src/multiplayer.h
@@ -54,6 +54,7 @@ void Multiplayer_Send_BiggoronTradeBit(u8 bit);
 void Multiplayer_Send_FullEntranceSync(u16 targetID);
 void Multiplayer_Send_DiscoveredScene(u32 index, u32 bit);
 void Multiplayer_Send_DiscoveredEntrance(u32 index, u32 bit);
+void Multiplayer_Send_UnlockedDoor(u32 flag);
 void Multiplayer_Send_ActorUpdate(Actor* actor, void* extraData, u32 extraDataSize);
 void Multiplayer_Send_ActorSpawn(s16 actorId, PosRot posRot, s16 params);
 // Etc

--- a/code/src/settings.h
+++ b/code/src/settings.h
@@ -449,6 +449,7 @@ typedef struct {
 
   u8 mp_Enabled;
   u8 mp_SharedProgress;
+  u8 mp_SyncId;
   u8 mp_SharedHealth;
   u8 mp_SharedRupees;
   u8 mp_SharedAmmo;

--- a/source/setting_descriptions.cpp
+++ b/source/setting_descriptions.cpp
@@ -920,9 +920,15 @@ string_view gkDurabilityRandomSafe    = "Each Giant's Knife will get a random du
 string_view mp_EnabledDesc            = "Enables multiplayer.\n"                           //
                                         "Other players will always be seen and heard\n"    //
                                         "regardless of the other settings.";               //
-string_view mp_SharedProgressDesc     = "Progress and certain actors will be synced\n"     //
-                                        "between everyone who has this option on and the\n"//
-                                        "same seed hash.";                                 //
+string_view mp_SharedProgressDesc     = "Progress and certain actors will be synced between"
+                                        "everyone in the network that has this option on,\n"
+                                        "the same seed hash, and the same sync id.";       //
+string_view mp_SyncIdDesc             = "Limits shared progress to only sync with other\n" //
+                                        "players that have the same sync ID. This is only\n"
+                                        "necessary to set if multiple groups of players\n" //
+                                        "play on the same seed hash, but only want to share"
+                                        "their progress with certan people.\n"             //
+                                        "For example, when doing a 2v2 race.";             //
 string_view mp_SharedHealthDesc       = "Syncs health when shared progress is on,\n"       //
                                         "otherwise just shares the damage and recovery.";  //
 string_view mp_SharedRupeesDesc       = "Syncs rupees when shared progress is on,\n"       //

--- a/source/setting_descriptions.hpp
+++ b/source/setting_descriptions.hpp
@@ -282,6 +282,7 @@ extern string_view gkDurabilityRandomSafe;
 
 extern string_view mp_EnabledDesc;
 extern string_view mp_SharedProgressDesc;
+extern string_view mp_SyncIdDesc;
 extern string_view mp_SharedHealthDesc;
 extern string_view mp_SharedRupeesDesc;
 extern string_view mp_SharedAmmoDesc;

--- a/source/settings.cpp
+++ b/source/settings.cpp
@@ -782,14 +782,16 @@ namespace Settings {
     &GlitchTripleSlashClip,
   };
 
-  Option MP_Enabled        = Option::U8  ("Multiplayer",     {"Off", "On (Local)"}, {mp_EnabledDesc});
-  Option MP_SharedProgress = Option::Bool("Shared Progress", {"Off", "On"},         {mp_SharedProgressDesc});
-  Option MP_SharedHealth   = Option::Bool("Shared Health",   {"Off", "On"},         {mp_SharedHealthDesc});
-  Option MP_SharedRupees   = Option::Bool("Shared Rupees",   {"Off", "On"},         {mp_SharedRupeesDesc});
-  Option MP_SharedAmmo     = Option::Bool("Shared Ammo",     {"Off", "On"},         {mp_SharedAmmoDesc});
+  Option MP_Enabled        = Option::U8  ("Multiplayer",     {"Off", "On (Local)"},                    {mp_EnabledDesc});
+  Option MP_SharedProgress = Option::Bool("Shared Progress", {"Off", "On"},                            {mp_SharedProgressDesc});
+  Option MP_SyncId         = Option::U8  ("  Sync ID",       {"1", "2", "3", "4", "5", "6", "7", "8"}, {mp_SyncIdDesc}, OptionCategory::Cosmetic);
+  Option MP_SharedHealth   = Option::Bool("Shared Health",   {"Off", "On"},                            {mp_SharedHealthDesc});
+  Option MP_SharedRupees   = Option::Bool("Shared Rupees",   {"Off", "On"},                            {mp_SharedRupeesDesc});
+  Option MP_SharedAmmo     = Option::Bool("Shared Ammo",     {"Off", "On"},                            {mp_SharedAmmoDesc});
   std::vector<Option*> multiplayerOptions = {
     &MP_Enabled,
     &MP_SharedProgress,
+    &MP_SyncId,
     &MP_SharedHealth,
     &MP_SharedRupees,
     &MP_SharedAmmo,
@@ -1114,6 +1116,7 @@ namespace Settings {
 
     ctx.mp_Enabled           = MP_Enabled.Value<u8>();
     ctx.mp_SharedProgress    = (MP_SharedProgress) ? 1 : 0;
+    ctx.mp_SyncId            = MP_SyncId.Value<u8>();
     ctx.mp_SharedAmmo        = (MP_SharedAmmo) ? 1 : 0;
     ctx.mp_SharedHealth      = (MP_SharedHealth) ? 1 : 0;
     ctx.mp_SharedRupees      = (MP_SharedRupees) ? 1 : 0;
@@ -1882,6 +1885,12 @@ namespace Settings {
         op->Hide();
         op->SetSelectedIndex(0);
       }
+    }
+    if (MP_SharedProgress) {
+      MP_SyncId.Unhide();
+    } else {
+      MP_SyncId.Hide();
+      MP_SyncId.SetSelectedIndex(0);
     }
 
     //Tunic Colors

--- a/source/settings.hpp
+++ b/source/settings.hpp
@@ -579,6 +579,7 @@ namespace Settings {
   //Multiplayer Settings
   extern Option MP_Enabled;
   extern Option MP_SharedProgress;
+  extern Option MP_SyncId;
   extern Option MP_SharedHealth;
   extern Option MP_SharedRupees;
   extern Option MP_SharedAmmo;


### PR DESCRIPTION
This should make it impossible to lose keys when opening the same door at the same time.
Also fixes chest minigame doors, keys, and chests syncing when that shuffle setting was off.

Marked as draft as it's based on #510 and it's code improvements.