### PR TITLE
Add Hide and Seek option to multiplayer

### DIFF
--- a/code/src/gfx_options.c
+++ b/code/src/gfx_options.c
@@ -9,7 +9,7 @@
 #define BORDER_WIDTH 2
 #define CHOICE_COLUMN 220
 #define DESCRIPTION_ROW 184
-#define OPTIONS_COUNT 5
+#define OPTIONS_COUNT 6
 
 typedef struct {
     char name[30];
@@ -57,6 +57,14 @@ void InitOptions(void) {
     strcpy(options[4].alternatives[2], "Skip (Keep SFX)");
     strcpy(options[4].description, "Toggle skipping the automatic replay after\nyou play a song.");
     options[4].optionPointer = &gExtSaveData.option_SkipSongReplays;
+
+    // Hide & Seek Mode
+    strcpy(options[5].name, "Hide & Seek Mode");
+    strcpy(options[5].alternatives[0], "Off");
+    strcpy(options[5].alternatives[1], "Hider");
+    strcpy(options[5].alternatives[2], "Seeker");
+    strcpy(options[5].description, "If set to hider, contact with a seeker\nin multiplayer will end in death.");
+    options[5].optionPointer = &gExtSaveData.option_HideSeek;
 }
 
 void Gfx_DrawOptions(void) {

--- a/code/src/multiplayer.c
+++ b/code/src/multiplayer.c
@@ -890,6 +890,7 @@ void Multiplayer_Send_GhostData(void) {
     ghostData.currentScene = gGlobalContext->sceneNum;
     ghostData.age = gSaveContext.linkAge;
     ghostData.position = PLAYER->actor.world.pos;
+    ghostData.hideSeek = gExtSaveData.option_HideSeek;
 
     memcpy(&mBuffer[memSpacer], &ghostData, sizeof(GhostData));
     memSpacer += sizeof(GhostData) / 4;

--- a/code/src/multiplayer_ghosts.h
+++ b/code/src/multiplayer_ghosts.h
@@ -8,6 +8,7 @@ typedef struct {
     s16 currentScene;
     s32 age;
     Vec3f position;
+    s8 hideSeek;
     // Animation vars here
 } GhostData;
 

--- a/code/src/savefile.c
+++ b/code/src/savefile.c
@@ -627,6 +627,7 @@ void SaveFile_InitExtSaveData(u32 saveNumber) {
     gExtSaveData.option_SilenceNavi = gSettingsContext.silenceNavi;
     gExtSaveData.option_IgnoreMaskReaction = gSettingsContext.ignoreMaskReaction;
     gExtSaveData.option_SkipSongReplays = gSettingsContext.skipSongReplays;
+    gExtSaveData.option_HideSeek = gSettingsContext.mp_HideSeek;
 }
 
 void SaveFile_LoadExtSaveData(u32 saveNumber) {

--- a/code/src/savefile.h
+++ b/code/src/savefile.h
@@ -58,6 +58,7 @@ typedef struct {
     s8 option_SilenceNavi;
     s8 option_IgnoreMaskReaction;
     s8 option_SkipSongReplays;
+    s8 option_HideSeek;
 } ExtSaveData;
 
 #ifdef DECLARE_EXTSAVEDATA

--- a/code/src/settings.h
+++ b/code/src/settings.h
@@ -663,7 +663,7 @@ typedef struct {
 } SettingsContext;
 
 extern SettingsContext gSettingsContext;
-extern const char hashIconNames[32][25];\
+extern const char hashIconNames[32][25];
 
 s32 Settings_ApplyDamageMultiplier(GlobalContext*, s32);
 void Settings_SkipSongReplays();

--- a/code/src/settings.h
+++ b/code/src/settings.h
@@ -246,6 +246,12 @@ typedef enum {
 } SkipSongReplaysSetting;
 
 typedef enum {
+  MP_HIDESEEK_OFF,
+  MP_HIDESEEK_HIDE,
+  MP_HIDESEEK_SEEK,
+} MP_HideSeekSetting;
+
+typedef enum {
   INCLUDE,
   EXCLUDE,
 } ExcludeLocationSetting;
@@ -548,6 +554,7 @@ typedef struct {
   u8 mp_SharedHealth;
   u8 mp_SharedRupees;
   u8 mp_SharedAmmo;
+  u8 mp_HideSeek;
 
   u8 zTargeting;
   u8 cameraControl;
@@ -656,7 +663,7 @@ typedef struct {
 } SettingsContext;
 
 extern SettingsContext gSettingsContext;
-extern const char hashIconNames[32][25];
+extern const char hashIconNames[32][25];\
 
 s32 Settings_ApplyDamageMultiplier(GlobalContext*, s32);
 void Settings_SkipSongReplays();

--- a/source/descriptions.cpp
+++ b/source/descriptions.cpp
@@ -1037,6 +1037,8 @@ string_view mp_SharedRupeesDesc       = "Syncs rupees when shared progress is on
                                         "otherwise just shares the gain and loss.";        //
 string_view mp_SharedAmmoDesc         = "Syncs ammo when shared progress is on,\n"         //
                                         "otherwise just shares the gain and loss.";        //
+string_view mp_HideSeekDesc           = "If set to hider, any multiplayers set to seeker\n"//
+                                        "will kill you on contact. Can be changed later."; //
                                                                                            //
 /*------------------------------                                                           //
 |       INGAME DEFAULTS        |                                                           //

--- a/source/descriptions.hpp
+++ b/source/descriptions.hpp
@@ -325,6 +325,7 @@ extern string_view mp_SyncIdDesc;
 extern string_view mp_SharedHealthDesc;
 extern string_view mp_SharedRupeesDesc;
 extern string_view mp_SharedAmmoDesc;
+extern string_view mp_HideSeekDesc;
 
 extern string_view silenceNaviDesc;
 extern string_view ignoreMaskReactionDesc;

--- a/source/settings.cpp
+++ b/source/settings.cpp
@@ -914,12 +914,13 @@ namespace Settings {
     &miscGlitchSettings,
   };
 
-  Option MP_Enabled        = Option::U8  ("Multiplayer",     {"Off", "On (Local)"}, {mp_EnabledDesc});
-  Option MP_SharedProgress = Option::Bool("Shared Progress", {"Off", "On"},         {mp_SharedProgressDesc});
-  Option MP_SyncId         = Option::U8  ("  Sync ID",       {NumOpts(1, 8)},       {mp_SyncIdDesc}, OptionCategory::Cosmetic);
-  Option MP_SharedHealth   = Option::Bool("Shared Health",   {"Off", "On"},         {mp_SharedHealthDesc});
-  Option MP_SharedRupees   = Option::Bool("Shared Rupees",   {"Off", "On"},         {mp_SharedRupeesDesc});
-  Option MP_SharedAmmo     = Option::Bool("Shared Ammo",     {"Off", "On"},         {mp_SharedAmmoDesc});
+  Option MP_Enabled        = Option::U8  ("Multiplayer",     {"Off", "On (Local)"},     {mp_EnabledDesc});
+  Option MP_SharedProgress = Option::Bool("Shared Progress", {"Off", "On"},             {mp_SharedProgressDesc});
+  Option MP_SyncId         = Option::U8  ("  Sync ID",       {NumOpts(1, 8)},           {mp_SyncIdDesc}, OptionCategory::Cosmetic);
+  Option MP_SharedHealth   = Option::Bool("Shared Health",   {"Off", "On"},             {mp_SharedHealthDesc});
+  Option MP_SharedRupees   = Option::Bool("Shared Rupees",   {"Off", "On"},             {mp_SharedRupeesDesc});
+  Option MP_SharedAmmo     = Option::Bool("Shared Ammo",     {"Off", "On"},             {mp_SharedAmmoDesc});
+  Option MP_HideSeek       = Option::U8  ("Hide & Seek",     {"Off", "Hider", "Seeker"},{mp_HideSeekDesc}, OptionCategory::Cosmetic);
   std::vector<Option*> multiplayerOptions = {
     &MP_Enabled,
     &MP_SharedProgress,
@@ -927,6 +928,7 @@ namespace Settings {
     &MP_SharedHealth,
     &MP_SharedRupees,
     &MP_SharedAmmo,
+    &MP_HideSeek,
   };
 
   Option QuickText           = Option::U8  ("Quick Text",             {"0: Vanilla", "1: Skippable", "2: Instant", "3: Turbo"},               {quickTextDesc0, quickTextDesc1, quickTextDesc2, quickTextDesc3},                                                 OptionCategory::Cosmetic,   QUICKTEXT_INSTANT);
@@ -1436,6 +1438,7 @@ namespace Settings {
     ctx.mp_SharedAmmo        = (MP_SharedAmmo) ? 1 : 0;
     ctx.mp_SharedHealth      = (MP_SharedHealth) ? 1 : 0;
     ctx.mp_SharedRupees      = (MP_SharedRupees) ? 1 : 0;
+    ctx.mp_HideSeek          = MP_HideSeek.Value<u8>();
 
     ctx.zTargeting           = ZTargeting.Value<u8>();
     ctx.cameraControl        = CameraControl.Value<u8>();

--- a/source/settings.hpp
+++ b/source/settings.hpp
@@ -646,6 +646,7 @@ namespace Settings {
   extern Option MP_SharedHealth;
   extern Option MP_SharedRupees;
   extern Option MP_SharedAmmo;
+  extern Option MP_HideSeek;
 
   //Ingame Default Settings
   extern Option ZTargeting;


### PR DESCRIPTION
Add the options for Hide and Seek to Multiplayer Settings.
Options include "Off", "Hider", and "Seeker".
If a Seeker catches a Hider (by touching them) the Hider is killed, and respawns as a Seeker.
Also includes the ability to change Hide and Seek mode in the GFX menu.

I fully understand if this Pull Request is not merged, as it is not fully a Randomizer option. However I figured it would be a neat addition to multiplayer and I will definitely be using it for my own games with my brothers.