### PR TITLE
Fix flag for Granny's item

### DIFF
--- a/code/src/actors/granny.c
+++ b/code/src/actors/granny.c
@@ -1,19 +1,21 @@
 #include "z3D/z3D.h"
 #include "settings.h"
 
+#define GRANNY_FLAG (gSaveContext.eventChkInf[3] & 0x04)
+
 s32 EnDs_GetTextID(void) {
-    if ((gSettingsContext.shuffleMerchants == SHUFFLEMERCHANTS_HINTS) && !Flags_GetSwitch(gGlobalContext, 0x32)) {
+    if ((gSettingsContext.shuffleMerchants == SHUFFLEMERCHANTS_HINTS) && !GRANNY_FLAG) {
         return 0x9121; // custom text
     }
     return 0x500C; // vanilla text
 }
 
 s32 EnDs_ShouldIgnoreBottle(void) {
-    return (gSettingsContext.shuffleMerchants != SHUFFLEMERCHANTS_OFF) && !Flags_GetSwitch(gGlobalContext, 0x32);
+    return (gSettingsContext.shuffleMerchants != SHUFFLEMERCHANTS_OFF) && !GRANNY_FLAG;
 }
 
 s32 EnDs_ItemOverride(void) {
-    if (gSettingsContext.shuffleMerchants == SHUFFLEMERCHANTS_OFF || Flags_GetSwitch(gGlobalContext, 0x32)) {
+    if (gSettingsContext.shuffleMerchants == SHUFFLEMERCHANTS_OFF || GRANNY_FLAG) {
         return GI_POTION_BLUE;
     } else {
         return GI_POTION_RED; // will be overridden
@@ -21,5 +23,5 @@ s32 EnDs_ItemOverride(void) {
 }
 
 void EnDs_SetRewardFlag(void) {
-    Flags_SetSwitch(gGlobalContext, 0x32);
+    gSaveContext.eventChkInf[3] |= 0x04;
 }


### PR DESCRIPTION
Granny was erroneously using a temporary flag to keep track of the sold item check, making it possible to buy the shuffled item multiple times by leaving and re-entering the shop.

Now she'll use the intended permanent flag.