### PR TITLE
Fix glitched logic errors

### DIFF
--- a/source/location_access.cpp
+++ b/source/location_access.cpp
@@ -266,9 +266,7 @@ void AreaTable_Init() {
   areaTable[ROOT_EXITS] = Area("Root Exits", "", NONE, NO_DAY_NIGHT_CYCLE, {}, {}, {
                   //Exits
                   Entrance(CHILD_SPAWN,             {[]{return IsChild;}}),
-                  Entrance(ADULT_SPAWN,             {[]{return IsAdult;},
-                                         /*Glitched*/[]{return (((IsChild && (ChildCanAccess(KOKIRI_FOREST) || ChildCanAccess(HYRULE_FIELD) || ChildCanAccess(LAKE_HYLIA))) || (IsAdult && (AdultCanAccess(KOKIRI_FOREST) || AdultCanAccess(HYRULE_FIELD) || AdultCanAccess(LAKE_HYLIA)))) && (CanDoGlitch(GlitchType::OutdoorBombOI, GlitchDifficulty::NOVICE) ||
-                                                                 ((Bugs || Fish) && CanShield && CanDoGlitch(GlitchType::QPA, GlitchDifficulty::ADVANCED)) || ((Bugs || Fish) && (CanJumpslash || CanUseProjectile || CanUse(MEGATON_HAMMER) || HasBombchus) && CanDoGlitch(GlitchType::ActionSwap, GlitchDifficulty::NOVICE)))) && PreludeOfLight   && CanLeaveForest;}}),
+                  Entrance(ADULT_SPAWN,             {[]{return IsAdult;}}),
                   Entrance(MINUET_OF_FOREST_WARP,   {[]{return CanPlay(MinuetOfForest);},
                                          /*Glitched*/[]{return (((IsChild && (ChildCanAccess(KOKIRI_FOREST) || ChildCanAccess(HYRULE_FIELD) || ChildCanAccess(LAKE_HYLIA))) || (IsAdult && (AdultCanAccess(KOKIRI_FOREST) || AdultCanAccess(HYRULE_FIELD) || AdultCanAccess(LAKE_HYLIA)))) && (CanDoGlitch(GlitchType::OutdoorBombOI, GlitchDifficulty::NOVICE) ||
                                                                  ((Bugs || Fish) && CanShield && CanDoGlitch(GlitchType::QPA, GlitchDifficulty::ADVANCED)) || ((Bugs || Fish) && (CanJumpslash || CanUseProjectile || CanUse(MEGATON_HAMMER) || HasBombchus) && CanDoGlitch(GlitchType::ActionSwap, GlitchDifficulty::NOVICE)))) && MinuetOfForest;}}),
@@ -286,7 +284,7 @@ void AreaTable_Init() {
                                                                  ((Bugs || Fish) && CanShield && CanDoGlitch(GlitchType::QPA, GlitchDifficulty::ADVANCED)) || ((Bugs || Fish) && (CanJumpslash || CanUseProjectile || CanUse(MEGATON_HAMMER) || HasBombchus) && CanDoGlitch(GlitchType::ActionSwap, GlitchDifficulty::NOVICE)))) && RequiemOfSpirit  && CanLeaveForest;}}),
                   Entrance(PRELUDE_OF_LIGHT_WARP,   {[]{return CanPlay(PreludeOfLight)   && CanLeaveForest;},
                                          /*Glitched*/[]{return (((IsChild && (ChildCanAccess(KOKIRI_FOREST) || ChildCanAccess(HYRULE_FIELD) || ChildCanAccess(LAKE_HYLIA))) || (IsAdult && (AdultCanAccess(KOKIRI_FOREST) || AdultCanAccess(HYRULE_FIELD) || AdultCanAccess(LAKE_HYLIA)))) && (CanDoGlitch(GlitchType::OutdoorBombOI, GlitchDifficulty::NOVICE) ||
-                                                                 ((Bugs || Fish) && CanShield && CanDoGlitch(GlitchType::QPA, GlitchDifficulty::ADVANCED)) || ((Bugs || Fish) && (CanJumpslash || CanUseProjectile || CanUse(MEGATON_HAMMER) || HasBombchus) && CanDoGlitch(GlitchType::ActionSwap, GlitchDifficulty::NOVICE)))) && RequiemOfSpirit  && CanLeaveForest;}}),
+                                                                 ((Bugs || Fish) && CanShield && CanDoGlitch(GlitchType::QPA, GlitchDifficulty::ADVANCED)) || ((Bugs || Fish) && (CanJumpslash || CanUseProjectile || CanUse(MEGATON_HAMMER) || HasBombchus) && CanDoGlitch(GlitchType::ActionSwap, GlitchDifficulty::NOVICE)))) && PreludeOfLight  && CanLeaveForest;}}),
   });
 
   areaTable[CHILD_SPAWN] = Area("Child Spawn", "", NONE, NO_DAY_NIGHT_CYCLE, {}, {}, {

--- a/source/location_access/locacc_forest_temple.cpp
+++ b/source/location_access/locacc_forest_temple.cpp
@@ -44,7 +44,7 @@ void AreaTable_Init_ForestTemple() {
                 }, {
                   //Locations
                   LocationAccess(FOREST_TEMPLE_GS_LOBBY, {[]{return HookshotOrBoomerang;},
-                                              /*Glitched*/[]{return IsAdult && HasBombchus && CanDoGlitch(GlitchType::BombHover, GlitchDifficulty::NOVICE);}}),
+                                              /*Glitched*/[]{return HasBombchus && CanDoGlitch(GlitchType::BombHover, GlitchDifficulty::NOVICE);}}),
                 }, {
                   //Exits
                   Entrance(FOREST_TEMPLE_SOUTH_CORRIDOR,    {[]{return true;}}),


### PR DESCRIPTION
I accidentally kept the glitched logic condition in for the ADULT_SPAWN area when it should've been moved to PRELUDE_OF_LIGHT_WARP.