### PR TITLE
Additional Mirror World settings

### DIFF
--- a/code/oot.ld
+++ b/code/oot.ld
@@ -1152,6 +1152,10 @@ SECTIONS
 		*(.patch_CheckForPocketCuccoHatchGameplayInit)
 	}
 
+	.patch_InitSceneMirrorWorld 0x4490DC : {
+		*(.patch_InitSceneMirrorWorld)
+	}
+
 	.patch_InitSceneClearExtendedObjects 0x449218 : {
 		*(.patch_InitSceneClearExtendedObjects)
 	}

--- a/code/oot_e.ld
+++ b/code/oot_e.ld
@@ -1152,6 +1152,10 @@ SECTIONS
 		*(.patch_CheckForPocketCuccoHatchGameplayInit)
 	}
 
+	.patch_InitSceneMirrorWorld 0x4490FC : {
+		*(.patch_InitSceneMirrorWorld)
+	}
+
 	.patch_InitSceneClearExtendedObjects 0x449238 : {
 		*(.patch_InitSceneClearExtendedObjects)
 	}

--- a/code/src/entrance.c
+++ b/code/src/entrance.c
@@ -834,3 +834,18 @@ void InitEntranceTrackingData(void) {
     }
     SortEntranceList(destList, 1);
 }
+
+void Entrance_UpdateMQFlag(void) {
+    if (IsInGame()) {
+        switch (gSettingsContext.mirrorWorld) {
+            case MIRRORWORLD_SCENESPECIFIC:
+                gSaveContext.masterQuestFlag = Hash(gGlobalContext->sceneNum) & 1;
+                return;
+            case MIRRORWORLD_ENTRANCESPECIFIC:
+                gSaveContext.masterQuestFlag = Hash(gSaveContext.entranceIndex) & 1;
+                return;
+            case MIRRORWORLD_RANDOM:
+                gSaveContext.masterQuestFlag = gRandInt & 1;
+        }
+    }
+}

--- a/code/src/hooks.s
+++ b/code/src/hooks.s
@@ -1687,6 +1687,14 @@ hook_CriticalHealthCheck:
     movle r0,#0x18
     bx lr
 
