### PR TITLE
Various logic fixes

### DIFF
--- a/source/descriptions.cpp
+++ b/source/descriptions.cpp
@@ -1336,7 +1336,7 @@ string_view LogicFireBossDoorJumpDesc                 = "Difficulty: Intermediat
                                                         "farther away than is normally possible.";         //
 string_view LogicFireStrengthDesc                     = "Difficulty: Expert\n"                             //
                                                         "A precise jump can be used to skip pushing the\n" //
-                                                        "block.";                                          //
+                                                        "block. This also allows child to reach the block.";
 string_view LogicFireScarecrowDesc                    = "Difficulty: Novice\n"                             //
                                                         "Also known as \"Pixelshot\". The Longshot can\n"  //
                                                         "reach the target on the elevator itself, allowing\n"

--- a/source/location_access.cpp
+++ b/source/location_access.cpp
@@ -294,7 +294,10 @@ void AreaTable_Init() {
                   Entrance(KF_LINKS_HOUSE, {[]{return true;}}),
   });
 
-  areaTable[ADULT_SPAWN] = Area("Adult Spawn", "", NONE, NO_DAY_NIGHT_CYCLE, {}, {}, {
+  areaTable[ADULT_SPAWN] = Area("Adult Spawn", "", TEMPLE_OF_TIME, NO_DAY_NIGHT_CYCLE, {}, {
+                  //Locations
+                  LocationAccess(TOT_MASTER_SWORD, {[]{return true;}}),
+                }, {
                   //Exits
                   Entrance(TEMPLE_OF_TIME, {[]{return true;}}),
   });

--- a/source/location_access/locacc_castle_town.cpp
+++ b/source/location_access/locacc_castle_town.cpp
@@ -52,7 +52,6 @@ void AreaTable_Init_CastleTown() {
 
   areaTable[TEMPLE_OF_TIME] = Area("Temple of Time", "", TEMPLE_OF_TIME, NO_DAY_NIGHT_CYCLE, {}, {
                   //Locations
-                  LocationAccess(TOT_MASTER_SWORD,          {[]{return IsAdult;}}),
                   LocationAccess(TOT_LIGHT_ARROWS_CUTSCENE, {[]{return IsAdult && CanTriggerLACS;}}),
                 }, {
                   //Exits

--- a/source/location_access/locacc_fire_temple.cpp
+++ b/source/location_access/locacc_fire_temple.cpp
@@ -165,8 +165,8 @@ void AreaTable_Init_FireTemple() {
                   Entrance(FIRE_TEMPLE_FIRE_PILLAR_ROOM,   {[]{return SmallKeys(FIRE_TEMPLE, 4);}}),
                   Entrance(FIRE_TEMPLE_SHORTCUT_CLIMB,     {[]{return Here(FIRE_TEMPLE_SHORTCUT_CLIMB, []{return true;});},
                                                 /*Glitched*/[]{return (GoronBracelet || LogicFireStrength) && Bombs && CanSurviveDamage && CanDoGlitch(GlitchType::LedgeClip, GlitchDifficulty::INTERMEDIATE);}}),
-                  Entrance(FIRE_TEMPLE_BOULDER_MAZE_LOWER, {[]{return (GoronBracelet || (IsAdult && LogicFireStrength)) && (HasExplosives || (IsAdult && (CanUse(BOW) || CanUse(HOOKSHOT) || CanUse(SLINGSHOT))));},
-                                                /*Glitched*/[]{return (GoronBracelet || (IsAdult && LogicFireStrength)) && (CanDoGlitch(GlitchType::SuperStab, GlitchDifficulty::NOVICE) ||
+                  Entrance(FIRE_TEMPLE_BOULDER_MAZE_LOWER, {[]{return (GoronBracelet || (IsAdult && LogicFireStrength)) && (IsAdult || LogicFireStrength) && (HasExplosives || (IsAdult && (CanUse(BOW) || CanUse(HOOKSHOT) || CanUse(SLINGSHOT))));},
+                                                /*Glitched*/[]{return (GoronBracelet || (IsAdult && LogicFireStrength)) && (IsAdult || LogicFireStrength) && (CanDoGlitch(GlitchType::SuperStab, GlitchDifficulty::NOVICE) ||
                                                                       (CanDoGlitch(GlitchType::QPA, GlitchDifficulty::ADVANCED) && CanUse(STICKS)));}}),
   });
 

--- a/source/location_access/locacc_forest_temple.cpp
+++ b/source/location_access/locacc_forest_temple.cpp
@@ -44,7 +44,7 @@ void AreaTable_Init_ForestTemple() {
                 }, {
                   //Locations
                   LocationAccess(FOREST_TEMPLE_GS_LOBBY, {[]{return HookshotOrBoomerang;},
-                                              /*Glitched*/[]{return IsAdult && HasBombchus && CanDoGlitch(GlitchType::BombHover, GlitchDifficulty::NOVICE);}}),
+                                              /*Glitched*/[]{return HasBombchus && CanDoGlitch(GlitchType::BombHover, GlitchDifficulty::NOVICE);}}),
                 }, {
                   //Exits
                   Entrance(FOREST_TEMPLE_SOUTH_CORRIDOR,    {[]{return true;}}),

--- a/source/location_access/locacc_lost_woods.cpp
+++ b/source/location_access/locacc_lost_woods.cpp
@@ -49,7 +49,7 @@ void AreaTable_Init_LostWoods() {
                   //Exits
                   Entrance(DEKU_TREE_ENTRYWAY, {[]{return IsChild || (ShuffleDungeonEntrances.IsNot(SHUFFLEDUNGEONS_OFF) && (OpenForest.Is(OPENFOREST_OPEN) || ShowedMidoSwordAndShield));},
                                     /*Glitched*/[]{return CanDoGlitch(GlitchType::HammerSlide, GlitchDifficulty::INTERMEDIATE) || CanDoGlitch(GlitchType::HoverBoost, GlitchDifficulty::INTERMEDIATE);}}),
-                  Entrance(KOKIRI_FOREST,      {[]{return IsAdult || OpenForest.Is(OPENFOREST_OPEN) || ShowedMidoSwordAndShield;},
+                  Entrance(KOKIRI_FOREST,      {[]{return (IsAdult && (CanAdultDamage || ForestTempleClear)) || (IsChild && (OpenForest.Is(OPENFOREST_OPEN) || ShowedMidoSwordAndShield));},
                                     /*Glitched*/[]{return CanDoGlitch(GlitchType::ASlide, GlitchDifficulty::INTERMEDIATE) || CanDoGlitch(GlitchType::BombHover, GlitchDifficulty::INTERMEDIATE);}}),
   });
 

--- a/source/location_access/locacc_lost_woods.cpp
+++ b/source/location_access/locacc_lost_woods.cpp
@@ -27,7 +27,7 @@ void AreaTable_Init_LostWoods() {
                   Entrance(KF_HOUSE_OF_TWINS,     {[]{return true;}}),
                   Entrance(KF_KNOW_IT_ALL_HOUSE,  {[]{return true;}}),
                   Entrance(KF_KOKIRI_SHOP,        {[]{return true;}}),
-                  Entrance(KF_OUTSIDE_DEKU_TREE,  {[]{return IsAdult || OpenForest.Is(OPENFOREST_OPEN) || ShowedMidoSwordAndShield;},
+                  Entrance(KF_OUTSIDE_DEKU_TREE,  {[]{return (IsAdult && (CanAdultDamage || ForestTempleClear)) || OpenForest.Is(OPENFOREST_OPEN) || ShowedMidoSwordAndShield;},
                                        /*Glitched*/[]{return CanDoGlitch(GlitchType::LedgeCancel, GlitchDifficulty::NOVICE) || CanDoGlitch(GlitchType::ASlide, GlitchDifficulty::INTERMEDIATE) || CanDoGlitch(GlitchType::BombHover, GlitchDifficulty::INTERMEDIATE);}}),
                   Entrance(THE_LOST_WOODS,        {[]{return true;}}),
                   Entrance(LW_BRIDGE_FROM_FOREST, {[]{return IsAdult || OpenForest.IsNot(OPENFOREST_CLOSED) || DekuTreeClear;},

--- a/source/location_access/locacc_lost_woods.cpp
+++ b/source/location_access/locacc_lost_woods.cpp
@@ -27,7 +27,7 @@ void AreaTable_Init_LostWoods() {
                   Entrance(KF_HOUSE_OF_TWINS,     {[]{return true;}}),
                   Entrance(KF_KNOW_IT_ALL_HOUSE,  {[]{return true;}}),
                   Entrance(KF_KOKIRI_SHOP,        {[]{return true;}}),
-                  Entrance(KF_OUTSIDE_DEKU_TREE,  {[]{return (IsAdult && (CanAdultDamage || ForestTempleClear)) || OpenForest.Is(OPENFOREST_OPEN) || ShowedMidoSwordAndShield;},
+                  Entrance(KF_OUTSIDE_DEKU_TREE,  {[]{return (IsAdult && (CanAdultDamage || ForestTempleClear)) || (IsChild && (OpenForest.Is(OPENFOREST_OPEN) || ShowedMidoSwordAndShield));},
                                        /*Glitched*/[]{return CanDoGlitch(GlitchType::LedgeCancel, GlitchDifficulty::NOVICE) || CanDoGlitch(GlitchType::ASlide, GlitchDifficulty::INTERMEDIATE) || CanDoGlitch(GlitchType::BombHover, GlitchDifficulty::INTERMEDIATE);}}),
                   Entrance(THE_LOST_WOODS,        {[]{return true;}}),
                   Entrance(LW_BRIDGE_FROM_FOREST, {[]{return IsAdult || OpenForest.IsNot(OPENFOREST_CLOSED) || DekuTreeClear;},

--- a/source/location_access/locacc_zoras_domain.cpp
+++ b/source/location_access/locacc_zoras_domain.cpp
@@ -129,7 +129,7 @@ void AreaTable_Init_ZorasDomain() {
                                      /*Glitched*/[]{return ((IsChild || CanUse(IRON_BOOTS)) && CanDoGlitch(GlitchType::TripleSlashClip, GlitchDifficulty::NOVICE)) || CanDoGlitch(GlitchType::ASlide, GlitchDifficulty::NOVICE) ||
                                                            CanDoGlitch(GlitchType::LedgeCancel, GlitchDifficulty::NOVICE) || CanDoGlitch(GlitchType::BombHover, GlitchDifficulty::INTERMEDIATE) || CanDoGlitch(GlitchType::LedgeClip, GlitchDifficulty::INTERMEDIATE);}}),
                   Entrance(ZD_SHOP,             {[]{return IsChild || BlueFire;},
-                                     /*Glitched*/[]{return GlitchZDOoBJumpSlash.Value<bool>();}}),
+                                     /*Glitched*/[]{return CanJumpslash && GlitchZDOoBJumpSlash;}}),
                   Entrance(ZD_STORMS_GROTTO,    {[]{return CanOpenStormGrotto;},
                                      /*Glitched*/[]{return (CanDoGlitch(GlitchType::OutdoorBombOI, GlitchDifficulty::INTERMEDIATE) || ((Bugs || Fish) && CanShield && CanDoGlitch(GlitchType::QPA, GlitchDifficulty::ADVANCED)) ||
                                                            ((Bugs || Fish) && CanShield && HasBombchus && CanDoGlitch(GlitchType::ActionSwap, GlitchDifficulty::ADVANCED))) && SongOfStorms && (ShardOfAgony || LogicGrottosWithoutAgony);}}),


### PR DESCRIPTION
- Getting through the room in FiT with the heavy block as child requires a logic trick for the curved jumps
- Getting OoB with a jumpslash in ZD now checks CanJumpSlash
- Going between KF and Deku Tree as adult checks for a weapon or if FoT has been cleared
- Master sword location has been moved to ADULT_SPAWN to match in game behaviour