### PR TITLE
Force child as starting age with intended DoT and unshuffled Ocarinas

### DIFF
--- a/source/descriptions.cpp
+++ b/source/descriptions.cpp
@@ -170,9 +170,8 @@ string_view ageDesc                   = "Choose which age Link will start as.\n"
                                         "Forest.\n"                                        //
                                         "\n"                                               //
                                         "Child will also be forced if Door of Time is set\n"
-                                        "to intended, ocarinas are unshuffled, and logic is"
-                                        "set to glitchless since adult Link can't obtain\n"//
-                                        "the Ocarina from the moat.";                      //
+                                        "to intended and ocarinas are unshuffled unless you"
+                                        "start with an ocarina already in your inventory.";//
 /*------------------------------                                                           //
 |      SHUFFLE ENTRANCES       |                                                           //
 ------------------------------*/                                                           //

--- a/source/descriptions.cpp
+++ b/source/descriptions.cpp
@@ -166,11 +166,13 @@ string_view ganonsTrialCountDesc      = "Set the number of trials required to en
 ------------------------------*/                                                           //
 string_view ageDesc                   = "Choose which age Link will start as.\n"           //
                                         "\n"                                               //
-                                        "Starting as adult means you start with the Master\n"
-                                        "Sword in your inventory.\n"                       //
-                                        "\n"                                               //
                                         "Only the child option is compatible with Closed\n"//
-                                        "Forest.";                                         //
+                                        "Forest.\n"                                        //
+                                        "\n"                                               //
+                                        "Child will also be forced if Door of Time is set\n"
+                                        "to intended, ocarinas are unshuffled, and logic is"
+                                        "set to glitchless since adult Link can't obtain\n"//
+                                        "the Ocarina from the moat.";                      //
 /*------------------------------                                                           //
 |      SHUFFLE ENTRANCES       |                                                           //
 ------------------------------*/                                                           //

--- a/source/settings.cpp
+++ b/source/settings.cpp
@@ -1851,8 +1851,9 @@ namespace Settings {
 
     //Only go through options if all settings are not randomized
     if (!RandomizeOpen) {
-      //Adult is not compatible with Closed Forest
-      if (OpenForest.Is(OPENFOREST_CLOSED)) {
+      // Adult is not compatible with Closed Forest
+      // Adult is also not compatible with Intended DoT + Unshuffled Ocarinas + glitchless logic
+      if (OpenForest.Is(OPENFOREST_CLOSED) || (OpenDoorOfTime.Is(OPENDOOROFTIME_INTENDED) && !ShuffleOcarinas && Logic.Is(LOGIC_GLITCHLESS))) {
         StartingAge.SetSelectedIndex(AGE_CHILD);
         StartingAge.Lock();
       } else {

--- a/source/settings.cpp
+++ b/source/settings.cpp
@@ -1852,8 +1852,8 @@ namespace Settings {
     //Only go through options if all settings are not randomized
     if (!RandomizeOpen) {
       // Adult is not compatible with Closed Forest
-      // Adult is also not compatible with Intended DoT + Unshuffled Ocarinas + glitchless logic
-      if (OpenForest.Is(OPENFOREST_CLOSED) || (OpenDoorOfTime.Is(OPENDOOROFTIME_INTENDED) && !ShuffleOcarinas && Logic.Is(LOGIC_GLITCHLESS))) {
+      // Adult is also not compatible with Intended DoT + Unshuffled Ocarinas unless the player starts with an ocarina
+      if (OpenForest.Is(OPENFOREST_CLOSED) || (OpenDoorOfTime.Is(OPENDOOROFTIME_INTENDED) && !ShuffleOcarinas && StartingOcarina.Is(OFF))) {
         StartingAge.SetSelectedIndex(AGE_CHILD);
         StartingAge.Lock();
       } else {


### PR DESCRIPTION
Logic fix for the issue brought up in #565 