### PR TITLE
Curse Traps

### DIFF
--- a/code/include/z3D/z3D.h
+++ b/code/include/z3D/z3D.h
@@ -428,7 +428,9 @@ typedef struct GlobalContext {
 _Static_assert(sizeof(GlobalContext) == 0x5F14, "Global Context size");
 
 typedef struct StaticContext {
-    /* 0x0000 */ char unk_0[0x0E60];
+    /* 0x0000 */ char unk_0[0x0D38];
+    /* 0x0D38 */ s16  dekuNutFlash; // set to -1 to trigger flash
+    /* 0x0D3A */ char unk_D3A[0x0126];
     /* 0x0E60 */ u16  spawnOnEpona;
     /* 0x0E62 */ char unk_E72[0x0010];
     /* 0x0E72 */ u16  collisionDisplay;
@@ -596,5 +598,9 @@ typedef u32 (*Flags_GetSwitch_proc)(GlobalContext* globalCtx, u32 flag);
 typedef u32 (*Flags_GetCollectible_proc)(GlobalContext* globalCtx, u32 flag);
 #define Flags_GetCollectible_addr 0x36405C
 #define Flags_GetCollectible ((Flags_GetCollectible_proc)Flags_GetCollectible_addr)
+
+typedef void (*Player_SetEquipmentData_proc)(GlobalContext* globalCtx, Player* player);
+#define Player_SetEquipmentData_addr 0x34913C
+#define Player_SetEquipmentData ((Player_SetEquipmentData_proc)Player_SetEquipmentData_addr)
 
 #endif //_Z3D_H_

--- a/code/include/z3D/z3Dactor.h
+++ b/code/include/z3D/z3Dactor.h
@@ -240,7 +240,7 @@ typedef struct {
     /* 0x172C */ char   unk_172C[0x0AF0];
     /* 0x221C */ float  xzSpeed; //probably
     /* 0x2220 */ char   unk_2220[0x0007];
-    /* 0x2227 */ u8     isg;
+    /* 0x2227 */ s8     meleeWeaponState;
     /* 0x2228 */ char   unk_2228[0x260];
     /* 0x2488 */ s8     invincibilityTimer; // prevents damage when nonzero (positive = visible, counts towards zero each frame)
     /* 0x2489 */ char   unk_2489[0x27B];

--- a/code/oot.ld
+++ b/code/oot.ld
@@ -480,6 +480,10 @@ SECTIONS
 		*(.patch_NoHealFromBombchuBowlingPrize)
 	}
 
+	.patch_HookshotDrawChain 0x2202A0 : {
+		*(.patch_HookshotDrawChain)
+	}
+
 	.patch_patch_ItemGiveBombchuDropTwo 0x22BAE4 : {
 		*(.patch_ItemGiveBombchuDropTwo)
 	}
@@ -1020,6 +1024,10 @@ SECTIONS
 		*(.patch_FireArrowCheckChestFlagTwo)
 	}
 
+	.patch_LinkReflection 0x3F2F0C : {
+		*(.patch_LinkReflection)
+	}
+
 	.patch_SlidingDoorDestroyCustomModels 0x3F4A70 : {
 		*(.patch_SlidingDoorDestroyCustomModels)
 	}
@@ -1200,6 +1208,10 @@ SECTIONS
 		*(.patch_EnableFW)
 	}
 
+	.patch_StoreTargetActorType 0x479984 : {
+		*(.patch_StoreTargetActorType)
+	}
+
 	.patch_FWKeepWarpPoint 0x47C3C0 : {
 		*(.patch_FWKeepWarpPoint)
 	}
@@ -1260,24 +1272,12 @@ SECTIONS
 		*(.patch_EditDrawGetItemBeforeModelSpawn)
 	}
 
-	.patch_HookshotDrawRedLaser 0x4C2620 : {
-		*(.patch_HookshotDrawRedLaser)
-	}
-
-	.patch_HookshotDrawChain 0x2202A0 : {
-		*(.patch_HookshotDrawChain)
-	}
-
 	.patch_HookshotRotation 0x4C2524 : {
 		*(.patch_HookshotRotation)
 	}
 
-	.patch_LinkReflection 0x3F2F0C : {
-		*(.patch_LinkReflection)
-	}
-
-	.patch_StoreTargetActorType 0x479984 : {
-		*(.patch_StoreTargetActorType)
+	.patch_HookshotDrawRedLaser 0x4C2620 : {
+		*(.patch_HookshotDrawRedLaser)
 	}
 
 	.patch_EditDrawGetItemAfterModelSpawn 0x4C61A4 : {

--- a/code/oot.ld
+++ b/code/oot.ld
@@ -724,6 +724,10 @@ SECTIONS
 		*(.patch_BiggoronDayCheck)
 	}
 
+	.patch_WarpSongTimerDepletion 0x33DE84 : {
+		*(.patch_WarpSongTimerDepletion)
+	}
+
 	.patch_MasterQuestGoldSkulltulaCheck 0x3415C8 : {
 		*(.patch_MasterQuestGoldSkulltulaCheck)
 	}
@@ -766,6 +770,10 @@ SECTIONS
 
 	.patch_FastChests 0x354CD4 : {
 		*(.patch_FastChests)
+	}
+
+	.patch_MasterSwordTimerCheck 0x354DFC : {
+		*(.patch_MasterSwordTimerCheck)
 	}
 
 	.patch_LikeLikeNeverEatTunic 0x355C2C : {
@@ -1052,6 +1060,14 @@ SECTIONS
 		*(.patch_SleepQueryCallback)
 	}
 
+	.patch_CurseTrapDizzyStick 0x41AB24 : {
+		*(.patch_CurseTrapDizzyStick)
+	}
+
+	.patch_CurseTrapDizzyButtons 0x41ABDC : {
+		*(.patch_CurseTrapDizzyButtons)
+	}
+
 	.patch_SaveMenuIgnoreOpen 0x42EC00 : {
 		*(.patch_SaveMenuIgnoreOpen)
 	}
@@ -1172,6 +1188,14 @@ SECTIONS
 		*(.patch_InterfaceDrawDontSpoilTradeItems)
 	}
 
