### PR TITLE
Make ISG patch optional

### DIFF
--- a/code/src/hooks.s
+++ b/code/src/hooks.s
@@ -1516,6 +1516,17 @@ hook_BossChallenge_ExitMenu:
     cmp r8,#0x0
     bx lr
 
+.global hook_RestoreISG
+hook_RestoreISG:
+    push {lr}
+    push {r0-r12}
+    bl Settings_IsIsgEnabled
+    cmp r0,#0x0
+    pop {r0-r12}
+    bleq 0x34BBFC @Function that cancels ISG
+    pop {lr}
+    bx lr
+
 .section .loader
 .global hook_into_loader
 hook_into_loader:

--- a/code/src/patches.s
+++ b/code/src/patches.s
@@ -650,12 +650,12 @@ OcarinaMinigameEndAfterWin_patch:
 .section .patch_ISGPutaway
 .global ISGPutaway_patch
 ISGPutaway_patch:
-    nop
+    bl hook_RestoreISG
 
 .section .patch_ISGCrouchStab
 .global ISGCrouchStab_patch
 ISGCrouchStab_patch:
-    nop
+    bl hook_RestoreISG
 
 .section .patch_ApplyDamageMultiplier
 .global ApplyDamageMultiplier_patch

--- a/code/src/settings.c
+++ b/code/src/settings.c
@@ -154,6 +154,10 @@ s32 Settings_IsMasterQuestDungeon(void) {
     return 0;
 }
 
+s32 Settings_IsIsgEnabled(void) {
+    return (s32)gSettingsContext.restoreISG;
+}
+
 const char hashIconNames[32][25] = {
     "Deku Stick",
     "Deku Nut",

--- a/code/src/settings.h
+++ b/code/src/settings.h
@@ -478,6 +478,7 @@ typedef struct {
   u8 mirrorShieldAsChild;
   u8 goronTunicAsChild;
   u8 zoraTunicAsChild;
+  u8 restoreISG;
   u8 gkDurability;
 
   u8 itemPoolValue;

--- a/source/setting_descriptions.cpp
+++ b/source/setting_descriptions.cpp
@@ -892,6 +892,13 @@ string_view childGoronTunicDesc       = "Child Link can equip the Goron Tunic.";
 string_view childZoraTunicDesc        = "Child Link can equip the Zora Tunic.";            //
                                                                                            //
 /*------------------------------                                                           //
+|          RESTORE ISG         |                                                           //
+------------------------------*/                                                           //
+string_view restoreISGdesc            = "The Infinite Sword Glitch will work like in OoT.\n\n"
+                                        "Specifically, interrupting a crouch stab will\n"  //
+                                        "activate the glitch, and putting away or pulling\n"
+                                        "out items will not cancel it.";                   //
+/*------------------------------                                                           //
 |         GK DURABILITY        |                                                           //
 ------------------------------*/                                                           //
 string_view gkDurabilityVanilla       = "The durability will always be set to 8.";         //

--- a/source/setting_descriptions.hpp
+++ b/source/setting_descriptions.hpp
@@ -283,6 +283,8 @@ extern string_view childMirrorShieldDesc;
 extern string_view childGoronTunicDesc;
 extern string_view childZoraTunicDesc;
 
+extern string_view restoreISGdesc;
+
 extern string_view gkDurabilityVanilla;
 extern string_view gkDurabilityRandomRisk;
 extern string_view gkDurabilityRandomSafe;

--- a/source/settings.cpp
+++ b/source/settings.cpp
@@ -341,6 +341,7 @@ namespace Settings {
   Option MirrorShieldAsChild = Option::Bool("  Child Mirror Shield",  {"Disabled", "Enabled"},                                                {childMirrorShieldDesc});
   Option GoronTunicAsChild   = Option::Bool("  Child Goron Tunic",    {"Disabled", "Enabled"},                                                {childGoronTunicDesc});
   Option ZoraTunicAsChild    = Option::Bool("  Child Zora Tunic",     {"Disabled", "Enabled"},                                                {childZoraTunicDesc});
+  Option RestoreISG          = Option::Bool("Restore ISG",            {"Disabled", "Enabled"},                                                {restoreISGdesc},                                                                                                 OptionCategory::Setting,    ON);
   Option GkDurability        = Option::U8  ("GK Durability",          {"Vanilla", "Random Risk", "Random Safe"},                              {gkDurabilityVanilla, gkDurabilityRandomRisk, gkDurabilityRandomSafe});
   std::vector<Option *> itemUsabilityOptions = {
     &FaroresWindAnywhere,
@@ -361,6 +362,7 @@ namespace Settings {
     &MirrorShieldAsChild,
     &GoronTunicAsChild,
     &ZoraTunicAsChild,
+    &RestoreISG,
     &GkDurability,
   };
 
@@ -1365,6 +1367,7 @@ namespace Settings {
     ctx.mirrorShieldAsChild  = (MirrorShieldAsChild) ? 1 : 0;
     ctx.goronTunicAsChild    = (GoronTunicAsChild) ? 1 : 0;
     ctx.zoraTunicAsChild     = (ZoraTunicAsChild) ? 1 : 0;
+    ctx.restoreISG           = (RestoreISG) ? 1 : 0;
     ctx.gkDurability         = GkDurability.Value<u8>();
 
     ctx.itemPoolValue        = ItemPoolValue.Value<u8>();
@@ -2062,6 +2065,16 @@ namespace Settings {
       StartingDoubleDefense.Lock();
     } else {
       StartingDoubleDefense.Unlock();
+    }
+
+    if (RestoreISG) {
+      GlitchISG.Unlock();
+      GlitchHover.Unlock();
+    } else {
+      GlitchISG.SetSelectedIndex(0);
+      GlitchISG.Lock();
+      GlitchHover.SetSelectedIndex(0);
+      GlitchHover.Lock();
     }
 
     if (currentSetting != nullptr) {

--- a/source/settings.hpp
+++ b/source/settings.hpp
@@ -407,6 +407,7 @@ namespace Settings {
   extern Option MirrorShieldAsChild;
   extern Option GoronTunicAsChild;
   extern Option ZoraTunicAsChild;
+  extern Option RestoreISG;
   extern Option GkDurability;
 
   extern Option ItemPoolValue;


### PR DESCRIPTION
The default option will keep ISG enabled.
Disabling it could be interesting to make more challenging playthroughs with no logic or glitched logic (after all why would you do super stabs if you can just do ISG and keep your stick), or just to stay closer to vanilla OoT3D.