### PR TITLE
Add 0 hearts to starting health options

### DIFF
--- a/code/src/actors/chest.c
+++ b/code/src/actors/chest.c
@@ -145,9 +145,19 @@ u8 Chest_OverrideDecoration() {
     return 0;
 }
 
+u8 vanillaIceTrap() {
+    // Ice Traps from chests softlock when max health is 0, so just kill Link immediately
+    if (gSaveContext.healthCapacity == 0) {
+        PLAYER->stateFlags1 &= ~0x20000C00;
+        gSaveContext.health = 0;
+        return 1;
+    }
+    return 0;
+}
+
 u8 Chest_OverrideIceSmoke(Actor* thisx) {
     if (gSettingsContext.randomTrapDmg == RANDOMTRAPS_OFF) {
-        return 0;
+        return vanillaIceTrap();
     }
 
     if (possibleChestTrapsAmount == 0)
@@ -172,7 +182,7 @@ u8 Chest_OverrideIceSmoke(Actor* thisx) {
         }
 
         if (trapType == ICETRAP_VANILLA) {
-            return 0;
+            return vanillaIceTrap();
         }
         PLAYER->getItemId = 0;
         PLAYER->stateFlags1 &= ~0x20000C00;

--- a/code/src/actors/player.c
+++ b/code/src/actors/player.c
@@ -62,6 +62,13 @@ void PlayerActor_rInit(Actor* thisx, GlobalContext* globalCtx) {
         gSaveContext.equips.equipment &= ~0xF0; // unequip shield
     }
 
+    // If the player has started with 0 hearts, some entrances that knock Link down will cause a Game Over.
+    // When respawning after the Game Over, change the entrance type to avoid softlocks.
+    u8 playerEntranceType = (thisx->params & 0xF00) >> 8;
+    if (gSaveContext.healthCapacity == 0 && gSaveContext.respawnFlag == -2 && playerEntranceType == 7) {
+        thisx->params = (thisx->params & ~0xF00) | 0xD00; // Link will spawn standing in place
+    }
+
     PlayerActor_Init(thisx, globalCtx);
 
     if (gSettingsContext.fastBunnyHood) {

--- a/code/src/item_effect.c
+++ b/code/src/item_effect.c
@@ -8,8 +8,11 @@ void ItemEffect_None(SaveContext* saveCtx, s16 arg1, s16 arg2) {
 }
 
 void ItemEffect_FullHeal(SaveContext* saveCtx, s16 arg1, s16 arg2) {
-    //With the No Health Refills option on, store-bought health upgrades do not heal the player
-    if((gSettingsContext.heartDropRefill != HEARTDROPREFILL_NOREFILL) && (gSettingsContext.heartDropRefill != HEARTDROPREFILL_NODROPREFILL)){
+    //With the No Health Refills option on, or if max health is currently 0, store-bought health upgrades do not heal the player
+    if (gSettingsContext.heartDropRefill != HEARTDROPREFILL_NOREFILL &&
+        gSettingsContext.heartDropRefill != HEARTDROPREFILL_NODROPREFILL &&
+        gSaveContext.healthCapacity > 0) {
+
         saveCtx->healthAccumulator = 20 * 0x10;
     }
 }
@@ -157,8 +160,11 @@ void ItemEffect_GiveSmallKeyRing(SaveContext* saveCtx, s16 dungeonId, s16 arg2) 
 void ItemEffect_GiveDefense(SaveContext* saveCtx, s16 arg1, s16 arg2) {
     saveCtx->doubleDefense = 1;
     // saveCtx->defense_hearts = 20; //TODO? is this needed?
-    //With the No Health Refills option on, store-bought health upgrades do not heal the player
-    if((gSettingsContext.heartDropRefill != HEARTDROPREFILL_NOREFILL) && (gSettingsContext.heartDropRefill != HEARTDROPREFILL_NODROPREFILL)){
+    //With the No Health Refills option on, or if max health is currently 0, store-bought health upgrades do not heal the player
+    if (gSettingsContext.heartDropRefill != HEARTDROPREFILL_NOREFILL &&
+        gSettingsContext.heartDropRefill != HEARTDROPREFILL_NODROPREFILL &&
+        gSaveContext.healthCapacity > 0) {
+
         saveCtx->healthAccumulator = 20 * 0x10;
     }
 

--- a/code/src/multiplayer.c
+++ b/code/src/multiplayer.c
@@ -2398,11 +2398,7 @@ void Multiplayer_Receive_HealthChange(u16 senderID) {
         }
         gSaveContext.health += diff;
 
-        if (gSaveContext.health > gSaveContext.healthCapacity) {
-            gSaveContext.health = gSaveContext.healthCapacity;
-        } else if (gSaveContext.health < 0) {
-            gSaveContext.health = 0;
-        }
+        SaveFile_EnforceHealthLimit();
 
         prevHealth = gSaveContext.health;
     }

--- a/code/src/savefile.c
+++ b/code/src/savefile.c
@@ -678,7 +678,10 @@ void SaveFile_SaveExtSaveData(u32 saveNumber) {
 }
 
 void SaveFile_EnforceHealthLimit(void) {
-    if (gSaveContext.health > gSaveContext.healthCapacity) {
-        gSaveContext.health = gSaveContext.healthCapacity;
+    u16 healthLimit = (gSaveContext.healthCapacity == 0) ? 2 : gSaveContext.healthCapacity;
+    if (gSaveContext.health > healthLimit) {
+        gSaveContext.health = healthLimit;
+    } else if (gSaveContext.health < 0) {
+        gSaveContext.health = 0;
     }
 }

--- a/code/src/settings.c
+++ b/code/src/settings.c
@@ -75,6 +75,8 @@ u32 Settings_SetFullHealthRestore(u8 setAmount) {
     }
 }
 u32 NoHealFromHealthUpgrades(void) {
+    if (gSaveContext.healthCapacity == 0) // avoid Game Over when picking up a PoH with 0 hearts
+        return 0;
     return Settings_SetFullHealthRestore(0);
 }
 u32 NoHealFromBombchuBowlingPrize(void) {

--- a/code/src/sfx.c
+++ b/code/src/sfx.c
@@ -28,8 +28,8 @@ u32 SetSFX(u32 original) {
         return SEQ_AUDIO_BLANK;
     }
 
-    static const u16 HITPOINT_ALARM = 1183; // Disable low health beep when max health is 1 heart
-    if (sfxID == HITPOINT_ALARM && gSaveContext.healthCapacity == 0x10) {
+    static const u16 HITPOINT_ALARM = 1183; // Disable low health beep when max health is 1 heart or lower
+    if (sfxID == HITPOINT_ALARM && gSaveContext.healthCapacity <= 0x10) {
         return SEQ_AUDIO_BLANK;
     }
 

--- a/source/item_pool.cpp
+++ b/source/item_pool.cpp
@@ -595,8 +595,8 @@ static void SetMinimalItemPool() {
   ReplaceMaxItem(PROGRESSIVE_SLINGSHOT, 1);
   ReplaceMaxItem(PROGRESSIVE_BOMB_BAG, 1);
   ReplaceMaxItem(PIECE_OF_HEART, 0);
-  // Need an extra heart container when starting with 1 heart to be able to reach 3 hearts
-  ReplaceMaxItem(HEART_CONTAINER, (StartingHearts.Value<u8>() == 18)? 1 : 0);
+  // Need extra heart containers when starting with 1 heart or less to be able to reach 3 hearts
+  ReplaceMaxItem(HEART_CONTAINER, 2 - StartingHearts.Value<u8>());
 }
 
 void GenerateItemPool() {
@@ -929,7 +929,7 @@ void GenerateItemPool() {
         AddItemToPool(PendingJunkPool, GANONS_CASTLE_KEY_RING);
       } else {
         AddItemToPool(PendingJunkPool, GANONS_CASTLE_SMALL_KEY);
-      } 
+      }
     }
 
     if (BossKeysanity.Is(BOSSKEYSANITY_ANYWHERE) || BossKeysanity.Is(BOSSKEYSANITY_ANY_DUNGEON) || BossKeysanity.Is(BOSSKEYSANITY_OVERWORLD)) {

--- a/source/location_access/locacc_ganons_castle.cpp
+++ b/source/location_access/locacc_ganons_castle.cpp
@@ -114,7 +114,7 @@ void AreaTable_Init_GanonsCastle() {
                   //Locations
                   LocationAccess(GANONS_TOWER_BOSS_KEY_CHEST, {[]{return true;}}),
                   LocationAccess(GANONDORF_HINT,              {[]{return BossKeyGanonsCastle;}}),
-                  LocationAccess(GANON,                       {[]{return BossKeyGanonsCastle && CanUse(LIGHT_ARROWS);}}),
+                  LocationAccess(GANON,                       {[]{return BossKeyGanonsCastle && CanUse(LIGHT_ARROWS) && Hearts > 0;}}),
   }, {});
 
   /*---------------------------

--- a/source/location_access/locacc_water_temple.cpp
+++ b/source/location_access/locacc_water_temple.cpp
@@ -245,8 +245,8 @@ void AreaTable_Init_WaterTemple() {
 
   areaTable[WATER_TEMPLE_DARK_LINK_ROOM] = Area("Water Temple Dark Link Room", "Water Temple", WATER_TEMPLE, NO_DAY_NIGHT_CYCLE, {}, {}, {
                   //Exits
-                  Entrance(WATER_TEMPLE_DRAGON_PILLARS_ROOM, {[]{return CanUse(KOKIRI_SWORD) || CanUse(MASTER_SWORD) || CanUse(BIGGORON_SWORD);}}),
-                  Entrance(WATER_TEMPLE_LONGSHOT_ROOM,       {[]{return CanUse(KOKIRI_SWORD) || CanUse(MASTER_SWORD) || CanUse(BIGGORON_SWORD);}}),
+                  Entrance(WATER_TEMPLE_DRAGON_PILLARS_ROOM, {[]{return (CanUse(KOKIRI_SWORD) || CanUse(MASTER_SWORD) || CanUse(BIGGORON_SWORD)) && Hearts > 0;}}),
+                  Entrance(WATER_TEMPLE_LONGSHOT_ROOM,       {[]{return (CanUse(KOKIRI_SWORD) || CanUse(MASTER_SWORD) || CanUse(BIGGORON_SWORD)) && Hearts > 0;}}),
   });
 
   areaTable[WATER_TEMPLE_LONGSHOT_ROOM] = Area("Water Temple Longshot Room", "Water Temple", WATER_TEMPLE, NO_DAY_NIGHT_CYCLE, {}, {

--- a/source/logic.cpp
+++ b/source/logic.cpp
@@ -1143,7 +1143,7 @@ namespace Logic {
      BigPoeKill          = false;
      HookshotOrBoomerang = false;
 
-     BaseHearts      = StartingHearts.Value<u8>() + 1;
+     BaseHearts      = StartingHearts.Value<u8>();
      Hearts          = 0;
      Multiplier      = (DamageMultiplier.Value<u8>() < 6) ? DamageMultiplier.Value<u8>() : 10;
      EffectiveHealth = 0;

--- a/source/logic.cpp
+++ b/source/logic.cpp
@@ -705,7 +705,7 @@ namespace Logic {
     Bugs         = HasBottle && BugsAccess;
     BlueFire     = HasBottle && BlueFireAccess;
     Fish         = HasBottle && FishAccess;
-    Fairy        = HasBottle && FairyAccess;
+    Fairy        = HasBottle && FairyAccess && Hearts > 0;
 
     FoundBombchus   = (BombchuDrop || Bombchus || Bombchus5 || Bombchus10 || Bombchus20);
     CanPlayBowling  = (BombchusInLogic && FoundBombchus) || (!BombchusInLogic && BombBag);
@@ -744,7 +744,7 @@ namespace Logic {
     EffectiveHealth = ((Hearts << (2 + DoubleDefense)) >> Multiplier) + ((Hearts << (2 + DoubleDefense)) % (1 << Multiplier) > 0); //Number of half heart hits to die, ranges from 1 to 160
     FireTimer       = CanUse(GORON_TUNIC) ? 255 : (LogicFewerTunicRequirements) ? (Hearts * 8) : 0;
     WaterTimer      = CanUse( ZORA_TUNIC) ? 255 : (LogicFewerTunicRequirements) ? (Hearts * 8) : 0;
-    NeedNayrusLove      = (EffectiveHealth == 1);
+    NeedNayrusLove      = (EffectiveHealth <= 1);
     CanSurviveDamage    = !NeedNayrusLove || CanUse(NAYRUS_LOVE);
     CanTakeDamage       = Fairy || CanSurviveDamage;
     CanTakeDamageTwice  = (Fairy && NumBottles >= 2) || ((EffectiveHealth == 2) && (CanUse(NAYRUS_LOVE) || Fairy)) || (EffectiveHealth > 2);

--- a/source/setting_descriptions.cpp
+++ b/source/setting_descriptions.cpp
@@ -755,6 +755,15 @@ string_view startWithConsumablesDesc  = "Start the game with maxed out Deku Stic
 ------------------------------*/                                                           //
 string_view startWithMaxRupeesDesc    = "Start the game with a full wallet.\n"             //
                                         "Wallet upgrades will also fill the wallet.";      //
+/*------------------------------                                                           //
+|        STARTING HEALTH       |                                                           //
+------------------------------*/                                                           //
+string_view startingHealthDesc        = "If you start with 0 hearts, Link will be instantly"
+                                        "KO'd not only by any damage source, but also by\n"//
+                                        "recovery hearts and fairies. Sometimes guards too.\n"
+                                        "You can safely pick up Heart Pieces and Containers"
+                                        "though, and the effects will end when you obtain\n"
+                                        "at least one heart.";                             //
                                                                                            //
 /*------------------------------                                                           //
 |          ITEM POOL           |                                                           //

--- a/source/setting_descriptions.hpp
+++ b/source/setting_descriptions.hpp
@@ -248,6 +248,8 @@ extern string_view startWithConsumablesDesc;
 
 extern string_view startWithMaxRupeesDesc;
 
+extern string_view startingHealthDesc;
+
 extern string_view itemPoolPlentiful;
 extern string_view itemPoolBalanced;
 extern string_view itemPoolScarce;

--- a/source/settings.cpp
+++ b/source/settings.cpp
@@ -522,7 +522,7 @@ namespace Settings {
   Option StartingScale            = Option::U8  ("Scale Upgrade",        {"Off",             "Silver Scale"  ,   "Golden Scale"},                         {""});
   Option StartingWallet           = Option::U8  ("Wallet Upgrade",       {"Off",             "Adult's Wallet",   "Giant's Wallet" ,  "Tycoon's Wallet"},  {""});
   Option StartingShardOfAgony     = Option::U8  ("Shard of Agony",       {"Off",             "On"},                                                       {""});
-  Option StartingHearts           = Option::U8  ("Hearts",               {NumOpts(1, 20)},                                                                {""}, OptionCategory::Setting, 2); // Default 3 hearts
+  Option StartingHearts           = Option::U8  ("Hearts",               {NumOpts(0, 20)},                                                                {startingHealthDesc,""}, OptionCategory::Setting, 3); // Default 3 hearts
   Option StartingMagicMeter       = Option::U8  ("Magic Meter",          {"Off",             "Single Magic",     "Double Magic"},                         {""});
   Option StartingDoubleDefense    = Option::U8  ("Double Defense",       {"Off",             "On"},                                                       {""});
   std::vector<Option *> startingEquipmentOptions = {
@@ -1470,7 +1470,7 @@ namespace Settings {
     ctx.startingOcarina       = StartingOcarina.Value<u8>();
     ctx.startingKokiriSword   = StartingKokiriSword.Value<u8>();
     ctx.startingBiggoronSword = StartingBiggoronSword.Value<u8>();
-    ctx.startingHearts        = StartingHearts.Value<u8>() + 1;
+    ctx.startingHearts        = StartingHearts.Value<u8>();
     ctx.startingMagicMeter    = StartingMagicMeter.Value<u8>();
     ctx.startingDoubleDefense = StartingDoubleDefense.Value<u8>();
 

--- a/source/starting_inventory.cpp
+++ b/source/starting_inventory.cpp
@@ -153,7 +153,7 @@ void GenerateStartingInventory() {
   AddItemToInventory(LIGHT_MEDALLION,           StartingLightMedallion.Value<u8>());
   AddItemToInventory(GOLD_SKULLTULA_TOKEN,      StartingSkulltulaToken.Value<u8>());
 
-  s8 hearts = StartingHearts.Value<u8>() - 2;
+  s8 hearts = StartingHearts.Value<u8>() - 3;
   AdditionalHeartContainers = 0;
   if (hearts < 0) {
     AddItemToInventory(PIECE_OF_HEART, 4);


### PR DESCRIPTION
Given that the health logic was already accounting for starting with less than 3 hearts, I've added the option to start with no hearts at all, which acts sort of like a temporary "super OHKO".

This also fixes an error regarding heart containers in the minimal item pool.