### PR TITLE
Bug fixes

### DIFF
--- a/code/include/z3D/z3D.h
+++ b/code/include/z3D/z3D.h
@@ -525,11 +525,11 @@ typedef void (*DisplayTextbox_proc)(GlobalContext* globalCtx, u16 textId, Actor*
 #define DisplayTextbox_addr 0x367C7C
 #define DisplayTextbox ((DisplayTextbox_proc)DisplayTextbox_addr)
 
-typedef u32 (*EventCheck_proc)(u32 param_1);
+typedef u32 (*EventCheck_proc)(u32 flag);
 #define EventCheck_addr 0x350CF4
 #define EventCheck ((EventCheck_proc)EventCheck_addr)
 
-typedef void (*EventSet_proc)(u32 param_1);
+typedef void (*EventSet_proc)(u32 flag);
 #define EventSet_addr 0x34CBF8
 #define EventSet ((EventSet_proc)EventSet_addr)
 

--- a/code/include/z3D/z3D.h
+++ b/code/include/z3D/z3D.h
@@ -169,7 +169,8 @@ typedef struct {
     /* 0x156F */ u8           buttonStatus[5];
     /* 0x1574 */ char         unk_1574[0x000F];
     /* 0x1584 */ u16          magicMeterSize;
-    /* 0x1586 */ char         unk_1586[0x000C];
+    /* 0x1586 */ char         unk_1586[0x0004];
+    /* 0x158A */ u16          eventInf[4];
     /* 0x1592 */ u16          dungeonIndex;
     /* 0x1594 */ char         unk_1594[0x000C];
     /* 0x15A0 */ u16          nextCutsceneIndex;

--- a/code/oot.ld
+++ b/code/oot.ld
@@ -312,12 +312,8 @@ SECTIONS
 		*(.patch_DampeChest)
 	}
 
-	.patch_JabuJabuItemGive 0x1A1918 : {
-		*(.patch_JabuJabuItemGive)
-	}
-
-	.patch_JabuJabuCutsceneOverride 0x1A192C : {
-		*(.patch_JabuJabuCutsceneOverride)
+	.patch_RutoBlueWarpOverride 0x1A1900 : {
+		*(.patch_RutoBlueWarpOverride)
 	}
 
 	.patch_KotakeDontPlayBattleMusic 0x1A8218 : {
@@ -388,52 +384,8 @@ SECTIONS
 		*(.patch_BombchuShopAlwaysOpen)
 	}
 
-	.patch_ForestTempleItemGive 0x1E3F84 : {
-		*(.patch_ForestTempleItemGive)
-	}
-
-	.patch_ForestTempleCutsceneOverride 0x1E3F98 : {
-		*(.patch_ForestTempleCutsceneOverride)
-	}
-
-	.patch_FireTempleItemGive 0x1E4010 : {
-		*(.patch_FireTempleItemGive)
-	}
-
-	.patch_FireTempleCutsceneOverride 0x1E4024 : {
-		*(.patch_FireTempleCutsceneOverride)
-	}
-
-	.patch_WaterTempleItemGive 0x1E40D8 : {
-		*(.patch_WaterTempleItemGive)
-	}
-
-	.patch_WaterTempleCutsceneOverride 0x1E40EC : {
-		*(.patch_WaterTempleCutsceneOverride)
-	}
-
-	.patch_SpiritTempleCompleteCheck 0x1E415C : {
-		*(.patch_SpiritTempleCompleteCheck)
-	}
-
-	.patch_SpiritTempleItemGive 0x1E4168 : {
-		*(.patch_SpiritTempleItemGive)
-	}
-
-	.patch_SpiritTempleCutsceneOverride 0x1E417C : {
-		*(.patch_SpiritTempleCutsceneOverride)
-	}
-
-	.patch_ShadowTempleCompleteCheck 0x1E41E4 : {
-		*(.patch_ShadowTempleCompleteCheck)
-	}
-
-	.patch_ShadowTempleItemGive 0x1E41F0 : {
-		*(.patch_ShadowTempleItemGive)
-	}
-
-	.patch_ShadowTempleCutsceneOverride 0x1E4204 : {
-		*(.patch_ShadowTempleCutsceneOverride)
+	.patch_AdultBlueWarpOverride 0x1E3F50 : {
+		*(.patch_AdultBlueWarpOverride)
 	}
 
 	.patch_DaruniaCheckStrength 0x1E489C : {
@@ -532,10 +484,6 @@ SECTIONS
 		*(.patch_EnExItemModelDraw)
 	}
 
-	.patch_SpiritTempleItemGiveTwo 0x24CF4C : {
-		*(.patch_SpiritTempleItemGiveTwo)
-	}
-
 	.patch_MultiplyPlayerSpeed 0x251D34 : {
 		*(.patch_MultiplyPlayerSpeed)
 	}
@@ -560,20 +508,12 @@ SECTIONS
 		*(.patch_CheckGerudoToken_269884)
 	}
 
-	.patch_SpiritTempleItemGiveThree 0x26B33C : {
-		*(.patch_SpiritTempleItemGiveThree)
-	}
-
 	.patch_MinuetLocation 0x26C388 : {
 		*(.patch_MinuetLocation)
 	}
 
 	.patch_BoleroLocation 0x26C448 : {
 		*(.patch_BoleroLocation)
-	}
-
-	.patch_WaterTempleItemGiveTwo 0x26DCD4 : {
-		*(.patch_WaterTempleItemGiveTwo)
 	}
 
 	.patch_BrownBoulderExplode 0x26F9F8 : {
@@ -592,24 +532,8 @@ SECTIONS
 		*(.patch_DoorOfTimeCheck)
 	}
 
-	.patch_FireTempleItemGiveThree 0x27D060 : {
-		*(.patch_FireTempleItemGiveThree)
-	}
-
-	.patch_ShadowTempleItemGiveTwo 0x27DED0 : {
-		*(.patch_ShadowTempleItemGiveTwo)
-	}
-
 	.patch_ImpaInCourtyardCheckForVisitedZelda 0x27DEF8 : {
 		*(.patch_ImpaInCourtyardCheckForVisitedZelda)
-	}
-
-	.patch_ForestTempleItemGiveTwo 0x27E074 : {
-		*(.patch_ForestTempleItemGiveTwo)
-	}
-
-	.patch_WaterTempleItemGiveThree 0x283CA8 : {
-		*(.patch_WaterTempleItemGiveThree)
 	}
 
 	.patch_AnjuGiveCojiro 0x2884F4 : {
@@ -622,18 +546,6 @@ SECTIONS
 
 	.patch_KakarikoGateCheck 0x28A678 : {
 		*(.patch_KakarikoGateCheck)
-	}
-
-	.patch_FireTempleItemGiveFour 0x28E2AC : {
-		*(.patch_FireTempleItemGiveFour)
-	}
-
-	.patch_ShadowTempleItemGiveThree 0x28F258 : {
-		*(.patch_ShadowTempleItemGiveThree)
-	}
-
-	.patch_ForestTempleItemGiveThree 0x28FF44 : {
-		*(.patch_ForestTempleItemGiveThree)
 	}
 
 	.patch_BombchuBowlingAlwaysFirstPrize 0x291924 : {
@@ -1072,20 +984,8 @@ SECTIONS
 		*(.patch_SlidingDoorDestroyCustomModels)
 	}
 
-	.patch_DodongosCavernItemGive 0x3F57B0 : {
-		*(.patch_DodongosCavernItemGive)
-	}
-
-	.patch_DodongosCavernCutsceneOverride 0x3F57C4 : {
-		*(.patch_DodongosCavernCutsceneOverride)
-	}
-
-	.patch_DekuTreeItemGive 0x3F582C : {
-		*(.patch_DekuTreeItemGive)
-	}
-
-	.patch_DekuTreeCutsceneOverride 0x3F5840 : {
-		*(.patch_DekuTreeCutsceneOverride)
+	.patch_ChildBlueWarpOverride 0x3F5774 : {
+		*(.patch_ChildBlueWarpOverride)
 	}
 
 	.patch_CarpetSalesmanSetFlag 0x3F9550 : {
@@ -1286,10 +1186,6 @@ SECTIONS
 
 	.patch_SwapAgeIgnoreSceneSetup 0x4918B0 : {
 		*(.patch_SwapAgeIgnoreSceneSetup)
-	}
-
-	.patch_FireTempleItemGiveTwo 0x491B60 : {
-		*(.patch_FireTempleItemGiveTwo)
 	}
 
 	.patch_FairyUseHealAmount 0x4968B4 : {

--- a/code/oot.ld
+++ b/code/oot.ld
@@ -444,6 +444,10 @@ SECTIONS
 		*(.patch_BugsRecatchable)
 	}
 
+	.patch_WaterSpoutMasterQuestCheck 0x212BDC : {
+		*(.patch_WaterSpoutMasterQuestCheck)
+	}
+
 	.patch_DekuSproutCheckForest 0x2153A4 : {
 		*(.patch_DekuSproutCheckForest)
 	}

--- a/code/oot.ld
+++ b/code/oot.ld
@@ -772,6 +772,10 @@ SECTIONS
 		*(.patch_BiggoronDayCheck)
 	}
 
+	.patch_MasterQuestGoldSkulltulaCheck 0x3415C8 : {
+		*(.patch_MasterQuestGoldSkulltulaCheck)
+	}
+
 	.patch_TurboTextSignalNPC 0x3469F4 : {
 		*(.patch_TurboTextSignalNPC)
 	}

--- a/code/src/cutscenes.c
+++ b/code/src/cutscenes.c
@@ -190,13 +190,17 @@ void Cutscene_OverrideFairyReward(BgDyYoseizo* fairy) {
 
 // skip dungeon exit cutscenes
 void Cutscene_OverrideDekuTree(void) {
-    ItemOverride_PushDungeonReward(DUNGEON_DEKU_TREE);
-    gSaveContext.eventChkInf[0x1] |= 0x1000; // spoke to Mido after Deku Tree's death
+    if (EventCheck(0x7) == 0) {
+        EventSet(0x7);
+        EventSet(0x9);
+        ItemOverride_PushDungeonReward(DUNGEON_DEKU_TREE);
+        gSaveContext.eventChkInf[0x1] |= 0x1000; // spoke to Mido after Deku Tree's death
 
-    // If warping with FW, let the wrong warp work
-    if (gSaveContext.respawnFlag == 3) {
-        gSaveContext.nextCutsceneIndex = 0xFFF1;
-        return;
+        // If warping with FW, let the wrong warp work
+        if (gSaveContext.respawnFlag == 3) {
+            gSaveContext.nextCutsceneIndex = 0xFFF1;
+            return;
+        }
     }
     gGlobalContext->nextEntranceIndex = Entrance_OverrideNextIndex(0x457);
     gGlobalContext->sceneLoadFlag = 0x14;
@@ -205,12 +209,15 @@ void Cutscene_OverrideDekuTree(void) {
 }
 
 void Custcene_OverrideDodongosCavern(void) {
-    ItemOverride_PushDungeonReward(DUNGEON_DODONGOS_CAVERN);
+    if (EventCheck(0x25) == 0) {
+        EventSet(0x25);
+        ItemOverride_PushDungeonReward(DUNGEON_DODONGOS_CAVERN);
 
-    // If warping with FW, let the wrong warp work
-    if (gSaveContext.respawnFlag == 3) {
-        gSaveContext.nextCutsceneIndex = 0xFFF1;
-        return;
+        // If warping with FW, let the wrong warp work
+        if (gSaveContext.respawnFlag == 3) {
+            gSaveContext.nextCutsceneIndex = 0xFFF1;
+            return;
+        }
     }
     gGlobalContext->nextEntranceIndex = Entrance_OverrideNextIndex(0x47A);
     gGlobalContext->sceneLoadFlag = 0x14;
@@ -219,13 +226,16 @@ void Custcene_OverrideDodongosCavern(void) {
 }
 
 void Custcene_OverrideJabuJabusBelly(void) {
-    ItemOverride_PushDungeonReward(DUNGEON_JABUJABUS_BELLY);
+    if (EventCheck(0x37) == 0) {
+        EventSet(0x37);
+        ItemOverride_PushDungeonReward(DUNGEON_JABUJABUS_BELLY);
 
-    // If warping with FW, let the wrong warp work
-    //(this code will never be executed lol)
-    if (gSaveContext.respawnFlag == 3) {
-        gSaveContext.nextCutsceneIndex = 0xFFF0;
-        return;
+        // If warping with FW, let the wrong warp work
+        //(this code will never be executed lol)
+        if (gSaveContext.respawnFlag == 3) {
+            gSaveContext.nextCutsceneIndex = 0xFFF0;
+            return;
+        }
     }
     gGlobalContext->nextEntranceIndex = Entrance_OverrideNextIndex(0x221);
     gGlobalContext->sceneLoadFlag = 0x14;
@@ -234,21 +244,27 @@ void Custcene_OverrideJabuJabusBelly(void) {
 }
 
 void Custcene_OverrideForestTemple(void) {
+    if (EventCheck(0x48) == 0) {
+        EventSet(0x48);
+        ItemOverride_PushDungeonReward(DUNGEON_FOREST_TEMPLE);
+    }
     gGlobalContext->nextEntranceIndex = Entrance_OverrideNextIndex(0x608);
     gGlobalContext->sceneLoadFlag = 0x14;
     gGlobalContext->fadeOutTransition = 0x3;
     gSaveContext.nextCutsceneIndex = 0x0;
-    ItemOverride_PushDungeonReward(DUNGEON_FOREST_TEMPLE);
 }
 
 void Cutscene_OverrideFireTemple(void) {
-    ItemOverride_PushDungeonReward(DUNGEON_FIRE_TEMPLE);
-    gSaveContext.eventChkInf[2] |= 0x8000; // Death Mountain cloud is normal again
+    if (EventCheck(0x49) == 0) {
+        EventSet(0x49);
+        ItemOverride_PushDungeonReward(DUNGEON_FIRE_TEMPLE);
+        gSaveContext.eventChkInf[2] |= 0x8000; // Death Mountain cloud is normal again
 
-    // If warping with FW, let the wrong warp work
-    if (gSaveContext.respawnFlag == 3) {
-        gSaveContext.nextCutsceneIndex = 0xFFF3;
-        return;
+        // If warping with FW, let the wrong warp work
+        if (gSaveContext.respawnFlag == 3) {
+            gSaveContext.nextCutsceneIndex = 0xFFF3;
+            return;
+        }
     }
     gGlobalContext->nextEntranceIndex = Entrance_OverrideNextIndex(0x564);
     gGlobalContext->sceneLoadFlag = 0x14;
@@ -257,32 +273,64 @@ void Cutscene_OverrideFireTemple(void) {
 }
 
 void Custcene_OverrideWaterTemple(void) {
+    if (EventCheck(0x4A) == 0) {
+        EventSet(0x4A);
+        ItemOverride_PushDungeonReward(DUNGEON_WATER_TEMPLE);
+        gSaveContext.eventChkInf[6] |= 0x0200; // Raise Lake Hylia's Water
+    }
     gGlobalContext->nextEntranceIndex = Entrance_OverrideNextIndex(0x60C);
     gGlobalContext->sceneLoadFlag = 0x14;
     gGlobalContext->fadeOutTransition = 0x3;
     gSaveContext.nextCutsceneIndex = 0x0;
-    ItemOverride_PushDungeonReward(DUNGEON_WATER_TEMPLE);
-    gSaveContext.eventChkInf[6] |= 0x0200; // Raise Lake Hylia's Water
 }
 
 void Custcene_OverrideSpiritTemple(void) {
+    if (EventCheck(0x47) == 0) {
+        EventSet(0x47);
+        ItemOverride_PushDungeonReward(DUNGEON_SPIRIT_TEMPLE);
+    }
     gGlobalContext->nextEntranceIndex = Entrance_OverrideNextIndex(0x610);
     gGlobalContext->sceneLoadFlag = 0x14;
     gGlobalContext->fadeOutTransition = 0x3;
     gSaveContext.nextCutsceneIndex = 0x0;
-    if (EventCheck(0x47) == 0) {
-        ItemOverride_PushDungeonReward(DUNGEON_SPIRIT_TEMPLE);
-        EventSet(0x47);
-    }
 }
 
 void Custcene_OverrideShadowTemple(void) {
+    if (EventCheck(0x46) == 0) {
+        EventSet(0x46);
+        ItemOverride_PushDungeonReward(DUNGEON_SHADOW_TEMPLE);
+    }
     gGlobalContext->nextEntranceIndex = Entrance_OverrideNextIndex(0x580);
     gGlobalContext->sceneLoadFlag = 0x14;
     gGlobalContext->fadeOutTransition = 0x3;
     gSaveContext.nextCutsceneIndex = 0x0;
-    if (EventCheck(0x46) == 0) {
-        ItemOverride_PushDungeonReward(DUNGEON_SHADOW_TEMPLE);
-        EventSet(0x46);
+}
+
+void Cutscene_BlueWarpOverride(void) {
+    switch (gGlobalContext->sceneNum - 0x11) { // dungeon index from boss room scene
+        case DUNGEON_DEKU_TREE:
+            Cutscene_OverrideDekuTree();
+            break;
+        case DUNGEON_DODONGOS_CAVERN:
+            Custcene_OverrideDodongosCavern();
+            break;
+        case DUNGEON_JABUJABUS_BELLY:
+            Custcene_OverrideJabuJabusBelly();
+            break;
+        case DUNGEON_FOREST_TEMPLE:
+            Custcene_OverrideForestTemple();
+            break;
+        case DUNGEON_FIRE_TEMPLE:
+            Cutscene_OverrideFireTemple();
+            break;
+        case DUNGEON_WATER_TEMPLE:
+            Custcene_OverrideWaterTemple();
+            break;
+        case DUNGEON_SPIRIT_TEMPLE:
+            Custcene_OverrideSpiritTemple();
+            break;
+        case DUNGEON_SHADOW_TEMPLE:
+            Custcene_OverrideShadowTemple();
+            break;
     }
 }

--- a/code/src/entrance.c
+++ b/code/src/entrance.c
@@ -12,10 +12,6 @@ typedef void (*SetNextEntrance_proc)(struct GlobalContext* globalCtx, s16 entran
 #define SetNextEntrance_addr 0x3716F0
 #define SetNextEntrance ((SetNextEntrance_proc)SetNextEntrance_addr)
 
-typedef void (*SetEventChkInf_proc)(u32 flag);
-#define SetEventChkInf_addr 0x34CBF8
-#define SetEventChkInf ((SetEventChkInf_proc)SetEventChkInf_addr)
-
 #define dynamicExitList_addr 0x53C094
 #define dynamicExitList ((s16*)dynamicExitList_addr) // = { 0x045B, 0x0482, 0x0340, 0x044B, 0x02A2, 0x0201, 0x03B8, 0x04EE, 0x03C0, 0x0463, 0x01CD, 0x0394, 0x0340, 0x057C }
 
@@ -345,7 +341,7 @@ u8 EntranceCutscene_ShouldPlay(u8 flag) {
         }
         return 1; // cutscene will play normally in DHWW, or always if it's freeing Epona or clearing a Trial
     }
-    SetEventChkInf(flag);
+    EventSet(flag);
     return 0; //cutscene will not play
 }
 

--- a/code/src/entrance.c
+++ b/code/src/entrance.c
@@ -70,7 +70,7 @@ void Scene_Init(void) {
     gRestrictionFlags[94].flags3 = 0; // Allows farore's wind in Ganon's Castle
 }
 
-static void Entrance_SeparateOGCFairyFountainExit() {
+static void Entrance_SeparateOGCFairyFountainExit(void) {
     //Overwrite unused entrance 0x03E8 with values from 0x0340 to use it as the
     //exit from OGC Great Fairy Fountain -> Castle Grounds
     for (size_t i = 0; i < 4; ++i) {
@@ -191,6 +191,11 @@ s16 Entrance_GetOverride(s16 index) {
 }
 
 s16 Entrance_OverrideNextIndex(s16 nextEntranceIndex) {
+    // When entering Spirit Temple, clear temp flags so they don't carry over to the randomized dungeon
+    if (nextEntranceIndex == 0x0082 && Entrance_GetOverride(nextEntranceIndex) != nextEntranceIndex) {
+        gGlobalContext->actorCtx.flags.tempSwch = 0;
+        gGlobalContext->actorCtx.flags.tempCollect = 0;
+    }
     SaveFile_SetEntranceDiscovered(nextEntranceIndex);
     return Grotto_CheckSpecialEntrance(Entrance_GetOverride(nextEntranceIndex));
 }
@@ -311,7 +316,7 @@ void Entrance_SetSavewarpEntrance(void) {
     }
 }
 
-void EnableFW() {
+void EnableFW(void) {
     // Leave restriction in Tower Collapse Interior, Castle Collapse, Treasure Box Shop, Tower Collapse Exterior,
     // Grottos area, Fishing Pond, Ganon Battle and for states that disable buttons.
     if (!gSettingsContext.faroresWindAnywhere ||
@@ -344,7 +349,7 @@ u8 EntranceCutscene_ShouldPlay(u8 flag) {
     return 0; //cutscene will not play
 }
 
-void Entrance_CheckEpona() {
+void Entrance_CheckEpona(void) {
     s32 entrance = gGlobalContext->nextEntranceIndex;
     //If Link is riding Epona but he's about to go through an entrance where she can't spawn,
     //unset the Epona flag to avoid Master glitch, and restore temp B.

--- a/code/src/hooks.s
+++ b/code/src/hooks.s
@@ -1370,6 +1370,14 @@ hook_IgnoreMaskReaction:
     moveq r0,#0x0
     b 0x36BBC8
 
+.global hook_MasterQuestGoldSkulltulaCheck
+hook_MasterQuestGoldSkulltulaCheck:
+    push {r0-r5,r7-r12, lr}
+    bl EnSw_IsMasterQuestSkulltula
+    cpy r6,r0
+    pop {r0-r5,r7-r12, lr}
+    b 0x3415CC
+
 .section .loader
 .global hook_into_loader
 hook_into_loader:

--- a/code/src/hooks.s
+++ b/code/src/hooks.s
@@ -1373,10 +1373,17 @@ hook_IgnoreMaskReaction:
 .global hook_MasterQuestGoldSkulltulaCheck
 hook_MasterQuestGoldSkulltulaCheck:
     push {r0-r5,r7-r12, lr}
-    bl EnSw_IsMasterQuestSkulltula
+    bl Settings_IsMasterQuestDungeon
     cpy r6,r0
     pop {r0-r5,r7-r12, lr}
     b 0x3415CC
+
+.global hook_WaterSpoutMasterQuestCheck
+hook_WaterSpoutMasterQuestCheck:
+    push {r1-r12, lr}
+    bl Settings_IsMasterQuestDungeon
+    pop {r1-r12, lr}
+    bx lr
 
 .section .loader
 .global hook_into_loader

--- a/code/src/patches.s
+++ b/code/src/patches.s
@@ -1825,6 +1825,11 @@ SendDroppedBottleContents_patch:
 IgnoreMaskReaction_patch:
     b hook_IgnoreMaskReaction
 
+.section .patch_MasterQuestGoldSkulltulaCheck
+.global MasterQuestGoldSkulltulaCheck_patch
+MasterQuestGoldSkulltulaCheck_patch:
+    b hook_MasterQuestGoldSkulltulaCheck
+
 .section .patch_loader
 .global loader_patch
 

--- a/code/src/patches.s
+++ b/code/src/patches.s
@@ -514,163 +514,29 @@ Kokiri_CheckOpenForest_patch:
 BombchuBowlingStaticReward_patch:
     b 0x20618C
 
-.section .patch_DekuTreeItemGive
-.global DekuTreeItemGive_patch
-DekuTreeItemGive_patch:
-    nop
+.section .patch_ChildBlueWarpOverride
+.global ChildBlueWarpOverride_patch
+ChildBlueWarpOverride_patch:
+    push {r0-r12, lr}
+    bl Cutscene_BlueWarpOverride
+    pop {r0-r12, lr}
+    b 0x3F58A8
 
-.section .patch_DekuTreeCutsceneOverride
-.global DekuTreeCutsceneOverride_patch
-DekuTreeCutsceneOverride_patch:
-    bl Cutscene_OverrideDekuTree
-    nop
+.section .patch_RutoBlueWarpOverride
+.global RutoBlueWarpOverride_patch
+RutoBlueWarpOverride_patch:
+    push {r0-r12, lr}
+    bl Cutscene_BlueWarpOverride
+    pop {r0-r12, lr}
+    b 0x1A1944
 
-.section .patch_DodongosCavernItemGive
-.global DodongosCavernItemGive_patch
-DodongosCavernItemGive_patch:
-    nop
-
-.section .patch_DodongosCavernCutsceneOverride
-.global DodongosCavernCutsceneOverride_patch
-DodongosCavernCutsceneOverride_patch:
-    bl Custcene_OverrideDodongosCavern
-    nop
-
-.section .patch_JabuJabuItemGive
-.global JabuJabuItemGive_patch
-JabuJabuItemGive_patch:
-    nop
-
-.section .patch_JabuJabuCutsceneOverride
-.global JabuJabuCutsceneOverride_patch
-JabuJabuCutsceneOverride_patch:
-    bl Custcene_OverrideJabuJabusBelly
-    nop
-    nop
-
-.section .patch_ForestTempleItemGive
-.global ForestTempleItemGive_patch
-ForestTempleItemGive_patch:
-    nop
-
-.section .patch_ForestTempleItemGiveTwo
-.global ForestTempleItemGiveTwo_patch
-ForestTempleItemGiveTwo_patch:
-    nop
-
-.section .patch_ForestTempleItemGiveThree
-.global ForestTempleItemGiveThree_patch
-ForestTempleItemGiveThree_patch:
-    nop
-
-.section .patch_ForestTempleCutsceneOverride
-.global ForestTempleCutsceneOverride_patch
-ForestTempleCutsceneOverride_patch:
-    bl Custcene_OverrideForestTemple
-    nop
-    nop
-
-.section .patch_FireTempleItemGive
-.global FireTempleItemGive_patch
-FireTempleItemGive_patch:
-    nop
-
-.section .patch_FireTempleItemGiveTwo
-.global FireTempleItemGiveTwo_patch
-FireTempleItemGiveTwo_patch:
-    nop
-
-.section .patch_FireTempleItemGiveThree
-.global FireTempleItemGiveThree_patch
-FireTempleItemGiveThree_patch:
-    nop
-
-.section .patch_FireTempleItemGiveFour
-.global FireTempleItemGiveFour_patch
-FireTempleItemGiveFour_patch:
-    nop
-
-.section .patch_FireTempleCutsceneOverride
-.global FireTempleCutsceneOverride_patch
-FireTempleCutsceneOverride_patch:
-    bl Cutscene_OverrideFireTemple
-    nop
-    nop
-
-.section .patch_WaterTempleItemGive
-.global WaterTempleItemGive_patch
-WaterTempleItemGive_patch:
-    nop
-
-.section .patch_WaterTempleItemGiveTwo
-.global WaterTempleItemGiveTwo_patch
-WaterTempleItemGiveTwo_patch:
-    nop
-
-.section .patch_WaterTempleItemGiveThree
-.global WaterTempleItemGiveThree_patch
-WaterTempleItemGiveThree_patch:
-    nop
-
-.section .patch_WaterTempleCutsceneOverride
-.global WaterTempleCutsceneOverride_patch
-WaterTempleCutsceneOverride_patch:
-    bl Custcene_OverrideWaterTemple
-    nop
-    nop
-    nop
-
-.section .patch_SpiritTempleItemGive
-.global SpiritTempleItemGive_patch
-SpiritTempleItemGive_patch:
-    nop
-
-.section .patch_SpiritTempleItemGiveTwo
-.global SpiritTempleItemGiveTwo_patch
-SpiritTempleItemGiveTwo_patch:
-    nop
-
-.section .patch_SpiritTempleItemGiveThree
-.global SpiritTempleItemGiveThree_patch
-SpiritTempleItemGiveThree_patch:
-    nop
-
-.section .patch_SpiritTempleCompleteCheck
-.global SpiritTempleCompleteCheck_patch
-SpiritTempleCompleteCheck_patch:
-    nop
-
-.section .patch_SpiritTempleCutsceneOverride
-.global SpiritTempleCutsceneOverride_patch
-SpiritTempleCutsceneOverride_patch:
-    bl Custcene_OverrideSpiritTemple
-    nop
-
-.section .patch_ShadowTempleItemGive
-.global ShadowTempleItemGive_patch
-ShadowTempleItemGive_patch:
-    nop
-
-.section .patch_ShadowTempleItemGiveTwo
-.global ShadowTempleItemGiveTwo_patch
-ShadowTempleItemGiveTwo_patch:
-    nop
-
-.section .patch_ShadowTempleItemGiveThree
-.global ShadowTempleItemGiveThree_patch
-ShadowTempleItemGiveThree_patch:
-    nop
-
-.section .patch_ShadowTempleCompleteCheck
-.global ShadowTempleCompleteCheck_patch
-ShadowTempleCompleteCheck_patch:
-    nop
-
-.section .patch_ShadowTempleCutsceneOverride
-.global ShadowTempleCutsceneOverride_patch
-ShadowTempleCutsceneOverride_patch:
-    bl Custcene_OverrideShadowTemple
-    nop
+.section .patch_AdultBlueWarpOverride
+.global AdultBlueWarpOverride_patch
+AdultBlueWarpOverride_patch:
+    push {r0-r12, lr}
+    bl Cutscene_BlueWarpOverride
+    pop {r0-r12, lr}
+    b 0x1E4274
 
 .section .patch_EnExItemModelDraw
 .global EnExItemModelDraw_patch

--- a/code/src/patches.s
+++ b/code/src/patches.s
@@ -1696,6 +1696,11 @@ IgnoreMaskReaction_patch:
 MasterQuestGoldSkulltulaCheck_patch:
     b hook_MasterQuestGoldSkulltulaCheck
 
+.section .patch_WaterSpoutMasterQuestCheck
+.global WaterSpoutMasterQuestCheck_patch
+WaterSpoutMasterQuestCheck_patch:
+    bl hook_WaterSpoutMasterQuestCheck
+
 .section .patch_loader
 .global loader_patch
 

--- a/code/src/settings.c
+++ b/code/src/settings.c
@@ -138,7 +138,22 @@ s32 Settings_BowAsChild() {
     return (s32)gSettingsContext.bowAsChild;
 }
 
-  const char hashIconNames[32][25] = {
+s32 Settings_IsMasterQuestDungeon(void) {
+    // Certain actors check the MQ flag in the base game, but they have to check the individual dungeon mode for the randomizer:
+    // - Gold Skulltulas becoming intangible if they're inside blocks in MQ;
+    // - The water jet covering the Boomerang chest (it didn't cover it on GameCube);
+    s16 scene = gGlobalContext->sceneNum;
+    if (scene <= 9)
+        return gSettingsContext.dungeonModes[scene];
+    else if (scene == 11) // GtG
+        return gSettingsContext.dungeonModes[11];
+    else if (scene == 13) // Inside Ganon's Castle
+        return gSettingsContext.dungeonModes[10];
+
+    return 0;
+}
+
+const char hashIconNames[32][25] = {
     "Deku Stick",
     "Deku Nut",
     "Bow",
@@ -171,4 +186,4 @@ s32 Settings_BowAsChild() {
     "Compass",
     "Map",
     "Big Magic",
-  };
+};

--- a/code/src/skulltula.c
+++ b/code/src/skulltula.c
@@ -1,5 +1,6 @@
 #include "skulltula.h"
 #include "multiplayer.h"
+#include "settings.h"
 
 #define EnSw_Update_addr 0x1BB110
 #define EnSw_Update ((ActorFunc)EnSw_Update_addr)
@@ -42,4 +43,19 @@ void EnSw_Kill(EnSw* thisx, GlobalContext* globalCtx) {
     thisx->deathTimer_maybe = 15;
     thisx->unk_word1 = 1;
     thisx->action_fn = EnSw_GoldSkulltulaDeath;
+}
+
+s32 EnSw_IsMasterQuestSkulltula(void) {
+    // Certain Gold Skulltulas check the MQ flag to determine if they should have a collider or not.
+    // Grezzo did this to make MQ skulltulas intangible if they're hidden inside blocks.
+    // For the randomizer they have to check the individual dungeon mode.
+    s16 scene = gGlobalContext->sceneNum;
+    if (scene <= 9)
+        return gSettingsContext.dungeonModes[scene];
+    else if (scene == 11) // GtG
+        return gSettingsContext.dungeonModes[11];
+    else if (scene == 13) // Inside Ganon's Castle
+        return gSettingsContext.dungeonModes[10];
+
+    return 0;
 }

--- a/code/src/skulltula.c
+++ b/code/src/skulltula.c
@@ -1,6 +1,5 @@
 #include "skulltula.h"
 #include "multiplayer.h"
-#include "settings.h"
 
 #define EnSw_Update_addr 0x1BB110
 #define EnSw_Update ((ActorFunc)EnSw_Update_addr)
@@ -43,19 +42,4 @@ void EnSw_Kill(EnSw* thisx, GlobalContext* globalCtx) {
     thisx->deathTimer_maybe = 15;
     thisx->unk_word1 = 1;
     thisx->action_fn = EnSw_GoldSkulltulaDeath;
-}
-
-s32 EnSw_IsMasterQuestSkulltula(void) {
-    // Certain Gold Skulltulas check the MQ flag to determine if they should have a collider or not.
-    // Grezzo did this to make MQ skulltulas intangible if they're hidden inside blocks.
-    // For the randomizer they have to check the individual dungeon mode.
-    s16 scene = gGlobalContext->sceneNum;
-    if (scene <= 9)
-        return gSettingsContext.dungeonModes[scene];
-    else if (scene == 11) // GtG
-        return gSettingsContext.dungeonModes[11];
-    else if (scene == 13) // Inside Ganon's Castle
-        return gSettingsContext.dungeonModes[10];
-
-    return 0;
 }

--- a/source/settings.cpp
+++ b/source/settings.cpp
@@ -403,8 +403,8 @@ namespace Settings {
 
   //Starting Inventory submenus and menus
   std::vector<std::string> bottleOptions = {"Off", "Empty Bottle", "Red Potion", "Green Potion", "Blue Potion", "Fairy", "Fish", "Milk", "Blue Fire", "Bugs", "Big Poe", "Half Milk", "Poe"};
-  Option StartingStickCapacity    = Option::U8  ("Deku Sticks",          {"Deku Sticks (10)","Deku Sticks (20)", "Deku Sticks (30)"},                     {""});
-  Option StartingNutCapacity      = Option::U8  ("Deku Nuts",            {"Deku Nuts (20)",  "Deku Nuts (30)",   "Deku Nuts (40)"},                       {""});
+  Option StartingStickCapacity    = Option::U8  ("Deku Sticks capacity", {"10 Deku Sticks",  "20 Deku Sticks",   "30 Deku Sticks"},                       {""});
+  Option StartingNutCapacity      = Option::U8  ("Deku Nuts capacity",   {"20 Deku Nuts",    "30 Deku Nuts",     "40 Deku Nuts"},                         {""});
   Option StartingSlingshot        = Option::U8  ("Slingshot",            {"Off",             "Slingshot (30)",   "Slingshot (40)",    "Slingshot (50)"},  {""});
   Option StartingOcarina          = Option::U8  ("Ocarina",              {"Off",             "Fairy Ocarina",    "Ocarina of Time"},                      {""});
   Option StartingBombBag          = Option::U8  ("Bombs",                {"Off",             "Bomb Bag (20)",    "Bomb Bag (30)",     "Bomb Bag (40)"},   {""});


### PR DESCRIPTION
- Entering Spirit Temple from Desert Colossus clears the temporary flags if the dungeon is randomized.
- Gold Skulltulas check the dungeon mode from the randomizer settings instead of the MQ flag, so that the ones inside blocks in MQ dungeons don't become tangible with mirror world disabled.
- The blue warp patches have been changed to fix the ER destination error when entering a blue warp multiple times. Some patches for the item override inside the Chamber of the Sages have been removed because the cutscenes are skipped now.
- Other minor fixes.