### PR TITLE
Various Bug Fixes

### DIFF
--- a/code/oot.ld
+++ b/code/oot.ld
@@ -816,6 +816,10 @@ SECTIONS
 		*(.patch_FastChests)
 	}
 
+	.patch_AboutToPickUpActor 0x354DD8 : {
+		*(.patch_AboutToPickUpActor)
+	}
+
 	.patch_MasterSwordTimerCheck 0x354DFC : {
 		*(.patch_MasterSwordTimerCheck)
 	}

--- a/code/oot.ld
+++ b/code/oot.ld
@@ -768,8 +768,8 @@ SECTIONS
 		*(.patch_BiggoronDayCheck)
 	}
 
-	.patch_WarpSongTimerDepletion 0x33DE84 : {
-		*(.patch_WarpSongTimerDepletion)
+	.patch_FWandWarpSongTimerDepletion 0x33DE84 : {
+		*(.patch_FWandWarpSongTimerDepletion)
 	}
 
 	.patch_MasterQuestGoldSkulltulaCheck 0x3415C8 : {

--- a/code/oot_e.ld
+++ b/code/oot_e.ld
@@ -816,6 +816,10 @@ SECTIONS
 		*(.patch_FastChests)
 	}
 
+	.patch_AboutToPickUpActor 0x354DD8 : {
+		*(.patch_AboutToPickUpActor)
+	}
+
 	.patch_MasterSwordTimerCheck 0x354DFC : {
 		*(.patch_MasterSwordTimerCheck)
 	}

--- a/code/oot_e.ld
+++ b/code/oot_e.ld
@@ -768,8 +768,8 @@ SECTIONS
 		*(.patch_BiggoronDayCheck)
 	}
 
