### PR TITLE
Bug fixes: app crash, adult start spawn, arrow swapping

### DIFF
--- a/code/src/savefile.c
+++ b/code/src/savefile.c
@@ -83,6 +83,7 @@ void SaveFile_Init(u32 fileBaseIndex) {
     }
 
     if (gSettingsContext.resolvedStartingAge == AGE_ADULT) {
+        gSaveContext.sceneIndex = 0x43;    //Temple of Time (any scene other than a dungeon or Link's House would work too)
         gSaveContext.linkAge = AGE_ADULT;  //age is adult
         gSaveContext.childEquips.equipment = 0x1100; //Child equips Kokiri Tunic and Kokiri Boots, no sword or shield
         gSaveContext.adultEquips.equipment = 0x1120; //Adult equips Kokiri Tunic, Kokiri Boots, and Master Sword

--- a/source/menu.cpp
+++ b/source/menu.cpp
@@ -261,6 +261,9 @@ void ModeChangeInit() {
     //loop through until we reach an unlocked setting
     while(currentMenu->settingsList->at(currentMenu->menuIdx)->IsLocked() || currentMenu->settingsList->at(currentMenu->menuIdx)->IsHidden()) {
       currentMenu->menuIdx++;
+      if (currentMenu->menuIdx >= currentMenu->settingsList->size()) {
+        currentMenu->menuIdx = 0;
+      }
     }
     currentSetting = currentMenu->settingsList->at(currentMenu->menuIdx);
 


### PR DESCRIPTION
- Added a boundary check on `menuIdx` when entering an options menu.
This fixes the bug where, if you place the cursor on the Ruto's Letter option in the Starting Inventory, then change Zora's Fountain to be open, and finally go back to the Starting Inventory menu, the app will close.

- Fixed the spawn point for adult start, which I accidentally broke with a previous PR (it currently spawns in Link's house).

- Fixed a bug where swapping arrows could make magic unusable.