### PR TITLE
Add functionality for in-app premade presets

### DIFF
--- a/code/src/actors/chest.c
+++ b/code/src/actors/chest.c
@@ -27,7 +27,7 @@ EnElf* fairy = 0;
 void EnBox_rInit(Actor* thisx, GlobalContext* globalCtx) {
     lastTrapChest = 0;
     // treasure box shop chests
-    u8 vanilla = (gSettingsContext.chestSize == VANILLA_SIZE) || (globalCtx->sceneNum == 16 && thisx->room != 6);
+    u8 vanilla = (gSettingsContext.chestSize == CHESTSIZE_VANILLA) || (globalCtx->sceneNum == 16 && thisx->room != 6);
 
     if (!checkedForBombchus && gSettingsContext.bombchusInLogic && gSaveContext.items[8] == 0xFF) {
         ItemTable_SetBombchusChestType(0);
@@ -127,7 +127,7 @@ void EnBox_rUpdate(Actor* thisx, GlobalContext* globalCtx) {
 
 u8 Chest_OverrideAnimation() {
 
-    if ((gSettingsContext.chestAnimations == ALWAYS_FAST) ||
+    if ((gSettingsContext.chestAnimations == CHESTANIMATIONS_ALWAYSFAST) ||
         (rActiveItemActionId == 0)) // The animation is always fast for unused chests that aren't randomized
         return 0;
 
@@ -139,7 +139,7 @@ u8 Chest_OverrideAnimation() {
 
 u8 Chest_OverrideDecoration() {
 
-    if (type == DECORATED_BIG || ((gSettingsContext.chestSize == SIZE_MATCHES_CONTENT) && (type == DECORATED_SMALL))) {
+    if (type == DECORATED_BIG || ((gSettingsContext.chestSize == CHESTSIZE_MATCHCONTENT) && (type == DECORATED_SMALL))) {
         return 1;
     }
     return 0;

--- a/code/src/actors/chest.h
+++ b/code/src/actors/chest.h
@@ -4,16 +4,6 @@
 #include "z3D/z3D.h"
 
 typedef enum {
-  VANILLA_SIZE,
-  SIZE_MATCHES_CONTENT,
-} ChestSize;
-
-typedef enum {
-  ALWAYS_FAST,
-  ANIMATION_MATCHES_CONTENT,
-} ChestAnim;
-
-typedef enum {
   WOODEN_BIG,
   WOODEN_SMALL,
   DECORATED_BIG,

--- a/code/src/actors/king_zora.c
+++ b/code/src/actors/king_zora.c
@@ -18,7 +18,7 @@ u32 EnKz_CheckMovedFlag(void) {
 void EnKz_rUpdate(Actor* thisx, GlobalContext* globalCtx) {
     EnKz_Update(thisx, globalCtx);
     // Zora's Domain scene, the position check is just to add a 1 frame delay
-    if (gSettingsContext.kingZoraSpeed != 1 && globalCtx->sceneNum == 88 && thisx->speedXZ != 0 && thisx->world.pos.x < 628.0f) {
+    if (gSettingsContext.kingZoraSpeed != KINGZORASPEED_VANILLA && globalCtx->sceneNum == 88 && thisx->speedXZ != 0 && thisx->world.pos.x < 628.0f) {
         u8 mweepCount = (gSettingsContext.kingZoraSpeed)? Bias(Hash(0)) + 1 : 1;
         thisx->speedXZ = 6.4f / (2.56f * (mweepCount - 0.58f));
         thisx->world.pos.z = -1783.0f; // lock Z position so the increased speed doesn't mess it up

--- a/code/src/settings.h
+++ b/code/src/settings.h
@@ -221,6 +221,12 @@ typedef enum {
 } GanonsBossKeySetting;
 
 typedef enum {
+  KINGZORASPEED_FAST,
+  KINGZORASPEED_VANILLA,
+  KINGZORASPEED_RANDOM,
+} KingZoraSpeedSetting;
+
+typedef enum {
   QUICKTEXT_VANILLA,
   QUICKTEXT_SKIPPABLE,
   QUICKTEXT_INSTANT,
@@ -248,10 +254,24 @@ typedef enum {
 } LogicTrickSetting;
 
 typedef enum {
+  HINTS_NO_HINTS,
+  HINTS_NEED_NOTHING,
+  HINTS_MASK_OF_TRUTH,
+  HINTS_SHARD_OF_AGONY,
+} GossipStoneHintsSetting;
+
+typedef enum {
   HINTMODE_OBSCURE,
   HINTMODE_AMBIGUOUS,
   HINTMODE_CLEAR,
 } HintModeSetting;
+
+typedef enum {
+  HINTDISTRIBUTION_USELESS,
+  HINTDISTRIBUTION_BALANCED,
+  HINTDISTRIBUTION_STRONG,
+  HINTDISTRIBUTION_VERYSTRONG,
+} HintDistributionSettings;
 
 typedef enum {
   DAMAGEMULTIPLIER_HALF,
@@ -269,11 +289,14 @@ typedef enum {
 } StartingTimeSetting;
 
 typedef enum {
-  HINTS_NO_HINTS,
-  HINTS_NEED_NOTHING,
-  HINTS_MASK_OF_TRUTH,
-  HINTS_SHARD_OF_AGONY,
-} GossipStoneHintsSetting;
+  CHESTANIMATIONS_ALWAYSFAST,
+  CHESTANIMATIONS_MATCHCONTENT,
+} ChestAnimationsSetting;
+
+typedef enum {
+  CHESTSIZE_VANILLA,
+  CHESTSIZE_MATCHCONTENT,
+} ChestSizeSetting;
 
 typedef enum {
   RANDOMTRAPS_OFF,

--- a/source/descriptions.cpp
+++ b/source/descriptions.cpp
@@ -1,4 +1,4 @@
-#include "setting_descriptions.hpp"
+#include "descriptions.hpp"
 
 /*------------------------------
 |      MENU DESCRIPTIONS       |                            *SCREEN WIDTH*
@@ -7,6 +7,20 @@ string_view personalizationDesc       = "These options do not affect seed genera
 string_view ingameDefaultsDesc        = "These options decide what the ingame options are\n"
                                         "set to when creating a save file. The new ingame\n"
                                         "options can be changed in the Custom Info Menu."; //
+
+/*------------------------------
+|      PRESET DESCRIPTIONS     |                            *SCREEN WIDTH*
+------------------------------*/       /*--------------------------------------------------*/
+string_view presetNintendedDesc       = "Locks the world in a state as intended by the\n"  //
+                                        "developers. Start as child and work your way\n"   //
+                                        "towards Ganon in a classical way.";               //
+string_view presetAllsanityDesc       = "ANYTHING ANYWHERE! Both items and entrances.";    //
+string_view presetRacingDesc          = "Community racing settings.";                      //
+string_view presetFullChaosDesc       = "The hardest and worst settings possible.\n"       //
+                                        "Closes everything as much as possible.\n"         //
+                                        "No logic. Anything anywhere.\n"                   //
+                                        "Full entrance shuffle.\n"                         //
+                                        "One-hit KO. Max ice traps.";                      //
 
 //Setting descriptions are mostly copied from OoT Randomizer tooltips with minor edits
 

--- a/source/descriptions.hpp
+++ b/source/descriptions.hpp
@@ -7,6 +7,11 @@ using string_view = std::string_view;
 extern string_view personalizationDesc;
 extern string_view ingameDefaultsDesc;
 
+extern string_view presetNintendedDesc;
+extern string_view presetAllsanityDesc;
+extern string_view presetRacingDesc;
+extern string_view presetFullChaosDesc;
+
 extern string_view openRandomize;
 extern string_view worldRandomize;
 extern string_view shuffleRandomize;

--- a/source/logic.cpp
+++ b/source/logic.cpp
@@ -9,7 +9,7 @@
 
 #include "settings.hpp"
 #include "dungeon.hpp"
-#include "setting_descriptions.hpp"
+#include "descriptions.hpp"
 
 using namespace Settings;
 

--- a/source/menu.cpp
+++ b/source/menu.cpp
@@ -75,7 +75,7 @@ void MenuInit() {
 
 void MoveCursor(u32 kDown, bool updatedByHeld) {
   //Option sub menus need special checking for locked options
-  if (currentMenu->mode == OPTION_SUB_MENU) {
+  if (currentMenu->mode == OPTION_MENU) {
     // Cancel if holding and reached first/last selectable option
     if (updatedByHeld) {
       bool noSelectableOption = true;
@@ -121,7 +121,9 @@ void MoveCursor(u32 kDown, bool updatedByHeld) {
   //All other menus except reset-to-defaults confirmation
   else if (currentMenu->mode != RESET_TO_DEFAULTS) {
     u16 max = -1;
-    if (currentMenu->mode == LOAD_PRESET || currentMenu->mode == DELETE_PRESET) { //Number of presets if applicable
+    if (currentMenu->mode == LOAD_PREMADE_PRESET) {
+      max = premadePresets.size();
+    } else if (currentMenu->mode == LOAD_CUSTOM_PRESET || currentMenu->mode == DELETE_CUSTOM_PRESET) { //Number of presets if applicable
       max = presetEntries.size();
     } else if (currentMenu->mode == GENERATE_MODE) { //Generate menu: 2 options
       max = 2;
@@ -153,7 +155,7 @@ void MoveCursor(u32 kDown, bool updatedByHeld) {
 
     //Scroll Check
     u16 max_entries_on_screen = MAX_SUBMENUS_ON_SCREEN;
-    if (currentMenu->mode == LOAD_PRESET || currentMenu->mode == DELETE_PRESET) {
+    if (currentMenu->mode == LOAD_CUSTOM_PRESET || currentMenu->mode == DELETE_CUSTOM_PRESET) {
         max_entries_on_screen = MAX_SUBMENU_SETTINGS_ON_SCREEN;
     }
     if (currentMenu->menuIdx > currentMenu->settingBound + (max_entries_on_screen - (currentMenu->menuIdx == max - 1 ? 1 : 2))) {
@@ -163,12 +165,12 @@ void MoveCursor(u32 kDown, bool updatedByHeld) {
     }
 
     // Shared cursor for preset menus
-    if (currentMenu->mode == LOAD_PRESET) {
-      Settings::deleteSettingsPreset.settingBound = currentMenu->settingBound;
-      Settings::deleteSettingsPreset.menuIdx = currentMenu->menuIdx;
-    } else if (currentMenu->mode == DELETE_PRESET) {
-      Settings::loadSettingsPreset.settingBound = currentMenu->settingBound;
-      Settings::loadSettingsPreset.menuIdx = currentMenu->menuIdx;
+    if (currentMenu->mode == LOAD_CUSTOM_PRESET) {
+      Settings::deleteCustomPreset.settingBound = currentMenu->settingBound;
+      Settings::deleteCustomPreset.menuIdx = currentMenu->menuIdx;
+    } else if (currentMenu->mode == DELETE_CUSTOM_PRESET) {
+      Settings::loadCustomPreset.settingBound = currentMenu->settingBound;
+      Settings::loadCustomPreset.menuIdx = currentMenu->menuIdx;
     }
   }
 }
@@ -179,7 +181,7 @@ void MenuUpdate(u32 kDown, bool updatedByHeld) {
 
   //Check for menu change
   //If user pressed A on a non-option, non-action menu, they're navigating to a new menu
-  if (kDown & KEY_A && currentMenu->mode != OPTION_SUB_MENU && currentMenu->type != MenuType::Action) {
+  if (kDown & KEY_A && currentMenu->mode != OPTION_MENU && currentMenu->type != MenuType::Action) {
     if (currentMenu->itemsList->size() > currentMenu->menuIdx) {
       Menu* newMenu;
       newMenu = currentMenu->itemsList->at(currentMenu->menuIdx);
@@ -234,15 +236,18 @@ void MenuUpdate(u32 kDown, bool updatedByHeld) {
   MoveCursor(kDown, updatedByHeld); //Move cursor, if applicable
   if (currentMenu->mode == MAIN_MENU) {
     PrintMainMenu();
-  } else if (currentMenu->mode == OPTION_SUB_MENU) {
+  } else if (currentMenu->mode == OPTION_MENU) {
     UpdateOptionSubMenu(kDown);
     PrintOptionSubMenu();
-  } else if (currentMenu->mode == LOAD_PRESET) {
-    UpdatePresetsMenu(kDown);
-    PrintPresetsMenu();
-  } else if (currentMenu->mode == DELETE_PRESET) {
-    UpdatePresetsMenu(kDown);
-    PrintPresetsMenu();
+  } else if (currentMenu->mode == LOAD_PREMADE_PRESET) {
+    UpdatePremadePresetsMenu(kDown);
+    PrintPremadePresetsMenu(kDown);
+  } else if (currentMenu->mode == LOAD_CUSTOM_PRESET) {
+    UpdateCustomPresetsMenu(kDown);
+    PrintCustomPresetsMenu();
+  } else if (currentMenu->mode == DELETE_CUSTOM_PRESET) {
+    UpdateCustomPresetsMenu(kDown);
+    PrintCustomPresetsMenu();
   } else if (currentMenu->mode == RESET_TO_DEFAULTS) {
     UpdateResetToDefaultsMenu(kDown);
     PrintResetToDefaultsMenu();
@@ -257,7 +262,7 @@ void MenuUpdate(u32 kDown, bool updatedByHeld) {
 }
 
 void ModeChangeInit() {
-  if (currentMenu->mode == OPTION_SUB_MENU) {
+  if (currentMenu->mode == OPTION_MENU) {
     //loop through until we reach an unlocked setting
     while(currentMenu->settingsList->at(currentMenu->menuIdx)->IsLocked() || currentMenu->settingsList->at(currentMenu->menuIdx)->IsHidden()) {
       currentMenu->menuIdx++;
@@ -267,7 +272,7 @@ void ModeChangeInit() {
     }
     currentSetting = currentMenu->settingsList->at(currentMenu->menuIdx);
 
-  } else if (currentMenu->mode == SAVE_PRESET) {
+  } else if (currentMenu->mode == SAVE_CUSTOM_PRESET) {
     ClearDescription();
     if (SaveSpecifiedPreset(GetInput("Preset Name").substr(0, 19), OptionCategory::Setting)) {
       printf("\x1b[24;5HPreset Saved!");
@@ -277,7 +282,7 @@ void ModeChangeInit() {
       printf("\x1b[26;5HPress B to return to the preset menu.");
     }
 
-  } else if (currentMenu->mode == LOAD_PRESET || currentMenu->mode == DELETE_PRESET) {
+  } else if (currentMenu->mode == LOAD_CUSTOM_PRESET || currentMenu->mode == DELETE_CUSTOM_PRESET) {
     presetEntries = GetSettingsPresets();
 
   } else if (currentMenu->mode == GENERATE_MODE) {
@@ -313,11 +318,30 @@ void UpdateOptionSubMenu(u32 kDown) {
   UpdateCustomCosmeticColors(kDown);
 }
 
-void UpdatePresetsMenu(u32 kDown) {
+void UpdatePremadePresetsMenu(u32 kDown) {
+    consoleSelect(&topScreen);
+    if (kDown & KEY_A) {
+        Settings::SetDefaultSettings();
+        for (auto optionOverride : premadePresets[currentMenu->menuIdx]->optionOverrides) {
+            optionOverride.first->SetSelectedIndex(optionOverride.second);
+        }
+        for (auto loc : premadePresets[currentMenu->menuIdx]->excludedLocations) {
+            Location(loc)->GetExcludedOption()->SetSelectedIndex(EXCLUDE);
+        }
+        Settings::ResolveExcludedLocationConflicts();
+        for (Menu* menu : Settings::GetAllOptionMenus()) {
+            menu->ResetMenuIndex();
+        }
+        ClearDescription();
+        printf("\x1b[24;5HPreset Loaded!");
+    }
+}
+
+void UpdateCustomPresetsMenu(u32 kDown) {
   consoleSelect(&topScreen);
   //clear any potential message
   ClearDescription();
-  if (kDown & KEY_A && currentMenu->mode == LOAD_PRESET && !presetEntries.empty()) {
+  if (kDown & KEY_A && currentMenu->mode == LOAD_CUSTOM_PRESET && !presetEntries.empty()) {
     if (LoadPreset(presetEntries[currentMenu->menuIdx], OptionCategory::Setting)) {
       Settings::ResolveExcludedLocationConflicts();
       for (Menu* menu : Settings::GetAllOptionMenus()) {
@@ -327,7 +351,7 @@ void UpdatePresetsMenu(u32 kDown) {
     } else {
       printf("\x1b[24;5HFailed to load preset.");
     }
-  } else if (kDown & KEY_A && currentMenu->mode == DELETE_PRESET && !presetEntries.empty()) {
+  } else if (kDown & KEY_A && currentMenu->mode == DELETE_CUSTOM_PRESET && !presetEntries.empty()) {
     if (DeletePreset(presetEntries[currentMenu->menuIdx], OptionCategory::Setting)) {
       presetEntries.erase(presetEntries.begin() + currentMenu->menuIdx);
       if(currentMenu->menuIdx == presetEntries.size()) { //Catch when last preset is deleted
@@ -379,7 +403,7 @@ void PrintMainMenu() {
     }
   }
 
-  PrintMenuDescription();
+  PrintDescription(currentMenu->itemsList->at(currentMenu->menuIdx)->description);
 }
 
 void PrintOptionSubMenu() {
@@ -451,7 +475,7 @@ void PrintOptionSubMenu() {
     }
   }
 
-  PrintOptionDescription();
+  PrintDescription(currentSetting->GetSelectedOptionDescription());
 }
 
 void PrintSubMenu() {
@@ -470,10 +494,34 @@ void PrintSubMenu() {
     }
   }
 
-  PrintMenuDescription();
+  PrintDescription(currentMenu->itemsList->at(currentMenu->menuIdx)->description);
 }
 
-void PrintPresetsMenu() {
+void PrintPremadePresetsMenu(u32 kDown) {
+    consoleSelect(&bottomScreen);
+    printf("\x1b[0;%dHSelect a Preset to Load", 1 + (BOTTOM_WIDTH - 23) / 2);
+
+    for (u8 i = 0; i < MAX_SUBMENU_SETTINGS_ON_SCREEN; i++) {
+        if (i + currentMenu->settingBound >= premadePresets.size()) break;
+
+        std::string preset = premadePresets[currentMenu->settingBound + i]->name.data();
+
+        u8 row = 3 + (i * 2);
+        //make the current preset green
+        if (currentMenu->menuIdx == currentMenu->settingBound + i) {
+            printf("\x1b[%d;%dH%s>", row, 14, GREEN);
+            printf("\x1b[%d;%dH%s%s", row, 15, preset.c_str(), RESET);
+        } else {
+            printf("\x1b[%d;%dH%s", row, 15, preset.c_str());
+        }
+    }
+
+    if (!(kDown & KEY_A)) {
+        PrintDescription(premadePresets[currentMenu->menuIdx]->description);
+    }
+}
+
+void PrintCustomPresetsMenu() {
   consoleSelect(&bottomScreen);
   if (presetEntries.empty()) {
     printf("\x1b[10;4HNo Presets Detected!");
@@ -481,9 +529,9 @@ void PrintPresetsMenu() {
     return;
   }
 
-  if(currentMenu->mode == LOAD_PRESET) {
+  if(currentMenu->mode == LOAD_CUSTOM_PRESET) {
     printf("\x1b[0;%dHSelect a Preset to Load", 1+(BOTTOM_WIDTH-23)/2);
-  } else if (currentMenu->mode == DELETE_PRESET) {
+  } else if (currentMenu->mode == DELETE_CUSTOM_PRESET) {
     printf("\x1b[0;%dHSelect a Preset to Delete", 1+(BOTTOM_WIDTH-25)/2);
   }
 
@@ -539,17 +587,8 @@ void ClearDescription() {
   printf("\x1b[20;0H%s", spaces.c_str());
 }
 
-void PrintOptionDescription() {
+void PrintDescription(std::string_view description) {
   ClearDescription();
-  std::string_view description = currentSetting->GetSelectedOptionDescription();
-
-  printf("\x1b[20;0H%s", description.data());
-}
-
-void PrintMenuDescription() {
-  ClearDescription();
-  std::string_view description = currentMenu->itemsList->at(currentMenu->menuIdx)->description;
-
   printf("\x1b[20;0H%s", description.data());
 }
 

--- a/source/menu.hpp
+++ b/source/menu.hpp
@@ -4,14 +4,15 @@
 #include <string>
 
 #define MAIN_MENU 0
-#define OPTION_SUB_MENU 1
-#define SUB_MENU 2
+#define SUB_MENU 1
+#define OPTION_MENU 2
 #define GENERATE_MODE 3
-#define LOAD_PRESET 4
-#define SAVE_PRESET 5
-#define DELETE_PRESET 6
-#define POST_GENERATE 7
-#define RESET_TO_DEFAULTS 8
+#define LOAD_PREMADE_PRESET 4
+#define LOAD_CUSTOM_PRESET 5
+#define SAVE_CUSTOM_PRESET 6
+#define DELETE_CUSTOM_PRESET 7
+#define POST_GENERATE 8
+#define RESET_TO_DEFAULTS 9
 
 #define MAX_SUBMENUS_ON_SCREEN 27
 #define MAX_SUBMENU_SETTINGS_ON_SCREEN 13
@@ -33,18 +34,19 @@
 
 void ModeChangeInit();
 void UpdateOptionSubMenu(u32 kDown);
-void UpdatePresetsMenu(u32 kdown);
+void UpdatePremadePresetsMenu(u32 kDown);
+void UpdateCustomPresetsMenu(u32 kDown);
 void UpdateResetToDefaultsMenu(u32 kdown);
 void UpdateGenerateMenu(u32 kDown);
 void PrintMainMenu();
 void PrintOptionSubMenu();
 void PrintSubMenu();
-void PrintPresetsMenu();
+void PrintPremadePresetsMenu(u32 kDown);
+void PrintCustomPresetsMenu();
 void PrintResetToDefaultsMenu();
 void PrintGenerateMenu();
 void ClearDescription();
-void PrintOptionDescription();
-void PrintMenuDescription();
+void PrintDescription(std::string_view description);
 void GenerateRandomizer();
 std::string GetInput(const char* hintText);
 

--- a/source/playthrough.cpp
+++ b/source/playthrough.cpp
@@ -29,7 +29,7 @@ namespace Playthrough {
       std::string settingsStr;
       for (Menu* menu : Settings::GetAllOptionMenus()) {
         //don't go through non-menus
-        if (menu->mode != OPTION_SUB_MENU) {
+        if (menu->mode != OPTION_MENU) {
           continue;
         }
 

--- a/source/preset.cpp
+++ b/source/preset.cpp
@@ -12,6 +12,7 @@
 
 #include "category.hpp"
 #include "settings.hpp"
+#include "descriptions.hpp"
 #include "tinyxml2.h"
 #include "utils.hpp"
 
@@ -92,7 +93,7 @@ bool SavePreset(std::string_view presetName, OptionCategory category) {
   preset.InsertEndChild(rootNode);
 
   for (Menu* menu : Settings::GetAllOptionMenus()) {
-    if (menu->mode != OPTION_SUB_MENU) {
+    if (menu->mode != OPTION_MENU) {
       continue;
     }
     for (const Option* setting : *menu->settingsList) {
@@ -129,7 +130,7 @@ bool LoadPreset(std::string_view presetName, OptionCategory category) {
   XMLElement* curNode = rootNode->FirstChildElement();
 
   for (Menu* menu : Settings::GetAllOptionMenus()) {
-    if (menu->mode != OPTION_SUB_MENU) {
+    if (menu->mode != OPTION_MENU) {
       continue;
     }
 
@@ -221,3 +222,225 @@ void LoadCachedCosmetics() {
     }
   }
 }
+
+PremadePreset presetNintended = {
+    "Nintended", presetNintendedDesc, {
+    // Open Settings
+    { &Settings::OpenForest, OPENFOREST_CLOSED },
+    { &Settings::OpenKakariko, OPENKAKARIKO_CLOSED },
+    { &Settings::OpenDoorOfTime, OPENDOOROFTIME_INTENDED },
+    { &Settings::ZorasFountain, ZORASFOUNTAIN_NORMAL },
+    { &Settings::GerudoFortress, GERUDOFORTRESS_NORMAL },
+    { &Settings::Bridge, RAINBOWBRIDGE_MEDALLIONS },
+    { &Settings::BridgeMedallionCount, 6 },
+    { &Settings::RandomGanonsTrials, OFF },
+    { &Settings::GanonsTrialsCount, 6 },
+} };
+
+PremadePreset presetAllsanity = {
+    "Allsanity", presetAllsanityDesc, {
+    // World Settings
+    { &Settings::ShuffleEntrances, ON },
+    { &Settings::ShuffleDungeonEntrances, SHUFFLEDUNGEONS_GANON },
+    { &Settings::ShuffleOverworldEntrances, ON },
+    { &Settings::ShuffleInteriorEntrances, SHUFFLEINTERIORS_ALL },
+    { &Settings::ShuffleGrottoEntrances, ON },
+    // Shuffle Settings
+    { &Settings::ShuffleRewards, REWARDSHUFFLE_ANYWHERE },
+    { &Settings::LinksPocketItem, LINKSPOCKETITEM_ANYTHING },
+    { &Settings::ShuffleSongs, SONGSHUFFLE_ANYWHERE },
+    { &Settings::Shopsanity, SHOPSANITY_FOUR },
+    { &Settings::Tokensanity, TOKENSANITY_ALL_TOKENS },
+    { &Settings::Scrubsanity, SCRUBSANITY_AFFORDABLE },
+    { &Settings::ShuffleCows, ON },
+    { &Settings::ShuffleKokiriSword, ON },
+    { &Settings::ShuffleOcarinas, ON },
+    { &Settings::ShuffleWeirdEgg, ON },
+    { &Settings::ShuffleGerudoToken, ON },
+    { &Settings::ShuffleMagicBeans, ON },
+    { &Settings::ShuffleMerchants, ON },
+    { &Settings::ShuffleAdultTradeQuest, ON },
+    { &Settings::ShuffleChestMinigame, ON },
+    { &Settings::ShuffleFrogSongRupees, ON },
+    // Shuffle Dungeon Items
+    { &Settings::MapsAndCompasses, MAPSANDCOMPASSES_ANYWHERE },
+    { &Settings::Keysanity, KEYSANITY_ANYWHERE },
+    { &Settings::GerudoKeys, GERUDOKEYS_ANYWHERE },
+    { &Settings::BossKeysanity, BOSSKEYSANITY_ANYWHERE },
+    { &Settings::GanonsBossKey, GANONSBOSSKEY_ANYWHERE },
+} };
+
+PremadePreset presetRacing = {
+    "Racing", presetRacingDesc, {
+    // Open Settings
+    { &Settings::OpenForest, OPENFOREST_OPEN },
+    { &Settings::OpenKakariko, OPENKAKARIKO_OPEN },
+    { &Settings::OpenDoorOfTime, OPENDOOROFTIME_OPEN },
+    { &Settings::ZorasFountain, ZORASFOUNTAIN_NORMAL },
+    { &Settings::GerudoFortress, GERUDOFORTRESS_FAST },
+    { &Settings::Bridge, RAINBOWBRIDGE_MEDALLIONS },
+    { &Settings::BridgeMedallionCount, 6 },
+    { &Settings::RandomGanonsTrials, OFF },
+    { &Settings::GanonsTrialsCount, 0 },
+    // World Settings
+    { &Settings::StartingAge, AGE_ADULT },
+    { &Settings::ShuffleEntrances, ON },
+    { &Settings::ShuffleDungeonEntrances, SHUFFLEDUNGEONS_ON },
+    { &Settings::BombchusInLogic, OFF },
+    { &Settings::AmmoDrops, AMMODROPS_VANILLA },
+    // Shuffle Settings
+    { &Settings::ShuffleRewards, REWARDSHUFFLE_ANYWHERE },
+    { &Settings::Tokensanity, TOKENSANITY_DUNGEONS },
+    { &Settings::ShuffleKokiriSword, ON },
+    { &Settings::MapsAndCompasses, MAPSANDCOMPASSES_START_WITH },
+    { &Settings::GanonsBossKey, GANONSBOSSKEY_LACS_DUNGEONS },
+    { &Settings::LACSDungeonCount, 5 },
+    // Timesaver Settings
+    { &Settings::SkipChildStealth, SKIP },
+    { &Settings::SkipTowerEscape, SKIP },
+    { &Settings::SkipEponaRace, SKIP },
+    { &Settings::SkipMinigamePhases, SKIP },
+    { &Settings::FreeScarecrow, ON },
+    { &Settings::FourPoesCutscene, SKIP },
+    { &Settings::LakeHyliaOwl, SKIP },
+    { &Settings::BigPoeTargetCount, 0 }, // Index 0 is 1 poe
+    { &Settings::NumRequiredCuccos, 3 },
+    { &Settings::KingZoraSpeed, KINGZORASPEED_FAST },
+    { &Settings::CompleteMaskQuest, ON },
+    { &Settings::FastBunnyHood, ON },
+    // Logical Tricks
+    { &Settings::LogicGrottosWithoutAgony, ON },
+    { &Settings::LogicVisibleCollision, ON },
+    { &Settings::LogicFewerTunicRequirements, ON },
+    { &Settings::LogicLostWoodsGSBean, ON },
+    { &Settings::LogicLabDiving, ON },
+    { &Settings::LogicManOnRoof, ON },
+    { &Settings::LogicWindmillPoHHookshot, ON },
+    { &Settings::LogicCraterBeanPoHWithHovers, ON },
+    { &Settings::LogicDCJump, ON },
+    { &Settings::LogicChildDeadhand, ON },
+    { &Settings::LogicLensSpirit, ON },
+    { &Settings::LogicLensShadow, ON },
+    { &Settings::LogicLensShadowBack, ON },
+    { &Settings::LogicLensBotw, ON },
+    { &Settings::LogicLensGtg, ON },
+    { &Settings::LogicLensCastle, ON },
+    { &Settings::LogicLensJabuMQ, ON },
+    { &Settings::LogicLensSpiritMQ, ON },
+    { &Settings::LogicLensShadowMQ, ON },
+    { &Settings::LogicLensShadowMQBack, ON },
+    { &Settings::LogicLensBotwMQ, ON },
+    { &Settings::LogicLensGtgMQ, ON },
+    { &Settings::LogicFlamingChests, ON },
+    // Starting Inventory
+    { &Settings::StartingOcarina, 1 }, // Fairy Ocarina
+    { &Settings::StartingKokiriSword, ON },
+    { &Settings::StartingDekuShield, ON },
+    { &Settings::StartingHylianShield, ON },
+    { &Settings::StartingConsumables, ON },
+    // Misc Settings
+    { &Settings::Racing, ON },
+    { &Settings::GossipStoneHints, HINTS_NEED_NOTHING },
+    { &Settings::ClearerHints, HINTMODE_CLEAR },
+    { &Settings::HintDistribution, HINTDISTRIBUTION_BALANCED },
+    { &Settings::CompassesShowReward, ON },
+    { &Settings::CompassesShowWotH, OFF },
+    { &Settings::MapsShowDungeonMode, ON },
+    { &Settings::StartingTime, STARTINGTIME_NIGHT },
+    { &Settings::ChestAnimations, CHESTANIMATIONS_ALWAYSFAST },
+    { &Settings::ChestSize, CHESTSIZE_MATCHCONTENT },
+    { &Settings::GenerateSpoilerLog, OFF },
+    { &Settings::RandomTrapDmg, RANDOMTRAPS_OFF },
+    // Item Pool Settings
+    { &Settings::IceTrapValue, ICETRAPS_OFF },
+}, {
+    // Excluded Locations
+    KAK_40_GOLD_SKULLTULA_REWARD,
+    KAK_50_GOLD_SKULLTULA_REWARD,
+} };
+
+PremadePreset presetFullChaos = {
+    "Full Chaos", presetFullChaosDesc, {
+    // Open Settings
+    { &Settings::OpenForest, OPENFOREST_CLOSED },
+    { &Settings::OpenKakariko, OPENKAKARIKO_CLOSED },
+    { &Settings::OpenDoorOfTime, OPENDOOROFTIME_INTENDED },
+    { &Settings::ZorasFountain, ZORASFOUNTAIN_NORMAL },
+    { &Settings::GerudoFortress, GERUDOFORTRESS_NORMAL },
+    { &Settings::Bridge, RAINBOWBRIDGE_TOKENS },
+    { &Settings::BridgeTokenCount, 100 },
+    { &Settings::RandomGanonsTrials, OFF },
+    { &Settings::GanonsTrialsCount, 6 },
+    // World Settings
+    { &Settings::StartingAge, AGE_CHILD },
+    { &Settings::ShuffleEntrances, ON },
+    { &Settings::ShuffleDungeonEntrances, SHUFFLEDUNGEONS_ON }, // Including Ganon's Castle could make it too easy
+    { &Settings::ShuffleOverworldEntrances, ON },
+    { &Settings::ShuffleInteriorEntrances, SHUFFLEINTERIORS_ALL },
+    { &Settings::ShuffleGrottoEntrances, ON },
+    { &Settings::AmmoDrops, AMMODROPS_NONE },
+    { &Settings::HeartDropRefill, HEARTDROPREFILL_NODROPREFILL },
+    { &Settings::MQDungeonCount, 13 }, // Random
+    // Shuffle Settings
+    { &Settings::ShuffleRewards, REWARDSHUFFLE_ANYWHERE },
+    { &Settings::LinksPocketItem, LINKSPOCKETITEM_ANYTHING },
+    { &Settings::ShuffleSongs, SONGSHUFFLE_ANYWHERE },
+    { &Settings::Shopsanity, SHOPSANITY_FOUR },
+    { &Settings::Tokensanity, TOKENSANITY_ALL_TOKENS },
+    { &Settings::Scrubsanity, SCRUBSANITY_RANDOM_PRICES },
+    { &Settings::ShuffleCows, ON },
+    { &Settings::ShuffleKokiriSword, ON },
+    { &Settings::ShuffleOcarinas, ON },
+    { &Settings::ShuffleWeirdEgg, ON },
+    { &Settings::ShuffleGerudoToken, ON },
+    { &Settings::ShuffleMagicBeans, ON },
+    { &Settings::ShuffleMerchants, SHUFFLEMERCHANTS_NO_HINTS },
+    { &Settings::ShuffleAdultTradeQuest, ON },
+    { &Settings::ShuffleChestMinigame, SHUFFLECHESTMINIGAME_SINGLE_KEYS },
+    { &Settings::ShuffleFrogSongRupees, ON },
+    // Shuffle Dungeon Items
+    { &Settings::MapsAndCompasses, MAPSANDCOMPASSES_ANYWHERE },
+    { &Settings::Keysanity, KEYSANITY_ANYWHERE },
+    { &Settings::GerudoKeys, GERUDOKEYS_ANYWHERE },
+    { &Settings::BossKeysanity, BOSSKEYSANITY_ANYWHERE },
+    { &Settings::GanonsBossKey, GANONSBOSSKEY_ANYWHERE },
+    // Timesaver Settings
+    { &Settings::SkipChildStealth, DONT_SKIP },
+    { &Settings::SkipTowerEscape, DONT_SKIP },
+    { &Settings::SkipEponaRace, DONT_SKIP },
+    { &Settings::SkipMinigamePhases, DONT_SKIP },
+    { &Settings::FreeScarecrow, OFF },
+    { &Settings::BigPoeTargetCount, 9 }, // Index 9 is 10 poes
+    { &Settings::NumRequiredCuccos, 7 },
+    { &Settings::KingZoraSpeed, KINGZORASPEED_RANDOM },
+    // Logic Options
+    { &Settings::Logic, LOGIC_NONE },
+    // Starting Inventory
+    { &Settings::StartingHearts, 0 },
+    // Misc Settings
+    { &Settings::GossipStoneHints, HINTS_NEED_NOTHING },
+    { &Settings::ClearerHints, HINTMODE_CLEAR },
+    { &Settings::HintDistribution, HINTDISTRIBUTION_USELESS },
+    { &Settings::CompassesShowReward, OFF },
+    { &Settings::CompassesShowWotH, OFF },
+    { &Settings::MapsShowDungeonMode, OFF },
+    { &Settings::DamageMultiplier, DAMAGEMULTIPLIER_OHKO },
+    { &Settings::RandomTrapDmg, RANDOMTRAPS_ADVANCED },
+    { &Settings::FireTrap, ON },
+    { &Settings::AntiFairyTrap, ON },
+    { &Settings::CurseTraps, ON },
+    // Item Pool Settings
+    { &Settings::IceTrapValue, ICETRAPS_ONSLAUGHT },
+    { &Settings::RemoveDoubleDefense, OFF },
+    { &Settings::ProgressiveGoronSword, ON },
+    // Item Usability Settings
+    { &Settings::RestoreISG, OFF },
+    { &Settings::GkDurability, GKDURABILITY_RANDOMRISK },
+} };
+
+std::vector<PremadePreset*> premadePresets = {
+    &presetNintended,
+    &presetAllsanity,
+    &presetRacing,
+    &presetFullChaos,
+};

--- a/source/preset.hpp
+++ b/source/preset.hpp
@@ -3,6 +3,9 @@
 #include <string>
 #include <vector>
 
+#include <settings.hpp>
+#include <item_location.hpp>
+
 enum class OptionCategory;
 
 bool CreatePresetDirectories();
@@ -15,3 +18,12 @@ void SaveCachedSettings();
 void LoadCachedSettings();
 bool SaveCachedCosmetics();
 void LoadCachedCosmetics();
+
+typedef struct {
+    std::string_view name;
+    std::string_view description;
+    std::vector<std::pair<Option*, u8>> optionOverrides;
+    std::vector<LocationKey> excludedLocations;
+} PremadePreset;
+
+extern std::vector<PremadePreset*> premadePresets;

--- a/source/settings.cpp
+++ b/source/settings.cpp
@@ -10,7 +10,7 @@
 #include "sound_effects.hpp"
 #include "random.hpp"
 #include "randomizer.hpp"
-#include "setting_descriptions.hpp"
+#include "descriptions.hpp"
 #include "trial.hpp"
 #include "keys.hpp"
 
@@ -287,19 +287,19 @@ namespace Settings {
   Option Racing              = Option::Bool("Racing",                 {"Off", "On"},                                                          {racingDesc});
   Option GossipStoneHints    = Option::U8  ("Gossip Stone Hints",     {"No Hints", "Need Nothing", "Mask of Truth", "Shard of Agony"},        {gossipStonesHintsDesc},                                                                                          OptionCategory::Setting,    HINTS_NEED_NOTHING);
   Option ClearerHints        = Option::U8  ("  Hint Clarity",         {"Obscure", "Ambiguous", "Clear"},                                      {obscureHintsDesc, ambiguousHintsDesc, clearHintsDesc});
-  Option HintDistribution    = Option::U8  ("  Hint Distribution",    {"Useless", "Balanced", "Strong", "Very Strong"},                       {uselessHintsDesc, balancedHintsDesc, strongHintsDesc, veryStrongHintsDesc},                                      OptionCategory::Setting,    1); // Balanced
-  Option CompassesShowReward = Option::U8  ("Compasses Show Rewards", {"No", "Yes"},                                                          {compassesShowRewardsDesc},                                                                                       OptionCategory::Setting,    1);
-  Option CompassesShowWotH   = Option::U8  ("Compasses Show WotH",    {"No", "Yes"},                                                          {compassesShowWotHDesc},                                                                                          OptionCategory::Setting,    1);
-  Option MapsShowDungeonMode = Option::U8  ("Maps Show Dungeon Modes",{"No", "Yes"},                                                          {mapsShowDungeonModesDesc},                                                                                       OptionCategory::Setting,    1);
+  Option HintDistribution    = Option::U8  ("  Hint Distribution",    {"Useless", "Balanced", "Strong", "Very Strong"},                       {uselessHintsDesc, balancedHintsDesc, strongHintsDesc, veryStrongHintsDesc},                                      OptionCategory::Setting,    HINTDISTRIBUTION_BALANCED);
+  Option CompassesShowReward = Option::U8  ("Compasses Show Rewards", {"No", "Yes"},                                                          {compassesShowRewardsDesc},                                                                                       OptionCategory::Setting,    ON);
+  Option CompassesShowWotH   = Option::U8  ("Compasses Show WotH",    {"No", "Yes"},                                                          {compassesShowWotHDesc},                                                                                          OptionCategory::Setting,    ON);
+  Option MapsShowDungeonMode = Option::U8  ("Maps Show Dungeon Modes",{"No", "Yes"},                                                          {mapsShowDungeonModesDesc},                                                                                       OptionCategory::Setting,    ON);
   Option DamageMultiplier    = Option::U8  ("Damage Multiplier",      {"x1/2", "x1", "x2", "x4", "x8", "x16", "OHKO"},                        {damageMultiDesc},                                                                                                OptionCategory::Setting,    DAMAGEMULTIPLIER_DEFAULT);
   Option StartingTime        = Option::U8  ("Starting Time",          {"Day", "Night"},                                                       {startingTimeDesc});
   Option ChestAnimations     = Option::Bool("Chest Animations",       {"Always Fast", "Match Contents"},                                      {chestAnimDesc});
   Option ChestSize           = Option::Bool("Chest Size and Color",   {"Vanilla", "Match Contents"},                                          {chestSizeDesc});
-  Option GenerateSpoilerLog  = Option::Bool("Generate Spoiler Log",   {"No", "Yes"},                                                          {""},                                                                                                             OptionCategory::Setting,    1); // On
+  Option GenerateSpoilerLog  = Option::Bool("Generate Spoiler Log",   {"No", "Yes"},                                                          {""},                                                                                                             OptionCategory::Setting,    ON);
   Option IngameSpoilers      = Option::Bool("Ingame Spoilers",        {"Hide", "Show"},                                                       {ingameSpoilersHideDesc, ingameSpoilersShowDesc });
-  Option RandomTrapDmg       = Option::U8  ("Random Trap Damage",     {"Off", "Basic", "Advanced"},                                           {randomTrapDmgDesc, basicTrapDmgDesc, advancedTrapDmgDesc},                                                       OptionCategory::Setting,    1); // Basic
-  Option FireTrap            = Option::Bool("  Fire Trap",            {"Off", "On"},                                                          {fireTrapDesc},                                                                                                   OptionCategory::Setting,    1); // On
-  Option AntiFairyTrap       = Option::Bool("  Anti-Fairy Trap",      {"Off", "On"},                                                          {antiFairyTrapDesc},                                                                                              OptionCategory::Setting,    1); // On
+  Option RandomTrapDmg       = Option::U8  ("Random Trap Damage",     {"Off", "Basic", "Advanced"},                                           {randomTrapDmgDesc, basicTrapDmgDesc, advancedTrapDmgDesc},                                                       OptionCategory::Setting,    RANDOMTRAPS_BASIC);
+  Option FireTrap            = Option::Bool("  Fire Trap",            {"Off", "On"},                                                          {fireTrapDesc},                                                                                                   OptionCategory::Setting,    ON);
+  Option AntiFairyTrap       = Option::Bool("  Anti-Fairy Trap",      {"Off", "On"},                                                          {antiFairyTrapDesc},                                                                                              OptionCategory::Setting,    ON);
   Option CurseTraps          = Option::Bool("  Curse Traps",          {"Off", "On"},                                                          {curseTrapsDesc},                                                                                                 OptionCategory::Setting);
   bool HasNightStart         = false;
   std::vector<Option *> miscOptions = {
@@ -587,7 +587,7 @@ namespace Settings {
     &startingOthers,
   };
   Option Logic              = Option::U8  ("Logic",                   {"Glitchless", "Glitched", "No Logic", "Vanilla"}, {logicGlitchless, logicGlitched, logicNoLogic, logicVanilla});
-  Option LocationsReachable = Option::Bool("All Locations Reachable", {"Off", "On"},                                     {locationsReachableDesc},                                                                                                              OptionCategory::Setting,    1); //All Locations Reachable On
+  Option LocationsReachable = Option::Bool("All Locations Reachable", {"Off", "On"},                                     {locationsReachableDesc},                                                                                                              OptionCategory::Setting,    ON);
   Option NightGSExpectSuns  = Option::Bool("Night GSs Expect Sun's",  {"Off", "On"},                                     {nightGSDesc});
   std::vector<Option *> logicOptions = {
     &Logic,
@@ -898,23 +898,22 @@ namespace Settings {
   };
 
   Option QuickText           = Option::U8  ("Quick Text",             {"0: Vanilla", "1: Skippable", "2: Instant", "3: Turbo"},               {quickTextDesc0, quickTextDesc1, quickTextDesc2, quickTextDesc3},                                                 OptionCategory::Cosmetic,   QUICKTEXT_INSTANT);
-  Option SkipSongReplays     = Option::U8  ("Skip Song Replays",      {"Don't Skip", "Skip (No SFX)", "Skip (Keep SFX)"},                     {skipSongReplaysDesc},                                                                                            OptionCategory::Cosmetic);
   Option MenuOpeningButton   = Option::U8  ("Open Info Menu with",    {"Select","Start","D-Pad Up","D-Pad Down","D-Pad Right","D-Pad Left",}, {menuButtonDesc},                                                                                                 OptionCategory::Cosmetic);
   Option ArrowSwitchButton   = Option::U8  ("Switch Arrows with",     {"D-Pad Right","D-Pad Left","D-Pad Up","D-Pad Down","Touch Screen",},   {arrowSwitchDesc},                                                                                                OptionCategory::Cosmetic);
   std::vector<Option*> preferenceOptions = {
     &QuickText,
-    &SkipSongReplays,
     &MenuOpeningButton,
     &ArrowSwitchButton,
   };
 
-  Option ZTargeting         = Option::U8("L-Targeting",          {"Switch", "Hold"},          {""},                     OptionCategory::Cosmetic, 1);
-  Option CameraControl      = Option::U8("Camera Control",       {"Normal", "Invert Y-axis"}, {""},                     OptionCategory::Cosmetic);
-  Option MotionControl      = Option::U8("Motion Control",       {"On", "Off"},               {""},                     OptionCategory::Cosmetic);
-  Option TogglePlayMusic    = Option::U8("Play Music",           {"Off", "On"},               {""},                     OptionCategory::Cosmetic, 1);
-  Option TogglePlaySFX      = Option::U8("Play Sound Effects",   {"Off", "On"},               {""},                     OptionCategory::Cosmetic, 1);
-  Option SilenceNavi        = Option::U8("Silence Navi",         {"Off", "On"},               {silenceNaviDesc},        OptionCategory::Cosmetic);
-  Option IgnoreMaskReaction = Option::U8("Ignore Mask Reaction", {"Off", "On"},               {ignoreMaskReactionDesc}, OptionCategory::Cosmetic);
+  Option ZTargeting         = Option::U8("L-Targeting",          {"Switch", "Hold"},                                 {""},                     OptionCategory::Cosmetic, 1);
+  Option CameraControl      = Option::U8("Camera Control",       {"Normal", "Invert Y-axis"},                        {""},                     OptionCategory::Cosmetic);
+  Option MotionControl      = Option::U8("Motion Control",       {"On", "Off"},                                      {""},                     OptionCategory::Cosmetic);
+  Option TogglePlayMusic    = Option::U8("Play Music",           {"Off", "On"},                                      {""},                     OptionCategory::Cosmetic, 1);
+  Option TogglePlaySFX      = Option::U8("Play Sound Effects",   {"Off", "On"},                                      {""},                     OptionCategory::Cosmetic, 1);
+  Option SilenceNavi        = Option::U8("Silence Navi",         {"Off", "On"},                                      {silenceNaviDesc},        OptionCategory::Cosmetic);
+  Option IgnoreMaskReaction = Option::U8("Ignore Mask Reaction", {"Off", "On"},                                      {ignoreMaskReactionDesc}, OptionCategory::Cosmetic);
+  Option SkipSongReplays    = Option::U8("Skip Song Replays",    {"Don't Skip", "Skip (No SFX)", "Skip (Keep SFX)"}, {skipSongReplaysDesc},    OptionCategory::Cosmetic);
   std::vector<Option*> ingameDefaultOptions = {
     &ZTargeting,
     &CameraControl,
@@ -923,6 +922,7 @@ namespace Settings {
     &TogglePlaySFX,
     &SilenceNavi,
     &IgnoreMaskReaction,
+    &SkipSongReplays,
   };
 
   //Function to make options vectors for Navi and Tunic colors without the "Same as ..." option
@@ -1154,12 +1154,12 @@ namespace Settings {
   Option ShuffleMusic =    Option::Bool("Shuffle Music",           {"Off", "On"},                         {musicRandoDesc},                                                                                                                                     OptionCategory::Cosmetic);
   Option ShuffleBGM =      Option::U8  ("  Shuffle BGM",           {"Off", "On (Grouped)", "On (Mixed)"}, {shuffleBGMDesc},                                                                                                                                     OptionCategory::Cosmetic,               2); // On (Mixed)
   Option ShuffleFanfares = Option::U8  ("  Shuffle Fanfares",      {fanfareOptions},                      {fanfareDescriptions},                                                                                                                                OptionCategory::Cosmetic,               1); // Fanfares only
-  Option ShuffleOcaMusic = Option::Bool("  Shuffle Ocarina Music", {"Off", "On"},                         {shuffleOcaMusicDesc},                                                                                                                                OptionCategory::Cosmetic,               1); // On
+  Option ShuffleOcaMusic = Option::Bool("  Shuffle Ocarina Music", {"Off", "On"},                         {shuffleOcaMusicDesc},                                                                                                                                OptionCategory::Cosmetic,               ON);
 
   Option ShuffleSFX              = Option::U8  ("Shuffle SFX",            {"Off", "All", "Scene Specific", "Chaos"}, {shuffleSFXOff, shuffleSFXAll, shuffleSFXSceneSpecific, shuffleSFXChaos},                                                                  OptionCategory::Cosmetic);
-  Option ShuffleSFXFootsteps     = Option::Bool("  Include Footsteps",    {"No", "Yes"},                             {""},                                                                                                                                      OptionCategory::Cosmetic,               1); // Yes
-  Option ShuffleSFXLinkVoice     = Option::Bool("  Include Link's Voice", {"No", "Yes"},                             {""},                                                                                                                                      OptionCategory::Cosmetic,               1); // Yes
-  Option ShuffleSFXCategorically = Option::Bool("  Categorical Shuffle",  {"Off", "On"},                             {shuffleSFXCategorically},                                                                                                                 OptionCategory::Cosmetic,               1); // On
+  Option ShuffleSFXFootsteps     = Option::Bool("  Include Footsteps",    {"No", "Yes"},                             {""},                                                                                                                                      OptionCategory::Cosmetic,               ON);
+  Option ShuffleSFXLinkVoice     = Option::Bool("  Include Link's Voice", {"No", "Yes"},                             {""},                                                                                                                                      OptionCategory::Cosmetic,               ON);
+  Option ShuffleSFXCategorically = Option::Bool("  Categorical Shuffle",  {"Off", "On"},                             {shuffleSFXCategorically},                                                                                                                 OptionCategory::Cosmetic,               ON);
 
   std::vector<Option*> audioOptions = {
     &ShuffleMusic,
@@ -1183,15 +1183,17 @@ namespace Settings {
     &audio,
   };
 
-  Menu loadSettingsPreset       = Menu::Action("Load Settings Preset",       LOAD_PRESET);
-  Menu saveSettingsPreset       = Menu::Action("Save Settings Preset",       SAVE_PRESET);
-  Menu deleteSettingsPreset     = Menu::Action("Delete Settings Preset",     DELETE_PRESET);
-  Menu resetToDefaultSettings   = Menu::Action("Reset to Default Settings",  RESET_TO_DEFAULTS);
+  Menu loadPremadePreset      = Menu::Action("Load Premade Preset",        LOAD_PREMADE_PRESET);
+  Menu loadCustomPreset       = Menu::Action("Load Settings Preset",       LOAD_CUSTOM_PRESET);
+  Menu saveCustomPreset       = Menu::Action("Save Settings Preset",       SAVE_CUSTOM_PRESET);
+  Menu deleteCustomPreset     = Menu::Action("Delete Settings Preset",     DELETE_CUSTOM_PRESET);
+  Menu resetToDefaultSettings = Menu::Action("Reset to Default Settings",  RESET_TO_DEFAULTS);
 
   std::vector<Menu *> settingsPresetItems = {
-    &loadSettingsPreset,
-    &saveSettingsPreset,
-    &deleteSettingsPreset,
+    &loadPremadePreset,
+    &loadCustomPreset,
+    &saveCustomPreset,
+    &deleteCustomPreset,
     &resetToDefaultSettings,
   };
 
@@ -1536,13 +1538,6 @@ namespace Settings {
     return ctx;
   }
 
-  //Set default cosmetics where the default is not the first option
-  static void SetDefaultCosmetics() {
-    for (auto op : cosmeticOptions) {
-      op->SetToDefault();
-    }
-  }
-
   //One-time initialization
   void InitSettings() {
     //Create Location Exclude settings
@@ -1553,76 +1548,28 @@ namespace Settings {
 
   //Set default settings for all settings
   void SetDefaultSettings() {
-    for (auto op : openOptions) {
-      op->SetToDefault();
-    }
-    for (auto op : worldOptions) {
-      op->SetToDefault();
-    }
-    for (auto op : shuffleOptions) {
-      op->SetToDefault();
-    }
-    for (auto op : shuffleDungeonItemOptions) {
-      op->SetToDefault();
-    }
-    for (auto op : timesaverOptions) {
-      op->SetToDefault();
-    }
-    for (auto op : miscOptions) {
-      op->SetToDefault();
-    }
-    for (auto op : itemUsabilityOptions) {
-      op->SetToDefault();
-    }
-    for (auto op : itemPoolOptions) {
-      op->SetToDefault();
-    }
-    for (auto menu : excludeLocationsMenus) {
-      for (auto op : *menu->settingsList) {
-        op->SetToDefault();
-      }
-    }
-    for (auto op : startingItemsOptions) {
-      op->SetToDefault();
-    }
-    for (auto op : startingSongsOptions) {
-      op->SetToDefault();
-    }
-    for (auto op : startingEquipmentOptions) {
-      op->SetToDefault();
-    }
-    for (auto op : startingStonesMedallionsOptions) {
-      op->SetToDefault();
-    }
-    for (auto op : startingOthersOptions) {
-      op->SetToDefault();
-    }
-    for (auto op : logicOptions) {
-      op->SetToDefault();
-    }
-    for (auto op : trickOptions) {
-      op->SetToDefault();
-    }
-    for (auto op : glitchCategories) {
-      op->SetToDefault();
-    }
-    for (auto op : miscGlitches) {
-      op->SetToDefault();
-    }
-    for (auto op : multiplayerOptions) {
-      op->SetToDefault();
-    }
+      std::function<void(std::vector<Menu*>*)> setAllOptionsToDefault = [&](std::vector<Menu*>* menuPtr) {
+          for (auto menu : *menuPtr) {
+              if (menu->mode == SUB_MENU) {
+                  setAllOptionsToDefault(menu->itemsList);
+              } else if (menu->mode == OPTION_MENU) {
+                  for (auto option : *menu->settingsList) {
+                      if (option->IsCategory(OptionCategory::Cosmetic)) {
+                          continue;
+                      }
+                      option->SetToDefault();
+                  }
+              }
+          }
+      };
 
-    for (auto loc : allLocations) {
-      Location(loc)->GetExcludedOption()->SetToDefault();
-    }
+      setAllOptionsToDefault(&mainMenu);
+
     //Don't let users exclude these locations
     //TODO: Make sure the defaults are set appropriately for these?
     Location(HC_ZELDAS_LETTER)->GetExcludedOption()->Hide();
     Location(MARKET_BOMBCHU_BOWLING_BOMBCHUS)->GetExcludedOption()->Hide();
     Location(GANON)->GetExcludedOption()->Hide();
-
-    SetDefaultCosmetics();
 
     ResolveExcludedLocationConflicts();
     for (Menu* menu : Settings::GetAllOptionMenus()) {
@@ -2744,7 +2691,7 @@ namespace Settings {
   //Else, recursively call each sub menu of this sub menu
   const std::vector<Menu*> GetMenusRecursive(Menu* menu) {
     std::vector<Menu*> menus;
-    if (menu->mode == OPTION_SUB_MENU) {
+    if (menu->mode == OPTION_MENU) {
       menus.push_back(menu);
     } else if (menu->mode == SUB_MENU) {
         for (Menu* subMenu : *menu->itemsList) {

--- a/source/settings.hpp
+++ b/source/settings.hpp
@@ -230,7 +230,7 @@ class Menu {
   public:
 
     static Menu SubMenu(std::string name_, std::vector<Option *>* settingsList_, std::string_view description_ = "", bool printInSpoiler_ = true) {
-      return Menu{std::move(name_), MenuType::SubMenu, std::move(settingsList_), OPTION_SUB_MENU, std::move(description_), printInSpoiler_};
+      return Menu{std::move(name_), MenuType::SubMenu, std::move(settingsList_), OPTION_MENU, std::move(description_), printInSpoiler_};
     }
 
     static Menu SubMenu(std::string name_, std::vector<Menu *>* itemsList_, std::string_view description_ = "", bool printInSpoiler_ = true) {
@@ -251,7 +251,7 @@ class Menu {
         : name(std::move(name_)), type(type_), mode(mode_) {}
 
     void ResetMenuIndex() {
-      if (mode == OPTION_SUB_MENU) {
+      if (mode == OPTION_MENU) {
         for (size_t i = 0; i < settingsList->size(); i++) {
           if (!settingsList->at(i)->IsLocked() && !settingsList->at(i)->IsHidden()) {
             menuIdx = i;
@@ -377,6 +377,9 @@ namespace Settings {
   extern Option GossipStoneHints;
   extern Option ClearerHints;
   extern Option HintDistribution;
+  extern Option CompassesShowReward;
+  extern Option CompassesShowWotH;
+  extern Option MapsShowDungeonMode;
   extern Option DamageMultiplier;
   extern Option StartingTime;
   extern Option ChestAnimations;
@@ -699,8 +702,8 @@ namespace Settings {
 
   extern u8 PlayOption;
 
-  extern Menu loadSettingsPreset;
-  extern Menu deleteSettingsPreset;
+  extern Menu loadCustomPreset;
+  extern Menu deleteCustomPreset;
 
   extern std::vector<std::vector<Option *>> excludeLocationsOptionsVector;
   extern std::vector<Menu *> excludeLocationsMenus;

--- a/source/spoiler_log.cpp
+++ b/source/spoiler_log.cpp
@@ -347,7 +347,7 @@ static void WriteSettings(tinyxml2::XMLDocument& spoilerLog, const bool printAll
 
   for (const Menu* menu : allMenus) {
     //This is a menu of settings, write them
-    if (menu->mode == OPTION_SUB_MENU && menu->printInSpoiler) {
+    if (menu->mode == OPTION_MENU && menu->printInSpoiler) {
       for (const Option* setting : *menu->settingsList) {
         if (printAll || (!setting->IsHidden() && setting->IsCategory(OptionCategory::Setting))) {
           auto node = parentNode->InsertNewChildElement("setting");


### PR DESCRIPTION
Comes with some examples and various app side improvements. 
Renames `setting_descriptions` files to just `descriptions` since it has for menus and presets now too, so merge this last because it'll be the easiest for me to rebase.

Also move `Skip Song Replays` to `Ingame Defaults` menu since it can be changed ingame now.