+	.patch_TimerExpiration 0x45A948 : {
+		*(.patch_TimerExpiration)
+	}
+
+	.patch_Timer2TickSound 0x45A9B4 : {
+		*(.patch_Timer2TickSound)
+	}
+
 	.patch_SunsSongEndCloseTextbox 0x45B514 : {
 		*(.patch_SunsSongEndCloseTextbox)
 	}
@@ -1282,6 +1306,10 @@ SECTIONS
 
 	.patch_EditDrawGetItemAfterModelSpawn 0x4C61A4 : {
 		*(.patch_EditDrawGetItemAfterModelSpawn)
+	}
+
+	.patch_CrouchStabHitbox 0x4C85D4 : {
+		*(.patch_CrouchStabHitbox)
 	}
 
 	. = 0x4C99A8;

--- a/code/src/actor.c
+++ b/code/src/actor.c
@@ -49,6 +49,7 @@
 #include "collapsing_platform.h"
 #include "carpenter.h"
 #include "pushblock.h"
+#include "spin_attack.h"
 
 #define OBJECT_GI_KEY 170
 #define OBJECT_GI_BOSSKEY 185
@@ -88,6 +89,8 @@ void Actor_Init() {
     gActorOverlayTable[0x3E].initInfo->init = BgTreemouth_rInit;
 
     gActorOverlayTable[0x4A].initInfo->update = BgSpot00Hanebasi_rUpdate;
+
+    gActorOverlayTable[0x57].initInfo->init = EnMThunder_rInit;
 
     gActorOverlayTable[0x5F].initInfo->init = ItemBHeart_rInit;
     gActorOverlayTable[0x5F].initInfo->destroy = ItemBHeart_rDestroy;

--- a/code/src/actors/chest.c
+++ b/code/src/actors/chest.c
@@ -6,6 +6,7 @@
 #include "player.h"
 #include "common.h"
 #include "fairy.h"
+#include "icetrap.h"
 
 #define EnBox_Init_addr 0x1899EC
 #define EnBox_Init ((ActorFunc)EnBox_Init_addr)
@@ -157,7 +158,19 @@ u8 Chest_OverrideIceSmoke(Actor* thisx) {
         if (gSettingsContext.randomTrapDmg == 1) { //basic
             damageType = pRandInt % 6;
         } else if (gSettingsContext.randomTrapDmg == 2) { //advanced
-            damageType = pRandInt % 9;
+            damageType = pRandInt % 13;
+        }
+
+        // Curses
+        if (damageType > 8) {
+            if (IceTrap_ActivateCurseTrap((s8)damageType - 9)) {
+                PLAYER->getItemId = 0;
+                PLAYER->stateFlags1 &= ~0x20000C00;
+                PLAYER->actor.home.pos.y = -5000; // Make Link airborne for a frame to cancel the get item event
+                return 1;
+            }
+            else
+                damageType = 1; // if the curse can't trigger, use a bomb trap
         }
 
         if (damageType == 3) {

--- a/code/src/actors/player.c
+++ b/code/src/actors/player.c
@@ -5,6 +5,7 @@
 #include "player.h"
 #include "settings.h"
 #include "fairy.h"
+#include "icetrap.h"
 
 #define PlayerActor_Init_addr 0x191844
 #define PlayerActor_Init ((ActorFunc)PlayerActor_Init_addr)
@@ -72,6 +73,14 @@ void PlayerActor_rUpdate(Actor* thisx, GlobalContext* globalCtx) {
 
     if (this->naviActor != 0) {
         updateNaviColors((EnElf*)this->naviActor);
+    }
+
+    if (IceTrap_ActiveCurse == ICETRAP_CURSE_SWORD && PLAYER->meleeWeaponState != 0 &&
+            ((PLAYER->itemActionParam >= 3 && PLAYER->itemActionParam <= 5) || PLAYER->itemActionParam == 35)) { //sword items
+        PLAYER->meleeWeaponState = -1; // slash effect with no hitbox (same as "damageless death ISG")
+    }
+    if (PLAYER->itemActionParam == 38) { // Blue Potion
+        IceTrap_DispelCurses();
     }
 
     if (healthDecrement <= 0) {

--- a/code/src/actors/player.c
+++ b/code/src/actors/player.c
@@ -58,7 +58,12 @@ void Player_SetChildCustomTunicCMAB(void) {
 }
 
 void PlayerActor_rInit(Actor* thisx, GlobalContext* globalCtx) {
+    if (IceTrap_ActiveCurse == ICETRAP_CURSE_SHIELD) {
+        gSaveContext.equips.equipment &= ~0xF0; // unequip shield
+    }
+
     PlayerActor_Init(thisx, globalCtx);
+
     if (gSettingsContext.fastBunnyHood) {
         PLAYER->currentMask = storedMask;
     }

--- a/code/src/actors/player.c
+++ b/code/src/actors/player.c
@@ -80,6 +80,9 @@ void PlayerActor_rUpdate(Actor* thisx, GlobalContext* globalCtx) {
         PLAYER->meleeWeaponState = -1; // slash effect with no hitbox (same as "damageless death ISG")
     }
     if (PLAYER->itemActionParam == 38) { // Blue Potion
+        if (IceTrap_ActiveCurse == ICETRAP_CURSE_BLIND)
+            gStaticContext.dekuNutFlash = -1;
+
         IceTrap_DispelCurses();
     }
 

--- a/code/src/actors/rupee_trap.c
+++ b/code/src/actors/rupee_trap.c
@@ -7,6 +7,10 @@
 void EnExRuppy_rUpdate(Actor* thisx, GlobalContext* globalCtx) {
     if (thisx->params == 0x2 && thisx->xzDistToPlayer < 30.0f) {
         PLAYER->actor.colChkInfo.damage = (gSettingsContext.mirrorWorld)? 16 : 8;
+
+        if (PLAYER->invincibilityTimer > 0) {
+            PLAYER->invincibilityTimer = 0;
+        }
     }
     EnExRuppy_Update(thisx, globalCtx);
 }

--- a/code/src/hooks.s
+++ b/code/src/hooks.s
@@ -1442,6 +1442,76 @@ hook_RainbowChuTrail:
     strb r7,[r0,#0x282]
     bx lr
 
+.global hook_TimerExpiration
+hook_TimerExpiration:
+    mov r0,#0x5
+    push {r0-r12,lr}
+    bl IceTrap_IsCurseActive
+    cmp r0,#0x1
+    pop {r0-r12,lr}
+    bxne lr
+    add lr,lr,#0x30
+    mov r0,#0x0
+    strh r0,[r4,#0x62]
+    bx lr
+
+.global hook_WarpSongTimerDepletion
+hook_WarpSongTimerDepletion:
+    moveq r1,#0x1
+    movne r1,#0xEF
+    push {r0-r12,lr}
+    bl IceTrap_IsCurseActive
+    cmp r0,#0x1
+    pop {r0-r12,lr}
+    bxne lr
+    strh r1,[r0,#0x64]
+    bx lr
+
+.global hook_Timer2TickSound
+hook_Timer2TickSound:
+    push {r0-r12,lr}
+    bl IceTrap_IsCurseActive
+    cmp r0,#0x1
+    pop {r0-r12,lr}
+    addeq lr,lr,#0x4
+    cmp r0,#0x3C
+    bx lr
+
+.global hook_CurseTrapDizzyStick
+hook_CurseTrapDizzyStick:
+    push {r0-r12,lr}
+    bl IceTrap_ReverseStick
+    pop {r0-r12,lr}
+    b 0x2FF258
+
+.global hook_CurseTrapDizzyButtons
+hook_CurseTrapDizzyButtons:
+    push {r0,r3-r12,lr}
+    # R1 and R2 contain button status fields
+    # Apply the curse effect to both
+    push {r2}
+    cpy r0,r1
+    bl IceTrap_RandomizeButtons
+    pop {r2}
+    push {r0}
+    cpy r0,r2
+    bl IceTrap_RandomizeButtons
+    cpy r2,r0
+    pop {r1}
+    pop {r0,r3-r12,lr}
+    stmia r0,{r1,r2,r3,r5,r6,r7,r8,r9,r10,r11,r12,lr}
+    b 0x41ABE0
+
+.global hook_CrouchStabHitbox
+hook_CrouchStabHitbox:
+    push {r0-r12,lr}
+    bl IceTrap_IsSlashHitboxDisabled
+    cmp r0,#0x0
+    pop {r0-r12,lr}
+    movne r10,#0xFF
+    strb r10,[r6,#0x227]
+    bx lr
+
 .section .loader
 .global hook_into_loader
 hook_into_loader:

--- a/code/src/icetrap.c
+++ b/code/src/icetrap.c
@@ -3,12 +3,22 @@
 #include "z3D/z3D.h"
 #include "settings.h"
 #include "common.h"
+#include "input.h"
+
+#define TimerFrameCounter *(s16*)0x539D8A // Used to decrease the timer every 30 frames
+#define ControlStick_X *(float*)0x5655C0
+#define ControlStick_Y *(float*)0x5655C4
 
 static u8 pendingFreezes = 0;
 static u8 cooldown = 0;
 static u8 modifyScale = 0;
 
 static u32 source[16];
+
+s8 IceTrap_ActiveCurse = -1;
+static s16 previousTimer1Value = 0;
+static s16 previousTimer2Value = 60;
+static u32 dizzyCurseSeed = 0;
 
 // LUT for 1 - 0.5sin(0.5x) * 1.1^-x where x = 30 - INDEX
 const f32 SCALE_TRAP[] = {
@@ -43,21 +53,29 @@ void LinkDamageNoKnockback(void) {
 void IceTrap_Give(void) {
     if (cooldown == 0 && pendingFreezes &&
         ExtendedObject_IsLoaded(&gGlobalContext->objectCtx, ExtendedObject_GetIndex(&gGlobalContext->objectCtx, 0x3))) {
-        u32 pRandInt = Hash(source[0]);
+        u32 pRandInt = dizzyCurseSeed = Hash(source[0]);
 
         u8 damageType = 3; // Default to ice trap
         if (gSettingsContext.randomTrapDmg == 1) { //Basic
             damageType = pRandInt % 5 + 1; // From testing 0-4 are all the unique damage types and 0 is boring (5 is custom)
         }
         else if (gSettingsContext.randomTrapDmg == 2) { //Advanced
-            damageType = pRandInt % 6; // 0 will be used for the fire trap
+            damageType = pRandInt % 10; // 0 will be used for the fire trap, 6 and higher for curses
         }
-        modifyScale = (damageType == 5);
 
         pendingFreezes--;
         for (int i = 0; i < 15; i++) {
             source[i] = source[i + 1];
         }
+
+        if (damageType > 5) {
+            if (IceTrap_ActivateCurseTrap((s8)damageType - 6))
+                return;
+            else
+                damageType = 5; // if the curse can't trigger, use a scale trap
+        }
+
+        modifyScale = (damageType == 5);
 
         PLAYER->stateFlags1 &= ~0xC00;
         if (damageType == 3 || damageType == 0) {
@@ -82,11 +100,98 @@ void IceTrap_Give(void) {
     }
 }
 
+u8 IceTrap_ActivateCurseTrap(s8 curseType) {
+    if (IceTrap_ActiveCurse >= 0 || gSaveContext.timer2State != 0)
+        return 0;
+
+    do {
+        switch (curseType) {
+            case ICETRAP_CURSE_SHIELD :
+                if (!(gSaveContext.equips.equipment & 0x70)) { // no shield equipped
+                    curseType++;
+                    continue;
+                }
+                gSaveContext.equips.equipment &= ~0xF0; // unequip shield
+                Player_SetEquipmentData(gGlobalContext, PLAYER);
+                gGearUsabilityTable[GearSlot(ITEM_SHIELD_DEKU)]   = 0x02;
+                gGearUsabilityTable[GearSlot(ITEM_SHIELD_HYLIAN)] = 0x02;
+                gGearUsabilityTable[GearSlot(ITEM_SHIELD_MIRROR)] = 0x02;
+                break;
+            case ICETRAP_CURSE_SWORD :
+                if (!(gSaveContext.equips.equipment & 0x07)) { // no sword equipped
+                    curseType++;
+                    continue;
+                }
+                break;
+            case ICETRAP_CURSE_DIZZY :
+                break;
+            case ICETRAP_CURSE_BLIND :
+                gStaticContext.dekuNutFlash = -1;
+                gStaticContext.renderGeometryDisable = 1;
+                break;
+            default : return 0;
+        }
+        break;
+    } while (1);
+
+    gSaveContext.timer2State = 4; // "active"
+    gSaveContext.timer2Value = 60;
+    TimerFrameCounter = 30;
+    DisplayTextbox(gGlobalContext, 0x8FF0 + curseType, 0);
+    PlaySound(0x100035C); // Poe laugh SFX
+    IceTrap_ActiveCurse = curseType;
+    return 1;
+}
+
+void IceTrap_DispelCurses(void) {
+    if (IceTrap_ActiveCurse >= 0) {
+        gGearUsabilityTable[GearSlot(ITEM_SHIELD_DEKU)]   = gSettingsContext.dekuShieldAsAdult ? 0x09 : 0x01;
+        gGearUsabilityTable[GearSlot(ITEM_SHIELD_HYLIAN)] = 0x09;
+        gGearUsabilityTable[GearSlot(ITEM_SHIELD_MIRROR)] = gSettingsContext.mirrorShieldAsChild ? 0x09 : 0x00;
+        gStaticContext.renderGeometryDisable = 0;
+        previousTimer2Value = 60;
+        gSaveContext.timer2State = 0;
+        IceTrap_ActiveCurse = -1;
+    }
+}
+
+void IceTrap_HandleCurses(void) {
+    if (IceTrap_ActiveCurse < 0)
+        return;
+
+    // If the white timer is overriding the yellow timer, force the yellow one to decrease anyway
+    if (gSaveContext.timer1State != 0 && gSaveContext.timer1Value != previousTimer1Value) {
+        gSaveContext.timer2Value--;
+    }
+    previousTimer1Value = gSaveContext.timer1Value;
+
+    // During the blindness curse, show geometry for 1 second every 20
+    if (IceTrap_ActiveCurse == ICETRAP_CURSE_BLIND) {
+        if (gSaveContext.timer2Value != previousTimer2Value && gSaveContext.timer2Value % 20 == 0) {
+            gStaticContext.dekuNutFlash = -1;
+            gStaticContext.renderGeometryDisable = 0;
+        }
+        else if (gSaveContext.timer2Value != previousTimer2Value && gSaveContext.timer2Value % 20 == 19 && gSaveContext.timer2Value < 59) {
+            gStaticContext.dekuNutFlash = -1;
+            gStaticContext.renderGeometryDisable = 1;
+        }
+        previousTimer2Value = gSaveContext.timer2Value;
+    }
+
+    // Dispel curses if the timer is reset or runs out, or if the scene is Tower Collapse Exterior
+    if ((!IsInGame() || gSaveContext.timer2State != 4 || gSaveContext.timer2Value == 0 || gGlobalContext->sceneNum == 0x1A)) {
+        IceTrap_DispelCurses();
+        return;
+    }
+}
+
 void IceTrap_Update(void) {
     // Make sure zelda_dangeon_keep is loaded
     if (ExtendedObject_GetIndex(&gGlobalContext->objectCtx, 0x3) < 0) {
         ExtendedObject_Spawn(&gGlobalContext->objectCtx, 0x3);
     }
+
+    IceTrap_HandleCurses();
 
     if (cooldown != 0) {
         cooldown--;
@@ -95,4 +200,41 @@ void IceTrap_Update(void) {
             PLAYER->actor.scale.y = 0.01f * SCALE_TRAP[cooldown];
         }
     }
+}
+
+u8 IceTrap_IsCurseActive(void) {
+    return IceTrap_ActiveCurse >= 0;
+}
+
+u8 IceTrap_IsSlashHitboxDisabled(void) {
+    return IceTrap_ActiveCurse == ICETRAP_CURSE_SWORD &&
+            ((PLAYER->heldItemActionParam >= 3 && PLAYER->heldItemActionParam <= 5) || PLAYER->heldItemActionParam == 35);
+}
+
+void IceTrap_ReverseStick(void) {
+    if (IceTrap_ActiveCurse == ICETRAP_CURSE_DIZZY) {
+        ControlStick_X = -ControlStick_X;
+        ControlStick_Y = -ControlStick_Y;
+    }
+}
+
+btn_t IceTrap_RandomizeButtons(btn_t in) {
+    if (IceTrap_ActiveCurse != ICETRAP_CURSE_DIZZY) {
+        return in;
+    }
+
+    uint32_t arr[4] = {in.a, in.b, in.r, in.l};
+    for (u32 i = 3; i > 0; i--) {
+        u32 j = dizzyCurseSeed % i;
+        u32 temp = arr[j];
+        arr[j] = arr[i];
+        arr[i] = temp;
+    }
+
+    btn_t out = in;
+    out.a = arr[0];
+    out.b = arr[1];
+    out.r = arr[2];
+    out.l = arr[3];
+    return out;
 }

--- a/code/src/icetrap.h
+++ b/code/src/icetrap.h
@@ -4,19 +4,33 @@
 #include "z3D/z3D.h"
 
 extern s8 IceTrap_ActiveCurse;
+extern u32 possibleChestTraps[20];
+extern u32 possibleChestTrapsAmount;
+extern u32 dizzyCurseSeed;
 
 void IceTrap_Push(u32 key);
 void IceTrap_Give(void);
-u32 IceTrap_IsPending(void);
+u32  IceTrap_IsPending(void);
 void IceTrap_Update(void);
-u8 IceTrap_ActivateCurseTrap(s8 curseType);
+void IceTrap_InitTypes(void);
+u8   IceTrap_ActivateCurseTrap(u8 curseType);
 void IceTrap_DispelCurses(void);
 
 typedef enum {
+    ICETRAP_FIRE,
+    ICETRAP_KNOCKDOWN,
+    ICETRAP_ZELDA2_KNOCKBACK,
+    ICETRAP_VANILLA,
+    ICETRAP_SHOCK,
+    ICETRAP_BOMB_SIMPLE,
+    ICETRAP_BOMB_KNOCKDOWN,
+    ICETRAP_ANTIFAIRY,
+    ICETRAP_RUPPY, // Explosive Rupee
+    ICETRAP_SCALE,
     ICETRAP_CURSE_SHIELD,
     ICETRAP_CURSE_SWORD,
     ICETRAP_CURSE_DIZZY,
     ICETRAP_CURSE_BLIND,
-} IceTrapCurses;
+} IceTrapTypes;
 
 #endif //_ICETRAP_H_

--- a/code/src/icetrap.h
+++ b/code/src/icetrap.h
@@ -3,9 +3,20 @@
 
 #include "z3D/z3D.h"
 
+extern s8 IceTrap_ActiveCurse;
+
 void IceTrap_Push(u32 key);
 void IceTrap_Give(void);
 u32 IceTrap_IsPending(void);
 void IceTrap_Update(void);
+u8 IceTrap_ActivateCurseTrap(s8 curseType);
+void IceTrap_DispelCurses(void);
+
+typedef enum {
+    ICETRAP_CURSE_SHIELD,
+    ICETRAP_CURSE_SWORD,
+    ICETRAP_CURSE_DIZZY,
+    ICETRAP_CURSE_BLIND,
+} IceTrapCurses;
 
 #endif //_ICETRAP_H_

--- a/code/src/patches.s
+++ b/code/src/patches.s
@@ -1755,6 +1755,43 @@ RainbowChuTrailOne_patch:
 RainbowChuTrailTwo_patch:
     bl hook_RainbowChuTrail
 
+.section .patch_WarpSongTimerDepletion
+.global WarpSongTimerDepletion_patch
+WarpSongTimerDepletion_patch:
+    push {lr}
+    bl hook_WarpSongTimerDepletion
+    pop {lr}
+
+.section .patch_TimerExpiration
+.global TimerExpiration_patch
+TimerExpiration_patch:
+    bl hook_TimerExpiration
+
+.section .patch_Timer2TickSound
+.global Timer2TickSound_patch
+Timer2TickSound_patch:
+    bl hook_Timer2TickSound
+
+.section .patch_CurseTrapDizzyStick
+.global CurseTrapDizzyStick_patch
+CurseTrapDizzyStick_patch:
+    bl hook_CurseTrapDizzyStick
+
+.section .patch_CurseTrapDizzyButtons
+.global CurseTrapDizzyButtons_patch
+CurseTrapDizzyButtons_patch:
+    b hook_CurseTrapDizzyButtons
+
+.section .patch_CrouchStabHitbox
+.global CrouchStabHitbox_patch
+CrouchStabHitbox_patch:
+    bl hook_CrouchStabHitbox
+
+.section .patch_MasterSwordTimerCheck
+.global MasterSwordTimerCheck_patch
+MasterSwordTimerCheck_patch:
+    nop
+
 .section .patch_loader
 .global loader_patch
 

--- a/code/src/settings.h
+++ b/code/src/settings.h
@@ -271,6 +271,12 @@ typedef enum {
 } GossipStoneHintsSetting;
 
 typedef enum {
+  RANDOMTRAPS_OFF,
+  RANDOMTRAPS_BASIC,
+  RANDOMTRAPS_ADVANCED,
+} RandomTrapDamageSetting;
+
+typedef enum {
   ITEMPOOL_PLENTIFUL,
   ITEMPOOL_BALANCED,
   ITEMPOOL_SCARCE,
@@ -445,6 +451,9 @@ typedef struct {
   u8 ingameSpoilers;
   u8 menuOpeningButton;
   u8 randomTrapDmg;
+  u8 fireTrap;
+  u8 antiFairyTrap;
+  u8 curseTraps;
 
   u8 faroresWindAnywhere;
   u8 stickAsAdult;

--- a/code/src/settings.h
+++ b/code/src/settings.h
@@ -277,10 +277,10 @@ typedef enum {
 } RandomTrapDamageSetting;
 
 typedef enum {
-  ITEMPOOL_PLENTIFUL,
-  ITEMPOOL_BALANCED,
-  ITEMPOOL_SCARCE,
   ITEMPOOL_MINIMAL,
+  ITEMPOOL_SCARCE,
+  ITEMPOOL_BALANCED,
+  ITEMPOOL_PLENTIFUL,
 } ItemPoolSetting;
 
 typedef enum {

--- a/code/src/songs_visual_effects.c
+++ b/code/src/songs_visual_effects.c
@@ -77,7 +77,11 @@ void OceffSpot_rUpdate(Actor* thisx, GlobalContext* globalCtx) {
 // Song of Storms
 void OceffStorm_rUpdate(Actor* thisx, GlobalContext* globalCtx) {
 
+    if (IceTrap_ActiveCurse == ICETRAP_CURSE_BLIND)
+        gStaticContext.dekuNutFlash = -1;
+
     IceTrap_DispelCurses();
+
     if (gSettingsContext.skipSongReplays == SONGREPLAYS_DONT_SKIP) {
         OceffStorm_Update(thisx, globalCtx);
     } else {

--- a/code/src/songs_visual_effects.c
+++ b/code/src/songs_visual_effects.c
@@ -1,6 +1,7 @@
 #include "z3D/z3D.h"
 #include "settings.h"
 #include "songs_visual_effects.h"
+#include "icetrap.h"
 
 #define OceffWipe_Update_addr 0x256158
 #define OceffWipe_Update ((ActorFunc)OceffWipe_Update_addr)
@@ -75,6 +76,8 @@ void OceffSpot_rUpdate(Actor* thisx, GlobalContext* globalCtx) {
 
 // Song of Storms
 void OceffStorm_rUpdate(Actor* thisx, GlobalContext* globalCtx) {
+
+    IceTrap_DispelCurses();
     if (gSettingsContext.skipSongReplays == SONGREPLAYS_DONT_SKIP) {
         OceffStorm_Update(thisx, globalCtx);
     } else {

--- a/code/src/spin_attack.c
+++ b/code/src/spin_attack.c
@@ -1,0 +1,14 @@
+#include "spin_attack.h"
+#include "icetrap.h"
+
+#define EnMThunder_Init_addr 0x24C910
+#define EnMThunder_Init ((ActorFunc)EnMThunder_Init_addr)
+
+void EnMThunder_rInit(Actor* thisx, GlobalContext* globalCtx) {
+    if (IceTrap_ActiveCurse != ICETRAP_CURSE_SWORD) {
+        EnMThunder_Init(thisx, globalCtx);
+    }
+    else {
+        Actor_Kill(thisx);
+    }
+}

--- a/code/src/spin_attack.h
+++ b/code/src/spin_attack.h
@@ -1,0 +1,8 @@
+#ifndef _SPIN_ATTACK_H_
+#define _SPIN_ATTACK_H_
+
+#include "z3D/z3D.h"
+
+void EnMThunder_rInit(Actor* thisx, GlobalContext* globalCtx);
+
+#endif //_SPIN_ATTACK_H_

--- a/source/custom_messages.cpp
+++ b/source/custom_messages.cpp
@@ -286,6 +286,24 @@ constexpr std::array DungeonColors = {
             UNSKIPPABLE()+INSTANT_TEXT_ON()+CENTER_TEXT()+COLOR(QM_RED)+"FOOL!"+COLOR(QM_WHITE)+INSTANT_TEXT_OFF()+MESSAGE_END(),
             UNSKIPPABLE()+INSTANT_TEXT_ON()+CENTER_TEXT()+COLOR(QM_RED)+"IDIOT!"+COLOR(QM_WHITE)+INSTANT_TEXT_OFF()+MESSAGE_END(),
             UNSKIPPABLE()+INSTANT_TEXT_ON()+CENTER_TEXT()+COLOR(QM_RED)+"¡TONTO!"+COLOR(QM_WHITE)+INSTANT_TEXT_OFF()+MESSAGE_END());
+        //Curse Traps
+        CreateMessage(0x8FF0, 0, 2, 3,
+            UNSKIPPABLE()+INSTANT_TEXT_ON()+CENTER_TEXT()+"You've been "+COLOR(QM_RED)+"cursed"+COLOR(QM_WHITE)+"!"+NEWLINE()+CENTER_TEXT()+"You can't use your shield!"+INSTANT_TEXT_OFF()+CLOSE_AFTER(120)+MESSAGE_END(),
+            UNSKIPPABLE()+INSTANT_TEXT_ON()+CENTER_TEXT()+"You've been "+COLOR(QM_RED)+"cursed"+COLOR(QM_WHITE)+"!"+NEWLINE()+CENTER_TEXT()+"You can't use your shield!"+INSTANT_TEXT_OFF()+CLOSE_AFTER(120)+MESSAGE_END(),
+            UNSKIPPABLE()+INSTANT_TEXT_ON()+CENTER_TEXT()+"You've been "+COLOR(QM_RED)+"cursed"+COLOR(QM_WHITE)+"!"+NEWLINE()+CENTER_TEXT()+"You can't use your shield!"+INSTANT_TEXT_OFF()+CLOSE_AFTER(120)+MESSAGE_END());
+        CreateMessage(0x8FF1, 0, 2, 3,
+            UNSKIPPABLE()+INSTANT_TEXT_ON()+CENTER_TEXT()+"You've been "+COLOR(QM_RED)+"cursed"+COLOR(QM_WHITE)+"!"+NEWLINE()+CENTER_TEXT()+"Your sword "+COLOR(QM_RED)+"can't hit"+COLOR(QM_WHITE)+" anything!"+INSTANT_TEXT_OFF()+CLOSE_AFTER(120)+MESSAGE_END(),
+            UNSKIPPABLE()+INSTANT_TEXT_ON()+CENTER_TEXT()+"You've been "+COLOR(QM_RED)+"cursed"+COLOR(QM_WHITE)+"!"+NEWLINE()+CENTER_TEXT()+"Your sword "+COLOR(QM_RED)+"can't hit"+COLOR(QM_WHITE)+" anything!"+INSTANT_TEXT_OFF()+CLOSE_AFTER(120)+MESSAGE_END(),
+            UNSKIPPABLE()+INSTANT_TEXT_ON()+CENTER_TEXT()+"You've been "+COLOR(QM_RED)+"cursed"+COLOR(QM_WHITE)+"!"+NEWLINE()+CENTER_TEXT()+"Your sword "+COLOR(QM_RED)+"can't hit"+COLOR(QM_WHITE)+" anything!"+INSTANT_TEXT_OFF()+CLOSE_AFTER(120)+MESSAGE_END());
+        CreateMessage(0x8FF2, 0, 2, 3,
+            UNSKIPPABLE()+INSTANT_TEXT_ON()+CENTER_TEXT()+"You've been "+COLOR(QM_RED)+"cursed"+COLOR(QM_WHITE)+"!"+NEWLINE()+CENTER_TEXT()+"You are "+COLOR(QM_RED)+"confused"+COLOR(QM_WHITE)+"!"+INSTANT_TEXT_OFF()+CLOSE_AFTER(120)+MESSAGE_END(),
+            UNSKIPPABLE()+INSTANT_TEXT_ON()+CENTER_TEXT()+"You've been "+COLOR(QM_RED)+"cursed"+COLOR(QM_WHITE)+"!"+NEWLINE()+CENTER_TEXT()+"You are "+COLOR(QM_RED)+"confused"+COLOR(QM_WHITE)+"!"+INSTANT_TEXT_OFF()+CLOSE_AFTER(120)+MESSAGE_END(),
+            UNSKIPPABLE()+INSTANT_TEXT_ON()+CENTER_TEXT()+"You've been "+COLOR(QM_RED)+"cursed"+COLOR(QM_WHITE)+"!"+NEWLINE()+CENTER_TEXT()+"You are "+COLOR(QM_RED)+"confused"+COLOR(QM_WHITE)+"!"+INSTANT_TEXT_OFF()+CLOSE_AFTER(120)+MESSAGE_END());
+        CreateMessage(0x8FF3, 0, 2, 3,
+            UNSKIPPABLE()+INSTANT_TEXT_ON()+CENTER_TEXT()+"You've been "+COLOR(QM_RED)+"cursed"+COLOR(QM_WHITE)+"!"+NEWLINE()+CENTER_TEXT()+"Terrain is "+COLOR(QM_RED)+"invisible"+COLOR(QM_WHITE)+"!"+INSTANT_TEXT_OFF()+CLOSE_AFTER(120)+MESSAGE_END(),
+            UNSKIPPABLE()+INSTANT_TEXT_ON()+CENTER_TEXT()+"You've been "+COLOR(QM_RED)+"cursed"+COLOR(QM_WHITE)+"!"+NEWLINE()+CENTER_TEXT()+"Terrain is "+COLOR(QM_RED)+"invisible"+COLOR(QM_WHITE)+"!"+INSTANT_TEXT_OFF()+CLOSE_AFTER(120)+MESSAGE_END(),
+            UNSKIPPABLE()+INSTANT_TEXT_ON()+CENTER_TEXT()+"You've been "+COLOR(QM_RED)+"cursed"+COLOR(QM_WHITE)+"!"+NEWLINE()+CENTER_TEXT()+"Terrain is "+COLOR(QM_RED)+"invisible"+COLOR(QM_WHITE)+"!"+INSTANT_TEXT_OFF()+CLOSE_AFTER(120)+MESSAGE_END());
+
         //Business Scrubs
         //The less significant byte represents the price of the item
         for (u32 price = 0; price <= 95; price += 5) {

--- a/source/setting_descriptions.cpp
+++ b/source/setting_descriptions.cpp
@@ -984,8 +984,17 @@ string_view randomTrapDmgDesc         = "All traps will be the base game ice tra
 string_view basicTrapDmgDesc          = "All alternative traps will cause a small damage\n"//
                                         "and no other negative effects";                   //
                                                                                            //
-string_view advancedTrapDmgDesc       = "Some chest traps will burn your Deku Shield or\n" //
-                                        "cause a lot of damage (with one-hit protection)"; //
+string_view advancedTrapDmgDesc       = "Choose which advanced traps may appear from the\n"//
+                                        "list below";                                      //
+                                                                                           //
+string_view fireTrapDesc              = "This trap will set you on fire, burning your\n"   //
+                                        "Deku Shield if it's equipped.";                   //
+                                                                                           //
+string_view antiFairyTrapDesc         = "This dangerous fairy will inflict up to 8 hearts\n"
+                                        "of damage, but it usually doesn't kill you if you\n"
+                                        "have less than that.";                            //
+                                                                                           //
+string_view curseTrapsDesc            = "Some traps will apply status effects for 1 minute.";
                                                                                            //--------------//
 /*------------------------------                                                                           //
 |  DETAILED LOGIC EXPLANATIONS |                                                                           //

--- a/source/setting_descriptions.hpp
+++ b/source/setting_descriptions.hpp
@@ -320,6 +320,9 @@ extern string_view shuffleSFXCategorically;
 extern string_view randomTrapDmgDesc;
 extern string_view basicTrapDmgDesc;
 extern string_view advancedTrapDmgDesc;
+extern string_view fireTrapDesc;
+extern string_view antiFairyTrapDesc;
+extern string_view curseTrapsDesc;
 
 extern string_view ToggleAllTricksDesc;
 

--- a/source/settings.cpp
+++ b/source/settings.cpp
@@ -367,7 +367,7 @@ namespace Settings {
   };
 
   //Item Pool Settings
-  Option ItemPoolValue         = Option::U8  ("Item Pool",             {"Plentiful", "Balanced", "Scarce", "Minimal"},                        {itemPoolPlentiful, itemPoolBalanced, itemPoolScarce, itemPoolMinimal},                                           OptionCategory::Setting,    ITEMPOOL_BALANCED);
+  Option ItemPoolValue         = Option::U8  ("Item Pool",             {"Minimal", "Scarce", "Balanced", "Plentiful"},                        {itemPoolMinimal, itemPoolScarce, itemPoolBalanced, itemPoolPlentiful},                                           OptionCategory::Setting,    ITEMPOOL_BALANCED);
   Option IceTrapValue          = Option::U8  ("Ice Traps",             {"Off", "Normal", "Extra", "Mayhem", "Onslaught"},                     {iceTrapsOff, iceTrapsNormal, iceTrapsExtra, iceTrapsMayhem, iceTrapsOnslaught},                                  OptionCategory::Setting,    ICETRAPS_NORMAL);
   Option RemoveDoubleDefense   = Option::Bool("Remove Double Defense", {"No", "Yes"},                                                         {removeDDDesc});
   Option ProgressiveGoronSword = Option::Bool("Prog Goron Sword",      {"Disabled", "Enabled"},                                               {progGoronSword});

--- a/source/settings.cpp
+++ b/source/settings.cpp
@@ -300,6 +300,9 @@ namespace Settings {
   Option IngameSpoilers      = Option::Bool("Ingame Spoilers",        {"Hide", "Show"},                                                       {ingameSpoilersHideDesc, ingameSpoilersShowDesc });
   Option MenuOpeningButton   = Option::U8  ("Open Info Menu with",    {"Select","Start","D-Pad Up","D-Pad Down","D-Pad Right","D-Pad Left",}, {menuButtonDesc});
   Option RandomTrapDmg       = Option::U8  ("Random Trap Damage",     {"Off", "Basic", "Advanced"},                                           {randomTrapDmgDesc, basicTrapDmgDesc, advancedTrapDmgDesc},                                                       OptionCategory::Setting,    1); // Basic
+  Option FireTrap            = Option::Bool("  Fire Trap",            {"Off", "On"},                                                          {fireTrapDesc},                                                                                                   OptionCategory::Setting,    1); // On
+  Option AntiFairyTrap       = Option::Bool("  Anti-Fairy Trap",      {"Off", "On"},                                                          {antiFairyTrapDesc},                                                                                              OptionCategory::Setting,    1); // On
+  Option CurseTraps          = Option::Bool("  Curse Traps",          {"Off", "On"},                                                          {curseTrapsDesc},                                                                                                 OptionCategory::Setting);
   bool HasNightStart         = false;
   std::vector<Option *> miscOptions = {
     &GossipStoneHints,
@@ -316,6 +319,9 @@ namespace Settings {
     &IngameSpoilers,
     &MenuOpeningButton,
     &RandomTrapDmg,
+    &FireTrap,
+    &AntiFairyTrap,
+    &CurseTraps,
   };
 
   //Item Usability Settings
@@ -1316,6 +1322,9 @@ namespace Settings {
     ctx.ingameSpoilers       = (IngameSpoilers) ? 1 : 0;
     ctx.menuOpeningButton    = MenuOpeningButton.Value<u8>();
     ctx.randomTrapDmg        = RandomTrapDmg.Value<u8>();
+    ctx.fireTrap             = (FireTrap) ? 1 : 0;
+    ctx.antiFairyTrap        = (AntiFairyTrap) ? 1 : 0;
+    ctx.curseTraps           = (CurseTraps) ? 1 : 0;
 
     ctx.faroresWindAnywhere  = (FaroresWindAnywhere) ? 1 : 0;
     ctx.stickAsAdult         = (StickAsAdult) ? 1 : 0;
@@ -2003,6 +2012,17 @@ namespace Settings {
     } else {
       ClearerHints.Unhide();
       HintDistribution.Unhide();
+    }
+
+    //Only show advanced trap options if random trap damage is set to "Advanced"
+    if (RandomTrapDmg.Is(RANDOMTRAPS_ADVANCED)) {
+      FireTrap.Unhide();
+      AntiFairyTrap.Unhide();
+      CurseTraps.Unhide();
+    } else {
+      FireTrap.Hide();
+      AntiFairyTrap.Hide();
+      CurseTraps.Hide();
     }
 
     //Manage toggle for item usability options

--- a/source/settings.hpp
+++ b/source/settings.hpp
@@ -382,6 +382,9 @@ namespace Settings {
   extern Option IngameSpoilers;
   extern Option MenuOpeningButton;
   extern Option RandomTrapDmg;
+  extern Option FireTrap;
+  extern Option AntiFairyTrap;
+  extern Option CurseTraps;
   extern bool HasNightStart;
 
   extern Option FaroresWindAnywhere;

--- a/source/starting_inventory.cpp
+++ b/source/starting_inventory.cpp
@@ -158,14 +158,14 @@ void GenerateStartingInventory() {
   if (hearts < 0) {
     AddItemToInventory(PIECE_OF_HEART, 4);
     // Plentiful and minimal have less than 4 standard pieces of heart so also replace the winner heart
-    if (ItemPoolValue.Value<u8>() == 0 || ItemPoolValue.Value<u8>() == 3) {
+    if (ItemPoolValue.Is(ITEMPOOL_PLENTIFUL) || ItemPoolValue.Is(ITEMPOOL_MINIMAL)) {
         AddItemToInventory(TREASURE_GAME_HEART);
     }
 
     AdditionalHeartContainers = 1 - hearts;
   } else if (hearts > 0) {
     // 16 containers in plentiful, 8 in balanced and 0 in the others
-    u8 maxContainers = 8 * std::max(0, 2 - ItemPoolValue.Value<u8>());
+    u8 maxContainers = 8 * std::max(0, ItemPoolValue.Value<u8>() - 1);
 
     if (hearts <= maxContainers) {
       AddItemToInventory(HEART_CONTAINER, hearts);


### PR DESCRIPTION
This PR adds a new type of trap that can be enabled via a setting.
Instead of damaging Link, these traps will apply a status effect for 1 minute. The currently implemented curses are:
- no shield
- no sword hitbox
- confusion
- invisible terrain

There is also a little easter egg/feature referencing MM's curses.

The new custom messages aren't translated yet.

I've added an enum for trap types so it's easier to read the code and the numbers are the same in `chest.c` and `icetrap.c`.
And I've included settings to disable the fire and anti-fairy advanced traps.

I've also inverted the options order for the Item Pool setting, to make it more consistent with the other settings where scrolling to the right means "increase amount".