### PR TITLE
Prevent duped decoupled entrances in spoiler log

### DIFF
--- a/source/fill.cpp
+++ b/source/fill.cpp
@@ -312,10 +312,11 @@ std::vector<LocationKey> GetAccessibleLocations(const std::vector<LocationKey>& 
                     !noRandomEntrances) {
                     entranceSphere.push_back(&exit);
                     exit.AddToPool();
-                    if (exit.GetReplacement()->GetReverse() != nullptr && !exit.GetReplacement()->GetReverse()->IsAddedToPool()) {
+                    if (exit.GetReplacement()->GetReverse() != nullptr &&
+                        !exit.GetReplacement()->GetReverse()->IsAddedToPool()) {
                         exit.GetReplacement()->GetReverse()->AddToPool();
-                        // When decoupled, list the reverse direction too
-                        if (Settings::DecoupleEntrances) {
+                        // When decoupled, list the reverse direction too, unless the entrance is one-way
+                        if (Settings::DecoupleEntrances && exit.GetReverse() != nullptr) {
                             entranceSphere.push_back(exit.GetReplacement()->GetReverse());
                         }
                     }

--- a/source/fill.cpp
+++ b/source/fill.cpp
@@ -312,7 +312,7 @@ std::vector<LocationKey> GetAccessibleLocations(const std::vector<LocationKey>& 
                     !noRandomEntrances) {
                     entranceSphere.push_back(&exit);
                     exit.AddToPool();
-                    if (exit.GetReplacement()->GetReverse() != nullptr) {
+                    if (exit.GetReplacement()->GetReverse() != nullptr && !exit.GetReplacement()->GetReverse()->IsAddedToPool()) {
                         exit.GetReplacement()->GetReverse()->AddToPool();
                         // When decoupled, list the reverse direction too
                         if (Settings::DecoupleEntrances) {


### PR DESCRIPTION
After the change to have decoupled entrances in the spoiler log, it seems some entrances were in there twice.

Adding an `!IsAddedToPool()` for the reverse check similar to the top level check prevents duplicate records.

The only thing I can't fully comment on is if some of the decoupled entrances should be considered in a different "sphere". I'm not sure how the spheres are determined.