### PR TITLE
Add logic trick for GF chest as child & logic fixes

### DIFF
--- a/source/location_access/locacc_death_mountain.cpp
+++ b/source/location_access/locacc_death_mountain.cpp
@@ -122,7 +122,7 @@ void AreaTable_Init_DeathMountain() {
                   Entrance(GC_SHOP,              {[]{return (IsAdult && StopGCRollingGoronAsAdult) || (IsChild && (CanBlastOrSmash || GoronBracelet || GoronCityChildFire || CanUse(BOW)));},
                                       /*Glitched*/[]{return IsChild && Sticks && CanDoGlitch(GlitchType::QPA, GlitchDifficulty::ADVANCED);}}),
                   Entrance(GC_DARUNIAS_CHAMBER,  {[]{return (IsAdult && StopGCRollingGoronAsAdult) || GCDaruniasDoorOpenChild;}}),
-                  Entrance(GC_GROTTO,            {[]{return IsAdult && ((CanPlay(SongOfTime) && ((EffectiveHealth > 2) || CanUse(GORON_TUNIC) || CanUse(LONGSHOT) || CanUse(NAYRUS_LOVE))) || (EffectiveHealth > 1 && CanUse(GORON_TUNIC) && CanUse(HOOKSHOT)) || (CanUse(NAYRUS_LOVE) && CanUse(HOOKSHOT)));},
+                  Entrance(GC_GROTTO_PLATFORM,   {[]{return IsAdult && ((CanPlay(SongOfTime) && ((EffectiveHealth > 2) || CanUse(GORON_TUNIC) || CanUse(LONGSHOT) || CanUse(NAYRUS_LOVE))) || (EffectiveHealth > 1 && CanUse(GORON_TUNIC) && CanUse(HOOKSHOT)) || (CanUse(NAYRUS_LOVE) && CanUse(HOOKSHOT)));},
                                       /*Glitched*/[]{return (HasBombchus && ((IsChild && CanDoGlitch(GlitchType::BombHover, GlitchDifficulty::NOVICE)) || CanDoGlitch(GlitchType::BombHover, GlitchDifficulty::INTERMEDIATE))) || (IsChild && CanUse(LONGSHOT));}}),
   });
 

--- a/source/location_access/locacc_forest_temple.cpp
+++ b/source/location_access/locacc_forest_temple.cpp
@@ -196,7 +196,7 @@ void AreaTable_Init_ForestTemple() {
                   Entrance(FOREST_TEMPLE_NW_CORRIDOR_TWISTED,      {[]{return IsAdult && GoronBracelet && SmallKeys(FOREST_TEMPLE, 2);},
                                                         /*Glitched*/[]{return ((IsAdult && (Bow || Hookshot || CanUse(SLINGSHOT)) && HasBombchus && CanShield && CanDoGlitch(GlitchType::ActionSwap, GlitchDifficulty::ADVANCED)) ||
                                                                                (Bombs && GoronBracelet && CanDoGlitch(GlitchType::BombHover, GlitchDifficulty::INTERMEDIATE) && CanDoGlitch(GlitchType::ISG, GlitchDifficulty::INTERMEDIATE))) && SmallKeys(FOREST_TEMPLE, 2);}}),
-                  Entrance(FOREST_TEMPLE_NW_CORRIDOR_STRAIGHTENED, {[]{return CanUse(BOW) && GoronBracelet && SmallKeys(FOREST_TEMPLE, 2);},
+                  Entrance(FOREST_TEMPLE_NW_CORRIDOR_STRAIGHTENED, {[]{return IsAdult && CanUse(BOW) && GoronBracelet && SmallKeys(FOREST_TEMPLE, 2);},
                                                         /*Glitched*/[]{return ((IsAdult && HasBombchus && CanShield && CanDoGlitch(GlitchType::ActionSwap, GlitchDifficulty::ADVANCED)) ||
                                                                                (IsChild && Bombs && GoronBracelet && CanDoGlitch(GlitchType::BombHover, GlitchDifficulty::INTERMEDIATE) && CanDoGlitch(GlitchType::ISG, GlitchDifficulty::INTERMEDIATE))) && (CanUse(BOW) || CanUse(SLINGSHOT)) && SmallKeys(FOREST_TEMPLE, 2);}}),
   });

--- a/source/location_access/locacc_gerudo_valley.cpp
+++ b/source/location_access/locacc_gerudo_valley.cpp
@@ -110,7 +110,7 @@ void AreaTable_Init_GerudoValley() {
                   EventAccess(&GtG_GateOpen,    {[]{return GtG_GateOpen || (IsAdult && GerudoToken);}}),
                 }, {
                   //Locations
-                  LocationAccess(GF_CHEST,              {[]{return ((IsAdult || LogicGerudoChildClimb) && CanUse(HOVER_BOOTS)) || (IsAdult && CanUse(SCARECROW)) || CanUse(LONGSHOT);},
+                  LocationAccess(GF_CHEST,              {[]{return ((IsAdult || LogicGerudoChildClimb) && (CanUse(HOVER_BOOTS) || CanUse(LONGSHOT))) || (IsAdult && CanUse(SCARECROW));},
                                              /*Glitched*/[]{return (((IsAdult || LogicGerudoChildClimb) && CanDoGlitch(GlitchType::Megaflip, GlitchDifficulty::NOVICE)) || (Bombs && HasBombchus && CanDoGlitch(GlitchType::BombHover, GlitchDifficulty::NOVICE))) && (GerudoToken || CanUse(BOW) || CanUse(HOOKSHOT) || CanUse(HOVER_BOOTS) || LogicGerudoKitchen);}}),
                   LocationAccess(GF_HBA_1000_POINTS,    {[]{return GerudoToken && CanRideEpona && Bow && AtDay;}}),
                   LocationAccess(GF_HBA_1500_POINTS,    {[]{return GerudoToken && CanRideEpona && Bow && AtDay;}}),

--- a/source/location_access/locacc_gerudo_valley.cpp
+++ b/source/location_access/locacc_gerudo_valley.cpp
@@ -110,8 +110,8 @@ void AreaTable_Init_GerudoValley() {
                   EventAccess(&GtG_GateOpen,    {[]{return GtG_GateOpen || (IsAdult && GerudoToken);}}),
                 }, {
                   //Locations
-                  LocationAccess(GF_CHEST,              {[]{return CanUse(HOVER_BOOTS) || (IsAdult && CanUse(SCARECROW)) || CanUse(LONGSHOT);},
-                                             /*Glitched*/[]{return (CanDoGlitch(GlitchType::Megaflip, GlitchDifficulty::NOVICE) || (Bombs && HasBombchus && CanDoGlitch(GlitchType::BombHover, GlitchDifficulty::NOVICE))) && (GerudoToken || CanUse(BOW) || CanUse(HOOKSHOT) || CanUse(HOVER_BOOTS) || LogicGerudoKitchen);}}),
+                  LocationAccess(GF_CHEST,              {[]{return ((IsAdult || LogicGerudoChildClimb) && CanUse(HOVER_BOOTS)) || (IsAdult && CanUse(SCARECROW)) || CanUse(LONGSHOT);},
+                                             /*Glitched*/[]{return (((IsAdult || LogicGerudoChildClimb) && CanDoGlitch(GlitchType::Megaflip, GlitchDifficulty::NOVICE)) || (Bombs && HasBombchus && CanDoGlitch(GlitchType::BombHover, GlitchDifficulty::NOVICE))) && (GerudoToken || CanUse(BOW) || CanUse(HOOKSHOT) || CanUse(HOVER_BOOTS) || LogicGerudoKitchen);}}),
                   LocationAccess(GF_HBA_1000_POINTS,    {[]{return GerudoToken && CanRideEpona && Bow && AtDay;}}),
                   LocationAccess(GF_HBA_1500_POINTS,    {[]{return GerudoToken && CanRideEpona && Bow && AtDay;}}),
                   LocationAccess(GF_NORTH_F1_CARPENTER, {[]{return  IsAdult || KokiriSword || CanUse(MASTER_SWORD) || CanUse(BIGGORON_SWORD);},

--- a/source/setting_descriptions.cpp
+++ b/source/setting_descriptions.cpp
@@ -1035,6 +1035,9 @@ string_view LogicGVHammerChestDesc                    = "Difficulty: Novice\n"  
 string_view LogicGerudoKitchenDesc                    = "Difficulty: Intermediate\n"                       //
                                                         "The logic normally guarantees one of Bow,\n"      //
                                                         "Hookshot, or Hover Boots.";                       //
+string_view LogicGerudoChildClimbDesc                 = "Difficulty: Intermediate\n"                       //
+                                                        "A precise jump allows child to climb the ledge\n" //
+                                                        "after the kitchen room.";                         //
 string_view LogicLensWastelandDesc                    = "Difficulty: Expert\n"                             //
                                                         "By memorizing the path, you can travel through the"
                                                         "Wasteland without using the Lens of Truth to see\n"

--- a/source/setting_descriptions.hpp
+++ b/source/setting_descriptions.hpp
@@ -337,6 +337,7 @@ extern string_view LogicGraveyardPoHDesc;
 extern string_view LogicChildDampeRacePoHDesc;
 extern string_view LogicGVHammerChestDesc;
 extern string_view LogicGerudoKitchenDesc;
+extern string_view LogicGerudoChildClimbDesc;
 extern string_view LogicLensWastelandDesc;
 extern string_view LogicReverseWastelandDesc;
 extern string_view LogicColossusGSDesc;

--- a/source/settings.cpp
+++ b/source/settings.cpp
@@ -606,6 +606,7 @@ namespace Settings {
   Option LogicChildDampeRacePoH           = LogicTrick(" GY Second Dampe\n   Race as Child",          LogicChildDampeRacePoHDesc);
   Option LogicGVHammerChest               = LogicTrick(" GV Hammer Chest\n   w/o Hammer",             LogicGVHammerChestDesc);
   Option LogicGerudoKitchen               = LogicTrick(" GF Through Kitchen\n   w/ Nothing",          LogicGerudoKitchenDesc);
+  Option LogicGerudoChildClimb            = LogicTrick(" GF Top Floor\n   as child",                  LogicGerudoChildClimbDesc);
   Option LogicLensWasteland               = LogicTrick(" Haunted Wasteland\n   w/o Lens of Truth",    LogicLensWastelandDesc);
   Option LogicReverseWasteland            = LogicTrick(" Haunted Wasteland\n   in Reverse",           LogicReverseWastelandDesc);
   Option LogicColossusGS                  = LogicTrick(" Colossus Hill GS\n   w/ Hookshot",           LogicColossusGSDesc);
@@ -696,6 +697,7 @@ namespace Settings {
     &LogicChildDampeRacePoH,
     &LogicGVHammerChest,
     &LogicGerudoKitchen,
+    &LogicGerudoChildClimb,
     &LogicLensWasteland,
     &LogicReverseWasteland,
     &LogicColossusGS,
@@ -2061,6 +2063,7 @@ namespace Settings {
           LogicLabWallGS.SetSelectedIndex(1);
           LogicChildDampeRacePoH.SetSelectedIndex(1);
           LogicGerudoKitchen.SetSelectedIndex(1);
+          LogicGerudoChildClimb.SetSelectedIndex(1);
           LogicOutsideGanonsGS.SetSelectedIndex(1);
           LogicDMTSoilGS.SetSelectedIndex(1);
           LogicDMTSummitHover.SetSelectedIndex(1);

--- a/source/settings.hpp
+++ b/source/settings.hpp
@@ -490,6 +490,7 @@ namespace Settings {
   extern Option LogicChildDampeRacePoH;
   extern Option LogicGVHammerChest;
   extern Option LogicGerudoKitchen;
+  extern Option LogicGerudoChildClimb;
   extern Option LogicLensWasteland;
   extern Option LogicReverseWasteland;
   extern Option LogicColossusGS;


### PR DESCRIPTION
Reaching the upper floor as child requires a curved jump which should've been a logic trick. Set to intermediate as is similar to LogicFireSongOfTime