### PR TITLE
Add decoupled entrances to spoiler log output

### DIFF
--- a/source/fill.cpp
+++ b/source/fill.cpp
@@ -294,9 +294,12 @@ std::vector<LocationKey> GetAccessibleLocations(const std::vector<LocationKey>& 
         if (mode == SearchMode::GeneratePlaythrough && exit.IsShuffled() && !exit.IsAddedToPool() && !noRandomEntrances) {
           entranceSphere.push_back(&exit);
           exit.AddToPool();
-          // Don't list a coupled entrance from both directions
-          if (exit.GetReplacement()->GetReverse() != nullptr /*&& !DecoupleEntrances*/) {
+          if (exit.GetReplacement()->GetReverse() != nullptr) {
             exit.GetReplacement()->GetReverse()->AddToPool();
+            // When decoupled, list the reverse direction too
+            if (Settings::DecoupleEntrances) {
+              entranceSphere.push_back(exit.GetReplacement()->GetReverse());
+            }
           }
         }
       }


### PR DESCRIPTION
Noticed the decoupled reverse entrances were not being saved in the spoiler log output/playthrough spheres.

We are relying on the playthrough spheres to implement entrance rando in Ship of Harkinian, and wanted to bring this upstream.
ref https://github.com/HarbourMasters/Shipwright/pull/1760