### PR TITLE
Setting for Extra Arrow Effects

### DIFF
--- a/code/include/z3D/z3D.h
+++ b/code/include/z3D/z3D.h
@@ -332,7 +332,6 @@ typedef struct SubGlobalContext_118 {
     /* 0x60 */ void** unk_60; //seems to point to an array of cutscene pointers, maybe?
 } SubGlobalContext_118; // size = at least 0x64
 
-typedef struct Collider Collider; //TODO
 typedef struct OcLine OcLine; //TODO
 #define COLLISION_CHECK_AT_MAX 50
 #define COLLISION_CHECK_AC_MAX 60
@@ -622,5 +621,9 @@ typedef void (*Player_SetEquipmentData_proc)(GlobalContext* globalCtx, Player* p
 typedef s32 (*BossChallenge_IsActive_proc)(void);
 #define BossChallenge_IsActive_addr 0x35B164
 #define BossChallenge_IsActive ((BossChallenge_IsActive_proc)BossChallenge_IsActive_addr)
+
+typedef s32 (*Audio_PlayActorSfx2_proc)(Actor* actor, s32 sfxID);
+#define Audio_PlayActorSfx2_addr 0x375BCC
+#define Audio_PlayActorSfx2 ((Audio_PlayActorSfx2_proc)Audio_PlayActorSfx2_addr)
 
 #endif //_Z3D_H_

--- a/code/include/z3D/z3Dactor.h
+++ b/code/include/z3D/z3Dactor.h
@@ -115,6 +115,25 @@ typedef struct {
 } CollisionCheckInfo; // size = 0x1C
 
 typedef struct {
+    /* 0x00 */ struct Actor* actor; // Attached actor
+    /* 0x04 */ struct Actor* at; // Actor attached to what it collided with as an AT collider.
+    /* 0x08 */ struct Actor* ac; // Actor attached to what it collided with as an AC collider.
+    /* 0x0C */ struct Actor* oc; // Actor attached to what it collided with as an OC collider.
+    /* 0x10 */ u8 atFlags; // Information flags for AT collisions.
+    /* 0x11 */ u8 acFlags; // Information flags for AC collisions.
+    /* 0x12 */ u8 ocFlags1; // Information flags for OC collisions.
+    /* 0x13 */ u8 ocFlags2;  // Flags related to which colliders it can OC collide with.
+    /* 0x14 */ u8 colType; // Determines hitmarks and sound effects during AC collisions.
+    /* 0x15 */ u8 shape; // JntSph, Cylinder, Tris, or Quad
+} Collider; // size = 0x18
+
+typedef struct {
+    /* 0x00 */ Collider base;
+    /* 0x18 */ //ColliderInfo info;
+    /* 0x40 */ //Cylinderf dim;
+} ColliderCylinder; // size = 0x58
+
+typedef struct {
     /* 0x00 */ Vec3s  rot; // Current actor shape rotation
     /* 0x06 */ u8     unk_06;
     /* 0x08 */ f32    unk_08; // Model y axis offset. Represents model space units. collision mesh related
@@ -194,6 +213,18 @@ typedef struct Actor {
     /* 0x1A0 */ f32           unk_1A0;
    /* From here on, the structure and size varies for each actor */
 } Actor; // size = 0x1A4
+
+typedef struct DynaPolyActor {
+    /* 0x000 */ struct Actor actor;
+    /* 0x1A4 */ s32 bgId;
+    /* 0x1A8 */ f32 unk_1A8;
+    /* 0x1AC */ f32 unk_1AC;
+    /* 0x1B0 */ s16 unk_1B0;
+    /* 0x1B2 */ u16 unk_1B2;
+    /* 0x1B4 */ u32 unk_1B4;
+    /* 0x1B8 */ u8 unk_1B8;
+    /* 0x1BA */ s16 unk_1BA;
+} DynaPolyActor; // size = 0x1BC
 
 typedef struct {
     /* 0x00 */ Actor* actor;

--- a/code/oot.ld
+++ b/code/oot.ld
@@ -700,6 +700,10 @@ SECTIONS
 		*(.patch_Gfx_Update)
 	}
 
+	.patch_CollisionATvsAC 0x3191B0 : {
+		*(.patch_CollisionATvsAC)
+	}
+
 	.patch_ISGPutaway 0x32B4AC : {
 		*(.patch_ISGPutaway)
 	}

--- a/code/oot_e.ld
+++ b/code/oot_e.ld
@@ -700,6 +700,10 @@ SECTIONS
 		*(.patch_Gfx_Update)
 	}
 
+	.patch_CollisionATvsAC 0x3191B0 : {
+		*(.patch_CollisionATvsAC)
+	}
+
 	.patch_ISGPutaway 0x32B4AC : {
 		*(.patch_ISGPutaway)
 	}

--- a/code/src/actors/red_ice.c
+++ b/code/src/actors/red_ice.c
@@ -1,0 +1,30 @@
+#include "z3D/z3D.h"
+#include "settings.h"
+#include "red_ice.h"
+
+#define ACTOR_BG_ICE_SHELTER 0xEF // Red Ice
+#define ACTOR_EN_ARROW 0x16
+#define ARROW_ICE 4
+
+#define BgIceShelter_Melt ((BgIceShelterActionFunc)0x3F5F00)
+#define NA_SE_EV_ICE_MELT 0x10001F9
+
+void RedIce_CheckIceArrow(Collider* at, Collider* ac) {
+    if (gSettingsContext.extraArrowEffects &&
+        at->actor != 0 && at->actor->id == ACTOR_EN_ARROW && at->actor->params == ARROW_ICE &&
+        ac->actor != 0 && ac->actor->id == ACTOR_BG_ICE_SHELTER) {
+
+        BgIceShelter* ice = (BgIceShelter*) ac->actor;
+        s16 type = (ice->dyna.actor.params >> 8) & 7;
+
+        if (type == RED_ICE_KING_ZORA) {
+            if (ice->dyna.actor.parent != 0) {
+                ice->dyna.actor.parent->freezeTimer = 50;
+            }
+        }
+
+        ice->actionFunc = BgIceShelter_Melt;
+        ice->alpha = 0xFF;
+        Audio_PlayActorSfx2(&ice->dyna.actor, NA_SE_EV_ICE_MELT);
+    }
+}

--- a/code/src/actors/red_ice.h
+++ b/code/src/actors/red_ice.h
@@ -1,0 +1,26 @@
+#ifndef _RED_ICE_H_
+#define _RED_ICE_H_
+
+#include "z3D/z3D.h"
+
+struct BgIceShelter;
+
+typedef void (*BgIceShelterActionFunc)(struct BgIceShelter*, GlobalContext*);
+
+typedef enum {
+    /* 0 */ RED_ICE_LARGE,    // Large red ice block
+    /* 1 */ RED_ICE_SMALL,    // Small red ice block
+    /* 2 */ RED_ICE_PLATFORM, // Complex structure that can be climbed and walked on. Unused in vanilla OoT, used in MQ to cover the Ice Cavern Map chest
+    /* 3 */ RED_ICE_WALL,     // Vertical ice sheets blocking corridors
+    /* 4 */ RED_ICE_KING_ZORA // Giant red ice block covering King Zora
+} RedIceType;
+
+typedef struct BgIceShelter {
+    /* 0x0000 */ DynaPolyActor          dyna;
+    /* 0x01BC */ BgIceShelterActionFunc actionFunc;
+    /* 0x01C0 */ ColliderCylinder       cylinder1; // Used to detect blue fire and also as OC for no-dynapoly types
+    /* 0x0218 */ ColliderCylinder       cylinder2; // Only used by no-dynapoly types to make weapons bounce off
+    /* 0x0270 */ s16                    alpha;
+} BgIceShelter; // size = 0x0204
+
+#endif

--- a/code/src/hooks.s
+++ b/code/src/hooks.s
@@ -1628,6 +1628,16 @@ hook_CriticalHealthCheck:
     movle r0,#0x18
     bx lr
 
+.global hook_CollisionATvsAC
+hook_CollisionATvsAC:
+    ldr r12,[sp,#0x18]
+    push {r0-r12,lr}
+    cpy r0,r1  @ AT collider
+    cpy r1,r12 @ AC collider
+    bl RedIce_CheckIceArrow
+    pop {r0-r12,lr}
+    bx lr
+
 .section .loader
 .global hook_into_loader
 hook_into_loader:

--- a/code/src/patches.s
+++ b/code/src/patches.s
@@ -1925,6 +1925,11 @@ CriticalHealthCheckThree_patch:
     nop
     nop
 
+.section .patch_CollisionATvsAC
+.global CollisionATvsAC_patch
+CollisionATvsAC_patch:
+    bl hook_CollisionATvsAC
+
 .section .patch_loader
 .global loader_patch
 

--- a/code/src/settings.h
+++ b/code/src/settings.h
@@ -499,6 +499,7 @@ typedef struct {
   u8 fireTrap;
   u8 antiFairyTrap;
   u8 curseTraps;
+  u8 extraArrowEffects;
 
   u8 faroresWindAnywhere;
   u8 stickAsAdult;

--- a/source/descriptions.cpp
+++ b/source/descriptions.cpp
@@ -1064,6 +1064,15 @@ string_view antiFairyTrapDesc         = "This dangerous fairy will inflict up to
                                         "have less than that.";                            //
                                                                                            //
 string_view curseTrapsDesc            = "Some traps will apply status effects for 1 minute.";
+                                                                                           //
+/*------------------------------                                                           //
+|      EXTRA ARROW EFFECTS     |                                                           //
+------------------------------*/                                                           //
+string_view extraArrowEffectsDesc     = "Ice Arrows will act like blue fire, melting red\n"//
+                                        "ice and breaking mud walls in Dodongo's Cavern.\n\n"
+                                        "Light Arrows will activate Sun Switches like in\n"//
+                                        "Majora's Mask.";                                  //
+                                                                                           //
                                                                                            //--------------//
 /*------------------------------                                                                           //
 |  DETAILED LOGIC EXPLANATIONS |                                                                           //

--- a/source/descriptions.hpp
+++ b/source/descriptions.hpp
@@ -338,6 +338,7 @@ extern string_view advancedTrapDmgDesc;
 extern string_view fireTrapDesc;
 extern string_view antiFairyTrapDesc;
 extern string_view curseTrapsDesc;
+extern string_view extraArrowEffectsDesc;
 
 extern string_view ToggleAllTricksDesc;
 

--- a/source/location_access/locacc_ganons_castle.cpp
+++ b/source/location_access/locacc_ganons_castle.cpp
@@ -86,8 +86,8 @@ void AreaTable_Init_GanonsCastle() {
 
   areaTable[GANONS_CASTLE_SPIRIT_TRIAL] = Area("Ganon's Castle Spirit Trial", "Ganon's Castle", GANONS_CASTLE, NO_DAY_NIGHT_CYCLE, {
                   //Events
-                  EventAccess(&NutPot,           {[]{return NutPot || ((LogicSpiritTrialHookshot || CanUse(HOOKSHOT)) && HasBombchus && Bow && MirrorShield && IsAdult);}}),
-                  EventAccess(&SpiritTrialClear, {[]{return CanUse(LIGHT_ARROWS) && IsAdult && CanUse(MIRROR_SHIELD) && HasBombchus && (LogicSpiritTrialHookshot || CanUse(HOOKSHOT));}}),
+                  EventAccess(&NutPot,           {[]{return NutPot || ((LogicSpiritTrialHookshot || CanUse(HOOKSHOT)) && HasBombchus && Bow && (MirrorShield || (ExtraArrowEffects && CanUse(LIGHT_ARROWS))) && IsAdult);}}),
+                  EventAccess(&SpiritTrialClear, {[]{return CanUse(LIGHT_ARROWS) && IsAdult && (CanUse(MIRROR_SHIELD) || ExtraArrowEffects) && HasBombchus && (LogicSpiritTrialHookshot || CanUse(HOOKSHOT));}}),
                 }, {
                   //Locations
                   LocationAccess(GANONS_CASTLE_SPIRIT_TRIAL_CRYSTAL_SWITCH_CHEST, {[]{return LogicSpiritTrialHookshot || CanUse(HOOKSHOT);}}),
@@ -189,16 +189,16 @@ void AreaTable_Init_GanonsCastle() {
 
   areaTable[GANONS_CASTLE_MQ_SPIRIT_TRIAL] = Area("Ganon's Castle MQ Spirit Castle", "Ganons Castle", GANONS_CASTLE, NO_DAY_NIGHT_CYCLE, {
                   //Events
-                  EventAccess(&SpiritTrialClear, {[]{return IsAdult && CanUse(LIGHT_ARROWS) && Hammer && HasBombchus && FireArrows && MirrorShield;}}),
-                  EventAccess(&NutPot,           {[]{return NutPot || (Hammer && HasBombchus && IsAdult && CanUse(FIRE_ARROWS) && MirrorShield);}}),
+                  EventAccess(&SpiritTrialClear, {[]{return IsAdult && CanUse(LIGHT_ARROWS) && Hammer && HasBombchus && ((FireArrows && MirrorShield) || ExtraArrowEffects);}}),
+                  EventAccess(&NutPot,           {[]{return NutPot || (Hammer && HasBombchus && IsAdult && ((CanUse(FIRE_ARROWS) && MirrorShield) || (ExtraArrowEffects && CanUse(LIGHT_ARROWS))));}}),
   }, {
                   //Locations
                   LocationAccess(GANONS_CASTLE_MQ_SPIRIT_TRIAL_FIRST_CHEST,             {[]{return IsAdult && Bow && Hammer;}}),
                   LocationAccess(GANONS_CASTLE_MQ_SPIRIT_TRIAL_INVISIBLE_CHEST,         {[]{return IsAdult && Bow && Hammer && HasBombchus && (LogicLensCastleMQ || CanUse(LENS_OF_TRUTH));}}),
-                  LocationAccess(GANONS_CASTLE_MQ_SPIRIT_TRIAL_SUN_FRONT_LEFT_CHEST,    {[]{return IsAdult && Hammer && HasBombchus && CanUse(FIRE_ARROWS) && CanUse(MIRROR_SHIELD);}}),
-                  LocationAccess(GANONS_CASTLE_MQ_SPIRIT_TRIAL_SUN_BACK_LEFT_CHEST,     {[]{return IsAdult && Hammer && HasBombchus && CanUse(FIRE_ARROWS) && CanUse(MIRROR_SHIELD);}}),
-                  LocationAccess(GANONS_CASTLE_MQ_SPIRIT_TRIAL_GOLDEN_GAUNTLETS_CHEST,  {[]{return IsAdult && Hammer && HasBombchus && CanUse(FIRE_ARROWS) && CanUse(MIRROR_SHIELD);}}),
-                  LocationAccess(GANONS_CASTLE_MQ_SPIRIT_TRIAL_SUN_BACK_RIGHT_CHEST,    {[]{return IsAdult && Hammer && HasBombchus && CanUse(FIRE_ARROWS) && CanUse(MIRROR_SHIELD);}}),
+                  LocationAccess(GANONS_CASTLE_MQ_SPIRIT_TRIAL_SUN_FRONT_LEFT_CHEST,    {[]{return IsAdult && Hammer && HasBombchus && ((CanUse(FIRE_ARROWS) && CanUse(MIRROR_SHIELD)) || (ExtraArrowEffects && CanUse(LIGHT_ARROWS)));}}),
+                  LocationAccess(GANONS_CASTLE_MQ_SPIRIT_TRIAL_SUN_BACK_LEFT_CHEST,     {[]{return IsAdult && Hammer && HasBombchus && ((CanUse(FIRE_ARROWS) && CanUse(MIRROR_SHIELD)) || (ExtraArrowEffects && CanUse(LIGHT_ARROWS)));}}),
+                  LocationAccess(GANONS_CASTLE_MQ_SPIRIT_TRIAL_GOLDEN_GAUNTLETS_CHEST,  {[]{return IsAdult && Hammer && HasBombchus && ((CanUse(FIRE_ARROWS) && CanUse(MIRROR_SHIELD)) || (ExtraArrowEffects && CanUse(LIGHT_ARROWS)));}}),
+                  LocationAccess(GANONS_CASTLE_MQ_SPIRIT_TRIAL_SUN_BACK_RIGHT_CHEST,    {[]{return IsAdult && Hammer && HasBombchus && ((CanUse(FIRE_ARROWS) && CanUse(MIRROR_SHIELD)) || (ExtraArrowEffects && CanUse(LIGHT_ARROWS)));}}),
   }, {});
 
   areaTable[GANONS_CASTLE_MQ_LIGHT_TRIAL] = Area("Ganon's Castle MQ Light Trial", "Ganons Castle", GANONS_CASTLE, NO_DAY_NIGHT_CYCLE, {

--- a/source/location_access/locacc_spirit_temple.cpp
+++ b/source/location_access/locacc_spirit_temple.cpp
@@ -51,7 +51,7 @@ void AreaTable_Init_SpiritTemple() {
                                                                                           ((SmallKeys(SPIRIT_TEMPLE, 3) || (SmallKeys(SPIRIT_TEMPLE, 2) && BombchusInLogic && ShuffleDungeonEntrances.Is(SHUFFLEDUNGEONS_OFF))) && CanUse(SILVER_GAUNTLETS) && (HasProjectile(HasProjectileAge::Adult) || (CanTakeDamage && CanJumpslash)));}}),
                 }, {
                   //Exits
-                  Entrance(SPIRIT_TEMPLE_CENTRAL_CHAMBER, {[]{return HasExplosives;}}),
+                  Entrance(SPIRIT_TEMPLE_CENTRAL_CHAMBER, {[]{return HasExplosives || (ExtraArrowEffects && CanUse(LIGHT_ARROWS));}}),
   });
 
   areaTable[SPIRIT_TEMPLE_EARLY_ADULT] = Area("Early Adult Spirit Temple", "Spirit Temple", SPIRIT_TEMPLE, NO_DAY_NIGHT_CYCLE, {}, {
@@ -114,7 +114,7 @@ void AreaTable_Init_SpiritTemple() {
 
   areaTable[SPIRIT_TEMPLE_BEYOND_CENTRAL_LOCKED_DOOR] = Area("Spirit Temple Beyond Central Locked Door", "Spirit Temple", SPIRIT_TEMPLE, NO_DAY_NIGHT_CYCLE, {}, {
                   //Locations
-                  LocationAccess(SPIRIT_TEMPLE_NEAR_FOUR_ARMOS_CHEST,         {[]{return MirrorShield && HasExplosives;}}),
+                  LocationAccess(SPIRIT_TEMPLE_NEAR_FOUR_ARMOS_CHEST,         {[]{return (MirrorShield || (ExtraArrowEffects && CanUse(LIGHT_ARROWS))) && HasExplosives;}}),
                   LocationAccess(SPIRIT_TEMPLE_HALLWAY_LEFT_INVISIBLE_CHEST,  {[]{return (LogicLensSpirit || CanUse(LENS_OF_TRUTH)) && HasExplosives;}}),
                   LocationAccess(SPIRIT_TEMPLE_HALLWAY_RIGHT_INVISIBLE_CHEST, {[]{return (LogicLensSpirit || CanUse(LENS_OF_TRUTH)) && HasExplosives;}}),
                 }, {
@@ -128,7 +128,7 @@ void AreaTable_Init_SpiritTemple() {
   }, {
                   //Locations
                   LocationAccess(SPIRIT_TEMPLE_BOSS_KEY_CHEST, {[]{return CanPlay(ZeldasLullaby) && ((CanTakeDamage && LogicFlamingChests) || (Bow && Hookshot));}}),
-                  LocationAccess(SPIRIT_TEMPLE_TOPMOST_CHEST,  {[]{return MirrorShield && CanAdultAttack;}}),
+                  LocationAccess(SPIRIT_TEMPLE_TOPMOST_CHEST,  {[]{return (MirrorShield || (ExtraArrowEffects && CanUse(LIGHT_ARROWS))) && CanAdultAttack;}}),
                   LocationAccess(SPIRIT_TEMPLE_TWINROVA_HEART, {[]{return MirrorShield && HasExplosives && Hookshot && BossKeySpiritTemple && (CanUse(KOKIRI_SWORD) || MasterSword || BiggoronSword);}}),
                   LocationAccess(TWINROVA,                     {[]{return MirrorShield && HasExplosives && Hookshot && BossKeySpiritTemple && (CanUse(KOKIRI_SWORD) || MasterSword || BiggoronSword);}}),
   }, {});
@@ -172,12 +172,12 @@ void AreaTable_Init_SpiritTemple() {
                   LocationAccess(SPIRIT_TEMPLE_MQ_STATUE_ROOM_INVISIBLE_CHEST, {[]{return (LogicLensSpiritMQ || CanUse(LENS_OF_TRUTH));}}),
                   LocationAccess(SPIRIT_TEMPLE_MQ_BEAMOS_ROOM_CHEST,           {[]{return SmallKeys(SPIRIT_TEMPLE, 5);}}),
                   LocationAccess(SPIRIT_TEMPLE_MQ_CHEST_SWITCH_CHEST,          {[]{return SmallKeys(SPIRIT_TEMPLE, 5) && CanPlay(SongOfTime);}}),
-                  LocationAccess(SPIRIT_TEMPLE_MQ_BOSS_KEY_CHEST,              {[]{return SmallKeys(SPIRIT_TEMPLE, 5) && CanPlay(SongOfTime) && MirrorShield;}}),
+                  LocationAccess(SPIRIT_TEMPLE_MQ_BOSS_KEY_CHEST,              {[]{return SmallKeys(SPIRIT_TEMPLE, 5) && CanPlay(SongOfTime) && (MirrorShield || (ExtraArrowEffects && CanUse(LIGHT_ARROWS)));}}),
                   LocationAccess(SPIRIT_TEMPLE_MQ_GS_NINE_THRONES_ROOM_WEST,   {[]{return SmallKeys(SPIRIT_TEMPLE, 7);}}),
                   LocationAccess(SPIRIT_TEMPLE_MQ_GS_NINE_THRONES_ROOM_NORTH,  {[]{return SmallKeys(SPIRIT_TEMPLE, 7);}}),
   }, {
                   //Exits
-                  Entrance(SPIRIT_TEMPLE_MQ_LOWER_ADULT,        {[]{return MirrorShield && IsAdult && CanUse(FIRE_ARROWS);}}),
+                  Entrance(SPIRIT_TEMPLE_MQ_LOWER_ADULT,        {[]{return (MirrorShield || (ExtraArrowEffects && CanUse(LIGHT_ARROWS))) && IsAdult && CanUse(FIRE_ARROWS);}}),
                     //Trick: MirrorShield && IsAdult && (CanUse(FIRE_ARROWS) || (LogicSpiritMQLowerAdult && CanUse(DINS_FIRE) && Bow))
                   Entrance(SPIRIT_TEMPLE_MQ_SHARED,             {[]{return true;}}),
                   Entrance(SPIRIT_TEMPLE_MQ_BOSS_AREA,          {[]{return SmallKeys(SPIRIT_TEMPLE, 6) && CanPlay(ZeldasLullaby) && Hammer;}}),

--- a/source/logic.cpp
+++ b/source/logic.cpp
@@ -704,7 +704,7 @@ namespace Logic {
     Nuts         = DekuNutDrop || Nuts;
     Sticks       = DekuStickDrop || Sticks;
     Bugs         = HasBottle && BugsAccess;
-    BlueFire     = HasBottle && BlueFireAccess;
+    BlueFire     = (HasBottle && BlueFireAccess) || (ExtraArrowEffects && CanUse(ICE_ARROWS));
     Fish         = HasBottle && FishAccess;
     Fairy        = HasBottle && FairyAccess && Hearts > 0;
 

--- a/source/patch.cpp
+++ b/source/patch.cpp
@@ -343,6 +343,30 @@ bool WriteAllPatches() {
   }
 
   /*--------------------------------
+  |       Extra Arrow Effects      |
+  ---------------------------------*/
+
+  const u32 BREAKWALL_BUMPERFLAGS_ADDR  = 0x00510C80;
+  const u32 ARROW_ATFLAGS_ADDR          = 0x00520749;
+  const u32 SUNSWITCH_BUMPERFLAGS_ADDR  = 0x00535390;
+
+  u32 patchOffset_Breakwall  = V_TO_P(BREAKWALL_BUMPERFLAGS_ADDR);
+  u32 patchOffset_Arrow      = V_TO_P(ARROW_ATFLAGS_ADDR);
+  u32 patchOffset_SunSwitch  = V_TO_P(SUNSWITCH_BUMPERFLAGS_ADDR);
+
+  u8  arrowAtFlags          = 0x29;       // adding AT_TYPE_OTHER (0x20)
+  u32 breakwallBumperFlags  = 0x00001048; // adding Ice Arrow damage (0x00001000)
+  u32 sunSwitchBumperFlags  = 0x00202000; // adding Light Arrow damage (0x00002000)
+
+  if (ctx.extraArrowEffects && (
+      !WritePatch(patchOffset_Breakwall, sizeof(breakwallBumperFlags), (char*)(&breakwallBumperFlags), code, bytesWritten, totalRW, buf) ||
+      !WritePatch(patchOffset_Arrow, sizeof(arrowAtFlags), (char*)(&arrowAtFlags), code, bytesWritten, totalRW, buf) ||
+      !WritePatch(patchOffset_SunSwitch, sizeof(sunSwitchBumperFlags), (char*)(&sunSwitchBumperFlags), code, bytesWritten, totalRW, buf)
+      )) {
+    return false;
+  }
+
+  /*--------------------------------
   |         rBGMOverrides          |
   ---------------------------------*/
 

--- a/source/settings.cpp
+++ b/source/settings.cpp
@@ -303,6 +303,7 @@ namespace Settings {
   Option FireTrap            = Option::Bool("  Fire Trap",            {"Off", "On"},                                                          {fireTrapDesc},                                                                                                   OptionCategory::Setting,    ON);
   Option AntiFairyTrap       = Option::Bool("  Anti-Fairy Trap",      {"Off", "On"},                                                          {antiFairyTrapDesc},                                                                                              OptionCategory::Setting,    ON);
   Option CurseTraps          = Option::Bool("  Curse Traps",          {"Off", "On"},                                                          {curseTrapsDesc},                                                                                                 OptionCategory::Setting);
+  Option ExtraArrowEffects   = Option::Bool("Extra Arrow Effects",    {"Off", "On"},                                                          {extraArrowEffectsDesc});
   bool HasNightStart         = false;
   std::vector<Option *> miscOptions = {
     &Racing,
@@ -322,6 +323,7 @@ namespace Settings {
     &FireTrap,
     &AntiFairyTrap,
     &CurseTraps,
+    &ExtraArrowEffects,
   };
 
   //Item Usability Settings
@@ -1367,6 +1369,7 @@ namespace Settings {
     ctx.fireTrap             = (FireTrap) ? 1 : 0;
     ctx.antiFairyTrap        = (AntiFairyTrap) ? 1 : 0;
     ctx.curseTraps           = (CurseTraps) ? 1 : 0;
+    ctx.extraArrowEffects    = (ExtraArrowEffects) ? 1 : 0;
 
     ctx.faroresWindAnywhere  = (FaroresWindAnywhere) ? 1 : 0;
     ctx.stickAsAdult         = (StickAsAdult) ? 1 : 0;

--- a/source/settings.hpp
+++ b/source/settings.hpp
@@ -393,6 +393,7 @@ namespace Settings {
   extern Option FireTrap;
   extern Option AntiFairyTrap;
   extern Option CurseTraps;
+  extern Option ExtraArrowEffects;
   extern bool HasNightStart;
 
   extern Option FaroresWindAnywhere;


### PR DESCRIPTION
When this setting is enabled, Ice Arrows will act like blue fire, melting red ice and breaking certain bombable walls, and Light Arrows will activate Sun Switches.

Logic is included: for the Ice Arrows I only changed the BlueFire helper, whereas for Light Arrows I added checks to each Sun Switch location.

Regarding the patch, the setting will add specific flags to the colliders for arrows, rock walls and sun switches. I didn't manage to make red ice detect hits from Ice Arrows only by changing its colliders and functions, so I instead hooked into one of the global functions for collision detection (`CollisionCheck_SetATvsAC`) to check when the hit happens and make the ice melt.