-	.patch_WarpSongTimerDepletion 0x33DE84 : {
-		*(.patch_WarpSongTimerDepletion)
+	.patch_FWandWarpSongTimerDepletion 0x33DE84 : {
+		*(.patch_FWandWarpSongTimerDepletion)
 	}
 
 	.patch_MasterQuestGoldSkulltulaCheck 0x3415C8 : {

--- a/code/src/actors/player.c
+++ b/code/src/actors/player.c
@@ -8,6 +8,7 @@
 #include "icetrap.h"
 #include "arrow.h"
 #include "grotto.h"
+#include "item_override.h"
 
 #define PlayerActor_Init_addr 0x191844
 #define PlayerActor_Init ((ActorFunc)PlayerActor_Init_addr)
@@ -167,4 +168,15 @@ s32 Player_ShouldUseSlingshot() {
 
 s32 Player_ShouldDrawHookshotParts() {
     return gSaveContext.linkAge == 0 || !gSettingsContext.hookshotAsChild;
+}
+
+s32 Player_CanPickUpThisActor(Actor* interactedActor) {
+    switch (interactedActor->id) {
+        case 0xA:  // Chest, can never be picked up
+            return 0;
+        case 0x6C: // Pedestal of Time, prevent interaction while waiting to get item
+            return !ItemOverride_IsAPendingOverride();
+        default:
+            return 1;
+    }
 }

--- a/code/src/cutscenes.c
+++ b/code/src/cutscenes.c
@@ -307,6 +307,9 @@ void Custcene_OverrideShadowTemple(void) {
 }
 
 void Cutscene_BlueWarpOverride(void) {
+    // Set nextEntranceIndex as a flag so that Grotto_CheckSpecialEntrance
+    // won't return index 0x7FFF, which can't work to override blue warps.
+    gGlobalContext->nextEntranceIndex = 0;
     switch (gGlobalContext->sceneNum - 0x11) { // dungeon index from boss room scene
         case DUNGEON_DEKU_TREE:
             Cutscene_OverrideDekuTree();

--- a/code/src/grotto.c
+++ b/code/src/grotto.c
@@ -148,8 +148,9 @@ s16 Grotto_CheckSpecialEntrance(s16 nextEntranceIndex) {
         Grotto_SetupReturnInfo(grotto, RESPAWN_MODE_RETURN);
         Grotto_SetupReturnInfo(grotto, RESPAWN_MODE_DOWN);
 
-        // When the nextEntranceIndex is determined by a dynamic exit, we have
-        // to set the respawn information and nextEntranceIndex manually
+        // When the nextEntranceIndex is determined by a dynamic exit,
+        // or set by Cutscene_BlueWarpOverride to mark a blue warp entrance,
+        // we have to set the respawn information and nextEntranceIndex manually
         if (gGlobalContext->nextEntranceIndex != -1) {
             gSaveContext.respawnFlag = 2;
             nextEntranceIndex = grotto.entranceIndex;

--- a/code/src/grotto.c
+++ b/code/src/grotto.c
@@ -109,10 +109,7 @@ static void Grotto_SetupReturnInfo(GrottoReturnInfo grotto, RespawnMode respawnM
   // Set necessary grotto return data to the Entrance Point, so that voiding out and setting FW work correctly
   gSaveContext.respawn[respawnMode].entranceIndex = grotto.entranceIndex;
   gSaveContext.respawn[respawnMode].roomIndex = grotto.room;
-
-  if (gSettingsContext.mixGrottos == ON || gSettingsContext.decoupleEntrances == ON) {
-    gSaveContext.respawn[respawnMode].playerParams = 0x04FF; // exiting grotto with no initial camera focus
-  }
+  gSaveContext.respawn[respawnMode].playerParams = 0x04FF; // exiting grotto with no initial camera focus
   gSaveContext.respawn[respawnMode].yaw = grotto.angle;
   gSaveContext.respawn[respawnMode].pos = grotto.pos;
   //If Mixed Entrance Pools or decoupled entrances are active, set these flags to 0 instead of restoring them

--- a/code/src/hooks.s
+++ b/code/src/hooks.s
@@ -1724,6 +1724,17 @@ hook_SetFWPlayerParams:
     pop {r0-r9,r11-r12,lr}
     bx lr
 
+.global hook_AboutToPickUpActor
+hook_AboutToPickUpActor:
+    ldrh r0,[r7]
+    push {r0-r12,lr}
+    mov r0,r7
+    bl Player_CanPickUpThisActor
+    cmp r0,#0x0
+    pop {r0-r12,lr}
+    subeq lr,lr,#0x8
+    bx lr
+
 @ ----------------------------------
 @ ----------------------------------
 

--- a/code/src/hooks.s
+++ b/code/src/hooks.s
@@ -1506,15 +1506,15 @@ hook_TimerExpiration:
     strh r0,[r4,#0x62]
     bx lr
 
-.global hook_WarpSongTimerDepletion
-hook_WarpSongTimerDepletion:
+.global hook_FWandWarpSongTimerDepletion
+hook_FWandWarpSongTimerDepletion:
     moveq r1,#0x1
     movne r1,#0xEF
     push {r0-r12,lr}
     bl IceTrap_IsCurseActive
     cmp r0,#0x1
     pop {r0-r12,lr}
-    bxne lr
+    bxeq lr
     strh r1,[r0,#0x64]
     bx lr
 

--- a/code/src/icetrap.c
+++ b/code/src/icetrap.c
@@ -222,7 +222,7 @@ void IceTrap_HandleCurses(void) {
     }
 
     // Dispel curses if the timer is reset or runs out, or if the scene is Tower Collapse Exterior
-    if ((!IsInGame() || gSaveContext.timer2State != 4 || gSaveContext.timer2Value == 0 || gGlobalContext->sceneNum == 0x1A)) {
+    if ((!IsInGame() || gSaveContext.timer2State <= 1 || gSaveContext.timer2Value == 0 || gGlobalContext->sceneNum == 0x1A)) {
         IceTrap_DispelCurses();
         return;
     }

--- a/code/src/patches.s
+++ b/code/src/patches.s
@@ -1991,6 +1991,11 @@ GanonDrawMasterSword_patch:
 SetFWPlayerParams_patch:
     bl hook_SetFWPlayerParams
 
+.section .patch_AboutToPickUpActor
+.global AboutToPickUpActor_patch
+AboutToPickUpActor_patch:
+    bl hook_AboutToPickUpActor
+
 @ ----------------------------------
 @ ----------------------------------
 

--- a/code/src/patches.s
+++ b/code/src/patches.s
@@ -1795,11 +1795,11 @@ RainbowChuTrailOne_patch:
 RainbowChuTrailTwo_patch:
     bl hook_RainbowChuTrail
 
-.section .patch_WarpSongTimerDepletion
-.global WarpSongTimerDepletion_patch
-WarpSongTimerDepletion_patch:
+.section .patch_FWandWarpSongTimerDepletion
+.global FWandWarpSongTimerDepletion_patch
+FWandWarpSongTimerDepletion_patch:
     push {lr}
-    bl hook_WarpSongTimerDepletion
+    bl hook_FWandWarpSongTimerDepletion
     pop {lr}
 
 .section .patch_TimerExpiration

--- a/source/descriptions.cpp
+++ b/source/descriptions.cpp
@@ -1482,7 +1482,7 @@ string_view LogicShadowStatueDesc                     = "Difficulty: Novice\n"  
                                                         "you can knock down the statue without needing a\n"//
                                                         "Bow. Applies in both vanilla and MQ Shadow.";     //
 string_view LogicChildDeadhandDesc                    = "Difficulty: Novice\n"                             //
-                                                        "Requires 9 sticks or 5 jump slashes.";            //
+                                                        "Requires 10 stick slashes.";                      //
 string_view LogicGtgWithoutHookshotDesc               = "Difficulty: Expert\n"                             //
                                                         "The final silver rupee on the ceiling can be\n"   //
                                                         "reached by being pulled up into it by the\n"      //

--- a/source/fill.cpp
+++ b/source/fill.cpp
@@ -296,8 +296,8 @@ std::vector<LocationKey> GetAccessibleLocations(const std::vector<LocationKey>& 
           exit.AddToPool();
           if (exit.GetReplacement()->GetReverse() != nullptr) {
             exit.GetReplacement()->GetReverse()->AddToPool();
-            // When decoupled, list the reverse direction too
-            if (Settings::DecoupleEntrances) {
+            // When decoupled, list the reverse direction too, unless the entrance is one-way
+            if (Settings::DecoupleEntrances && exit.GetReverse() != nullptr) {
               entranceSphere.push_back(exit.GetReplacement()->GetReverse());
             }
           }


### PR DESCRIPTION
This fixes some of the bugs reported in the Discord and in the GitHub issues:
- Softlock when exiting a grotto reached from an overworld spawn or a warp song with specific settings
- Crash when generating the spoiler log with decoupled entrances if specific conditions are met (closes #587)
- Blue warps leading to the Deku Tree if their dungeon was shuffled to a grotto entrance
- Curse traps being dispelled when a room/heat/underwater timer runs out, or when warping with FW
- Description for the "BotW Deadhand w/o Sword" logic trick referencing OoT damage values (closes #531)
- Picking up chests and Pedestal of Time (closes #480).