### PR TITLE
Fix child B button glitch

### DIFF
--- a/code/src/savefile.c
+++ b/code/src/savefile.c
@@ -181,6 +181,7 @@ u16 SaveFile_RestoreChildEquips(void) {
     //if Kokiri Sword is not on child B button
     if (gSaveContext.childEquips.buttonItems[0] != ITEM_SWORD_KOKIRI) {
         gSaveContext.infTable[29] |= 0x1; //set swordless flag
+        gSaveContext.buttonStatus[0] = 0xFF; //clear Temp B
     }
     return (gSaveContext.childEquips.equipment & 0xFFF0) | (gSaveContext.equipment & 0x1);
 }


### PR DESCRIPTION
This fixes the issue where the Master Sword could get automatically equipped as child after playing a minigame as adult to put the sword on Temp B, then going back in time and dying as child to restore the stale Temp B value.