+.global hook_InitSceneMirrorWorld
+hook_InitSceneMirrorWorld:
+    push {r0-r12,lr}
+    bl Entrance_UpdateMQFlag
+    pop {r0-r12,lr}
+    cpy r4,r0
+    bx lr
+
 .global hook_CollisionATvsAC
 hook_CollisionATvsAC:
     ldr r12,[sp,#0x18]

--- a/code/src/patches.s
+++ b/code/src/patches.s
@@ -1971,6 +1971,11 @@ CriticalHealthCheckThree_patch:
     nop
     nop
 
+.section .patch_InitSceneMirrorWorld
+.global InitSceneMirrorWorld_patch
+InitSceneMirrorWorld_patch:
+    bl hook_InitSceneMirrorWorld
+
 .section .patch_CollisionATvsAC
 .global CollisionATvsAC_patch
 CollisionATvsAC_patch:

--- a/code/src/settings.h
+++ b/code/src/settings.h
@@ -391,6 +391,14 @@ typedef enum {
 } TrailDuration;
 
 typedef enum {
+    MIRRORWORLD_OFF,
+    MIRRORWORLD_ON,
+    MIRRORWORLD_SCENESPECIFIC,
+    MIRRORWORLD_ENTRANCESPECIFIC,
+    MIRRORWORLD_RANDOM,
+} MirrorWorld;
+
+typedef enum {
   PLAY_ON_CONSOLE,
   PLAY_ON_CITRA,
 } PlayOption;

--- a/source/descriptions.cpp
+++ b/source/descriptions.cpp
@@ -1078,8 +1078,13 @@ string_view coloredBossKeysDesc       = "If set, boss key models will be colored
 /*------------------------------                                                           //
 |         MIRROR WORLD         |                                                           //
 ------------------------------*/                                                           //
-string_view mirrorWorldDesc           = "If set, the world will be mirrored.";             //
-                                                                                           //
+string_view mirrorWorldOffDesc        = "The world will not be mirrored.";                 //
+string_view mirrorWorldOnDesc         = "The world will be mirrored.";                     //
+string_view mirrorWorldSceneDesc      = "Some regions will be mirrored while others won't.";
+string_view mirrorWorldEntranceDesc   = "Different entrances to the same region will alter\n"
+                                        "whether it is mirrored or not.";                  //
+string_view mirrorWorldRandomDesc     = "Whether the world is mirrored may change after\n" //
+                                        "every loading zone inconsistently.";              //
 /*------------------------------                                                           //
 |        SHUFFLE MUSIC         |                                                           //
 ------------------------------*/                                                           //

--- a/source/descriptions.hpp
+++ b/source/descriptions.hpp
@@ -336,7 +336,11 @@ extern string_view alwaysSimpleModeDesc;
 extern string_view coloredKeysDesc;
 extern string_view coloredBossKeysDesc;
 
-extern string_view mirrorWorldDesc;
+extern string_view mirrorWorldOffDesc;
+extern string_view mirrorWorldOnDesc;
+extern string_view mirrorWorldSceneDesc;
+extern string_view mirrorWorldEntranceDesc;
+extern string_view mirrorWorldRandomDesc;
 
 extern string_view musicRandoDesc;
 extern string_view shuffleBGMDesc;

--- a/source/settings.cpp
+++ b/source/settings.cpp
@@ -1146,7 +1146,7 @@ namespace Settings {
 
   Option ColoredKeys =     Option::Bool("Colored Small Keys", {"Off", "On"},                                {coloredKeysDesc},                                                                                                                                  OptionCategory::Cosmetic);
   Option ColoredBossKeys = Option::Bool("Colored Boss Keys",  {"Off", "On"},                                {coloredBossKeysDesc},                                                                                                                              OptionCategory::Cosmetic);
-  Option MirrorWorld =     Option::Bool("Mirror World",       {"Off", "On", "Scene", "Entrance", "Random"}, {mirrorWorldOffDesc, mirrorWorldOnDesc, mirrorWorldSceneDesc, mirrorWorldEntranceDesc, mirrorWorldRandomDesc},                                      OptionCategory::Cosmetic);
+  Option MirrorWorld =     Option::U8  ("Mirror World",       {"Off", "On", "Scene", "Entrance", "Random"}, {mirrorWorldOffDesc, mirrorWorldOnDesc, mirrorWorldSceneDesc, mirrorWorldEntranceDesc, mirrorWorldRandomDesc},                                      OptionCategory::Cosmetic);
 
   std::vector<Option *> cosmeticOptions = {
     &CustomTunicColors,

--- a/source/settings.cpp
+++ b/source/settings.cpp
@@ -1144,9 +1144,9 @@ namespace Settings {
   std::string finalChuTrailInnerColor   = BombchuTrailInnerColor.GetSelectedOptionText();
   std::string finalChuTrailOuterColor   = BombchuTrailOuterColor.GetSelectedOptionText();
 
-  Option ColoredKeys =     Option::Bool("Colored Small Keys", {"Off", "On"}, {coloredKeysDesc},                                                                                                                                                                 OptionCategory::Cosmetic);
-  Option ColoredBossKeys = Option::Bool("Colored Boss Keys",  {"Off", "On"}, {coloredBossKeysDesc},                                                                                                                                                             OptionCategory::Cosmetic);
-  Option MirrorWorld =     Option::Bool("Mirror World",       {"Off", "On"}, {mirrorWorldDesc},                                                                                                                                                                 OptionCategory::Cosmetic);
+  Option ColoredKeys =     Option::Bool("Colored Small Keys", {"Off", "On"},                                {coloredKeysDesc},                                                                                                                                  OptionCategory::Cosmetic);
+  Option ColoredBossKeys = Option::Bool("Colored Boss Keys",  {"Off", "On"},                                {coloredBossKeysDesc},                                                                                                                              OptionCategory::Cosmetic);
+  Option MirrorWorld =     Option::Bool("Mirror World",       {"Off", "On", "Scene", "Entrance", "Random"}, {mirrorWorldOffDesc, mirrorWorldOnDesc, mirrorWorldSceneDesc, mirrorWorldEntranceDesc, mirrorWorldRandomDesc},                                      OptionCategory::Cosmetic);
 
   std::vector<Option *> cosmeticOptions = {
     &CustomTunicColors,
@@ -1467,7 +1467,7 @@ namespace Settings {
     ctx.rainbowChuTrailInnerColor  = (BombchuTrailInnerColor.Value<u8>() == RAINBOW_TRAIL) ? 1 : 0;
     ctx.rainbowChuTrailOuterColor  = (BombchuTrailOuterColor.Value<u8>() == RAINBOW_TRAIL) ? 1 : 0;
     ctx.bombchuTrailDuration       = BombchuTrailDuration.Value<u8>();
-    ctx.mirrorWorld                = (MirrorWorld) ? 1 : 0;
+    ctx.mirrorWorld                = MirrorWorld.Value<u8>();
     ctx.coloredKeys                = (ColoredKeys) ? 1 : 0;
     ctx.coloredBossKeys            = (ColoredBossKeys) ? 1 : 0;
     ctx.shuffleSFX                 = ShuffleSFX.Value<u8>();


### PR DESCRIPTION
In addition to on and off, mirror world can now change after loading zones in 3 ways:
- Scene: every entrance to a specific scene uses the same orientation
- Entrance: each entrance sets the orientation independently and consistently
- Random: each entrance sets the orientation inconsistently