### PR TITLE
Increase Armos and Fire Pillar Block push speed

### DIFF
--- a/code/oot.ld
+++ b/code/oot.ld
@@ -16,6 +16,14 @@ SECTIONS
 		*(.patch_MidoCheckDekuTreeClearTwo)
 	}
 
+	.patch_ArmosCooldownTimer 0x10B41C : {
+		*(.patch_ArmosCooldownTimer)
+	}
+
+	.patch_ArmosPushSpeed 0x10B5C4 : {
+		*(.patch_ArmosPushSpeed)
+	}
+
 	.patch_ShortenRainbowBridgeCS 0x10B904 : {
 		*(.patch_ShortenRainbowBridgeCS)
 	}
@@ -976,14 +984,6 @@ SECTIONS
 		*(.patch_MidoCheckDekuTreeClearFour)
 	}
 
-	.patch_FireBlockCooldownTimer 0x3E0A2C : {
-		*(.patch_FireBlockCooldownTimer)
-	}
-
-	.patch_FireBlockSpeed 0x3E0BA8 : {
-		*(.patch_FireBlockSpeed)
-	}
-
 	.patch_BombPurchaseableCheck 0x3CE800 : {
 		*(.patch_BombPurchaseableCheck)
 	}
@@ -994,6 +994,10 @@ SECTIONS
 
 	.patch_ScrubNutUpgradeTwo 0x3CE9DC : {
 		*(.patch_ScrubNutUpgradeTwo)
+	}
+
+	.patch_FireBlockSpeed 0x3E0BB4 : {
+		*(.patch_FireBlockSpeed)
 	}
 
 	.patch_FreeScarecrow 0x3E55A8 : {

--- a/code/oot_e.ld
+++ b/code/oot_e.ld
@@ -16,6 +16,14 @@ SECTIONS
 		*(.patch_MidoCheckDekuTreeClearTwo)
 	}
 
+	.patch_ArmosCooldownTimer 0x10B41C : {
+		*(.patch_ArmosCooldownTimer)
+	}
+
+	.patch_ArmosPushSpeed 0x10B5C4 : {
+		*(.patch_ArmosPushSpeed)
+	}
+
 	.patch_ShortenRainbowBridgeCS 0x10B904 : {
 		*(.patch_ShortenRainbowBridgeCS)
 	}
@@ -976,14 +984,6 @@ SECTIONS
 		*(.patch_MidoCheckDekuTreeClearFour)
 	}
 
-	.patch_FireBlockCooldownTimer 0x3E0A2C : {
-		*(.patch_FireBlockCooldownTimer)
-	}
-
-	.patch_FireBlockSpeed 0x3E0BA8 : {
-		*(.patch_FireBlockSpeed)
-	}
-
 	.patch_BombPurchaseableCheck 0x3CE800 : {
 		*(.patch_BombPurchaseableCheck)
 	}
@@ -994,6 +994,10 @@ SECTIONS
 
 	.patch_ScrubNutUpgradeTwo 0x3CE9DC : {
 		*(.patch_ScrubNutUpgradeTwo)
+	}
+
+	.patch_FireBlockSpeed 0x3E0BB4 : {
+		*(.patch_FireBlockSpeed)
 	}
 
 	.patch_FreeScarecrow 0x3E55A8 : {

--- a/code/src/patches.s
+++ b/code/src/patches.s
@@ -820,12 +820,13 @@ AmyBlockCooldownTimer_patch:
     mov r1,#0x1
 
 .section .patch_FireBlockSpeed
-    .word 0x40800000
+    .word 0x3DCCCCCD
 
-.section .patch_FireBlockCooldownTimer
-.global FireBlockCooldownTimer_patch
-FireBlockCooldownTimer_patch:
-    mov r0,#0x1
+.section .patch_ArmosPushSpeed
+    .word 0x3F800000
+
+.section .patch_ArmosCooldownTimer
+    mov r0,#0xC
 
 .section .patch_ForestTempleBasementPuzzleDelay
 .global ForestTempleBasementPuzzleDelay_patch


### PR DESCRIPTION
Seems like the previous patches for the fire block were affecting the geyser instead, but this fixes it.