### PR TITLE
Bug fixes: starting tokens, key rings placement and menu glitches

### DIFF
--- a/source/fill.cpp
+++ b/source/fill.cpp
@@ -769,7 +769,7 @@ static void RandomizeOwnDungeon(const Dungeon::DungeonInfo* dungeon) {
 
   //Add specific items that need be randomized within this dungeon
   if (Keysanity.Is(KEYSANITY_OWN_DUNGEON) && dungeon->GetSmallKey() != NONE) {
-    std::vector<ItemKey> dungeonSmallKeys = FilterAndEraseFromPool(ItemPool, [dungeon](const ItemKey i){ return i == dungeon->GetSmallKey();});
+    std::vector<ItemKey> dungeonSmallKeys = FilterAndEraseFromPool(ItemPool, [dungeon](const ItemKey i){ return (i == dungeon->GetSmallKey()) || (i == dungeon->GetKeyRing());});
     AddElementsToPool(dungeonItems, dungeonSmallKeys);
   }
 
@@ -810,10 +810,10 @@ static void RandomizeDungeonItems() {
 
   for (auto dungeon : dungeonList) {
     if (Keysanity.Is(KEYSANITY_ANY_DUNGEON)) {
-      auto dungeonKeys = FilterAndEraseFromPool(ItemPool, [dungeon](const ItemKey i){return i == dungeon->GetSmallKey();});
+      auto dungeonKeys = FilterAndEraseFromPool(ItemPool, [dungeon](const ItemKey i){return (i == dungeon->GetSmallKey()) || (i == dungeon->GetKeyRing());});
       AddElementsToPool(anyDungeonItems, dungeonKeys);
     } else if (Keysanity.Is(KEYSANITY_OVERWORLD)) {
-      auto dungeonKeys = FilterAndEraseFromPool(ItemPool, [dungeon](const ItemKey i){return i == dungeon->GetSmallKey();});
+      auto dungeonKeys = FilterAndEraseFromPool(ItemPool, [dungeon](const ItemKey i){return (i == dungeon->GetSmallKey()) || (i == dungeon->GetKeyRing());});
       AddElementsToPool(overworldItems, dungeonKeys);
     }
 

--- a/source/fill.cpp
+++ b/source/fill.cpp
@@ -162,8 +162,8 @@ static int GetMaxGSCount() {
   else if (Location(KAK_10_GOLD_SKULLTULA_REWARD)->GetPlacedItem().IsAdvancement() && Location(KAK_10_GOLD_SKULLTULA_REWARD)->GetPlacedItem().GetItemType() != ITEMTYPE_TOKEN) {
     maxUseful = 10;
   }
-  //Return max of the two possible reasons tokens could be important
-  return std::max(maxUseful, maxBridge);
+  //Return max of the two possible reasons tokens could be important, minus the tokens in the starting inventory
+  return std::max(maxUseful, maxBridge) - StartingSkulltulaToken.Value<u8>();
 }
 
 std::string GetShopItemBaseName(std::string itemName) {

--- a/source/menu.cpp
+++ b/source/menu.cpp
@@ -202,7 +202,7 @@ void MenuUpdate(u32 kDown, bool updatedByHeld) {
     kDown = 0;
   }
 
-  if (currentMenu->mode != GENERATE_MODE) {
+  if (currentMenu->mode != POST_GENERATE) {
 
     //New Random Seed
     if (kDown & KEY_Y) {

--- a/source/preset.cpp
+++ b/source/preset.cpp
@@ -66,7 +66,7 @@ bool CreatePresetDirectories() {
 std::vector<std::string> GetSettingsPresets() {
   std::vector<std::string> presetEntries = {};
   for (const auto& entry : fs::directory_iterator(GetBasePath(OptionCategory::Setting))) {
-    if(entry.path().stem().string() != CACHED_SETTINGS_FILENAME) {
+    if(entry.is_regular_file() && entry.path().stem().string() != CACHED_SETTINGS_FILENAME) {
       presetEntries.push_back(entry.path().stem().string());
     }
   }


### PR DESCRIPTION
Currently the filling algorithm thinks that all required tokens have to be collected during the playthrough, even if you start with some of them.

Here's an example with a seed that required the 50 tokens reward, but with 20 already in the starting inventory.
Before the fix, 20 useless tokens appear in the playthrough after the reward is obtained:
![bugged](https://user-images.githubusercontent.com/82058772/186484850-9cfd69cf-4c2f-4972-b441-b14cde1032fc.png)

After the fix:
![fixed](https://user-images.githubusercontent.com/82058772/186484876-ff4d30d7-d7a3-45b2-901a-85efc97018a1.png)


Key rings will now be placed according to the keysanity setting (own dungeon / any dungeon / overworld), which they previously ignored.

A couple of minor glitches in the menus have also been fixed.