### PR TITLE
Add option to reduce bottles depending on the item pool

### DIFF
--- a/code/src/settings.h
+++ b/code/src/settings.h
@@ -547,6 +547,7 @@ typedef struct {
   u8 gkDurability;
 
   u8 itemPoolValue;
+  u8 includeBottles;
   u8 iceTrapValue;
   u8 progressiveGoronSword;
 

--- a/code/src/settings.h
+++ b/code/src/settings.h
@@ -547,7 +547,7 @@ typedef struct {
   u8 gkDurability;
 
   u8 itemPoolValue;
-  u8 includeBottles;
+  u8 reduceBottles;
   u8 iceTrapValue;
   u8 progressiveGoronSword;
 

--- a/source/descriptions.cpp
+++ b/source/descriptions.cpp
@@ -869,9 +869,9 @@ string_view itemPoolMinimal           = "Most excess items are removed.";       
 /*------------------------------                                                           //
 |       INCLUDE BOTTLES        |                                                           //
 ------------------------------*/                                                           //
-string_view includeBottlesOffDesc     = "The Item Pool setting will not affect the\n"      //
+string_view reduceBottlesOffDesc      = "The Item Pool setting will not affect the\n"      //
                                         "amount of bottles in the game.";                  //
-string_view includeBottlesOnDesc      = "Scarce also takes 2 bottles out of the pool.\n"   //
+string_view reduceBottlesOnDesc       = "Scarce also takes 2 bottles out of the pool.\n"   //
                                         "Minimal also takes 3 bottles out of the pool.";   //
                                                                                            //
 /*------------------------------                                                           //

--- a/source/descriptions.cpp
+++ b/source/descriptions.cpp
@@ -867,6 +867,14 @@ string_view itemPoolScarce            = "Some excess items are removed, includin
 string_view itemPoolMinimal           = "Most excess items are removed.";                  //
                                                                                            //
 /*------------------------------                                                           //
+|       INCLUDE BOTTLES        |                                                           //
+------------------------------*/                                                           //
+string_view includeBottlesOffDesc     = "The Item Pool setting will not affect the\n"      //
+                                        "amount of bottles in the game.";                  //
+string_view includeBottlesOnDesc      = "Scarce also takes 2 bottles out of the pool.\n"   //
+                                        "Minimum also takes 3 bottles out of the pool.";   //
+                                                                                           //
+/*------------------------------                                                           //
 |          ICE TRAPS           |                                                           //
 ------------------------------*/                                                           //
 string_view iceTrapsOff               = "All Ice Traps are removed.";                      //

--- a/source/descriptions.cpp
+++ b/source/descriptions.cpp
@@ -872,7 +872,7 @@ string_view itemPoolMinimal           = "Most excess items are removed.";       
 string_view includeBottlesOffDesc     = "The Item Pool setting will not affect the\n"      //
                                         "amount of bottles in the game.";                  //
 string_view includeBottlesOnDesc      = "Scarce also takes 2 bottles out of the pool.\n"   //
-                                        "Minimum also takes 3 bottles out of the pool.";   //
+                                        "Minimal also takes 3 bottles out of the pool.";   //
                                                                                            //
 /*------------------------------                                                           //
 |          ICE TRAPS           |                                                           //

--- a/source/descriptions.hpp
+++ b/source/descriptions.hpp
@@ -282,8 +282,8 @@ extern string_view itemPoolBalanced;
 extern string_view itemPoolScarce;
 extern string_view itemPoolMinimal;
 
-extern string_view includeBottlesOffDesc;
-extern string_view includeBottlesOnDesc;
+extern string_view reduceBottlesOffDesc;
+extern string_view reduceBottlesOnDesc;
 
 extern string_view iceTrapsOff;
 extern string_view iceTrapsNormal;

--- a/source/descriptions.hpp
+++ b/source/descriptions.hpp
@@ -282,6 +282,9 @@ extern string_view itemPoolBalanced;
 extern string_view itemPoolScarce;
 extern string_view itemPoolMinimal;
 
+extern string_view includeBottlesOffDesc;
+extern string_view includeBottlesOnDesc;
+
 extern string_view iceTrapsOff;
 extern string_view iceTrapsNormal;
 extern string_view iceTrapsExtra;

--- a/source/item_pool.cpp
+++ b/source/item_pool.cpp
@@ -1061,13 +1061,13 @@ void GenerateItemPool() {
     rutoBottles = 0;
   }
 
-  //Add 4 total bottles, 2 or 1 if bottles are included in the Item Pool
+  //Add 4 total bottles, 2 or 1 if bottles should be reduced by the Item Pool setting
   u8 bottleCount = 4;
-  if ((ItemPoolValue.Is(ITEMPOOL_MINIMAL)) && IncludeBottles) {
-	  bottleCount = 1;
-  } else if ((ItemPoolValue.Is(ITEMPOOL_SCARCE)) && IncludeBottles) {
-	  bottleCount = 2;
-    }
+  if (ReduceBottles && ItemPoolValue.Is(ITEMPOOL_SCARCE)) {
+    bottleCount = 2;
+  } else if (ReduceBottles && ItemPoolValue.Is(ITEMPOOL_MINIMAL)) {
+    bottleCount = 1;
+  }
   std::vector<ItemKey> bottles;
   bottles.assign(normalBottles.begin(), normalBottles.end());
   IceTrapModels.push_back(ItemTable(RandomElement(bottles)).GetItemID()); //Get one random bottle type for ice traps

--- a/source/item_pool.cpp
+++ b/source/item_pool.cpp
@@ -567,33 +567,6 @@ static void PlaceVanillaCowMilk() {
   }
 }
 
-static void ReplaceBottlesInPool(u8 bottleCount) {
-  ReplaceMaxItem(EMPTY_BOTTLE, 0);
-  ReplaceMaxItem(BOTTLE_WITH_MILK, 0);
-  ReplaceMaxItem(BOTTLE_WITH_RED_POTION, 0);
-  ReplaceMaxItem(BOTTLE_WITH_GREEN_POTION, 0);
-  ReplaceMaxItem(BOTTLE_WITH_BLUE_POTION, 0);
-  ReplaceMaxItem(BOTTLE_WITH_FAIRY, 0);
-  ReplaceMaxItem(BOTTLE_WITH_FISH, 0);
-  ReplaceMaxItem(BOTTLE_WITH_BUGS, 0);
-  ReplaceMaxItem(BOTTLE_WITH_POE, 0);
-  ReplaceMaxItem(BOTTLE_WITH_BIG_POE, 0);
-  ReplaceMaxItem(BOTTLE_WITH_BLUE_FIRE, 0);
-  
-  u8 rutoBottles = 1;
-  if (ZorasFountain.Is(ZORASFOUNTAIN_OPEN)) {
-    rutoBottles = 0;
-  }
-  bottleCount = bottleCount - rutoBottles;
-  
-  std::vector<ItemKey> bottles;
-  bottles.assign(normalBottles.begin(), normalBottles.end());
-  
-  for (u8 i = 0; i < bottleCount; i++) {
-	  AddRandomBottle(bottles);
-  }
-}
-
 static void SetScarceItemPool() {
   ReplaceMaxItem(PROGRESSIVE_BOMBCHUS, 3);
   ReplaceMaxItem(BOMBCHU_5, 1);
@@ -607,11 +580,6 @@ static void SetScarceItemPool() {
   ReplaceMaxItem(PROGRESSIVE_SLINGSHOT, 2);
   ReplaceMaxItem(PROGRESSIVE_BOMB_BAG, 2);
   ReplaceMaxItem(HEART_CONTAINER, 0);
-  // Bottles
-  if (IncludeBottles) {
-	  u8 bottleCount = 2;
-	  ReplaceBottlesInPool(bottleCount);
-  }
 }
 
 static void SetMinimalItemPool() {
@@ -630,11 +598,6 @@ static void SetMinimalItemPool() {
   ReplaceMaxItem(PIECE_OF_HEART, 0);
   // Need extra heart containers when starting with 1 heart or less to be able to reach 3 hearts
   ReplaceMaxItem(HEART_CONTAINER, 2 - StartingHearts.Value<u8>());
-    // Bottles
-  if (IncludeBottles) {
-	  u8 bottleCount = 1;
-	  ReplaceBottlesInPool(bottleCount);
-  }
 }
 
 void GenerateItemPool() {
@@ -1098,8 +1061,13 @@ void GenerateItemPool() {
     rutoBottles = 0;
   }
 
-  //Add 4 total bottles
+  //Add 4 total bottles, 2 or 1 if bottles are included in the Item Pool
   u8 bottleCount = 4;
+  if ((ItemPoolValue.Is(ITEMPOOL_MINIMAL)) && IncludeBottles) {
+	  bottleCount = 1;
+  } else if ((ItemPoolValue.Is(ITEMPOOL_SCARCE)) && IncludeBottles) {
+	  bottleCount = 2;
+    }
   std::vector<ItemKey> bottles;
   bottles.assign(normalBottles.begin(), normalBottles.end());
   IceTrapModels.push_back(ItemTable(RandomElement(bottles)).GetItemID()); //Get one random bottle type for ice traps

--- a/source/item_pool.cpp
+++ b/source/item_pool.cpp
@@ -567,6 +567,33 @@ static void PlaceVanillaCowMilk() {
   }
 }
 
+static void ReplaceBottlesInPool(u8 bottleCount) {
+  ReplaceMaxItem(EMPTY_BOTTLE, 0);
+  ReplaceMaxItem(BOTTLE_WITH_MILK, 0);
+  ReplaceMaxItem(BOTTLE_WITH_RED_POTION, 0);
+  ReplaceMaxItem(BOTTLE_WITH_GREEN_POTION, 0);
+  ReplaceMaxItem(BOTTLE_WITH_BLUE_POTION, 0);
+  ReplaceMaxItem(BOTTLE_WITH_FAIRY, 0);
+  ReplaceMaxItem(BOTTLE_WITH_FISH, 0);
+  ReplaceMaxItem(BOTTLE_WITH_BUGS, 0);
+  ReplaceMaxItem(BOTTLE_WITH_POE, 0);
+  ReplaceMaxItem(BOTTLE_WITH_BIG_POE, 0);
+  ReplaceMaxItem(BOTTLE_WITH_BLUE_FIRE, 0);
+  
+  u8 rutoBottles = 1;
+  if (ZorasFountain.Is(ZORASFOUNTAIN_OPEN)) {
+    rutoBottles = 0;
+  }
+  bottleCount = bottleCount - rutoBottles;
+  
+  std::vector<ItemKey> bottles;
+  bottles.assign(normalBottles.begin(), normalBottles.end());
+  
+  for (u8 i = 0; i < bottleCount; i++) {
+	  AddRandomBottle(bottles);
+  }
+}
+
 static void SetScarceItemPool() {
   ReplaceMaxItem(PROGRESSIVE_BOMBCHUS, 3);
   ReplaceMaxItem(BOMBCHU_5, 1);
@@ -580,6 +607,11 @@ static void SetScarceItemPool() {
   ReplaceMaxItem(PROGRESSIVE_SLINGSHOT, 2);
   ReplaceMaxItem(PROGRESSIVE_BOMB_BAG, 2);
   ReplaceMaxItem(HEART_CONTAINER, 0);
+  // Bottles
+  if (IncludeBottles) {
+	  u8 bottleCount = 2;
+	  ReplaceBottlesInPool(bottleCount);
+  }
 }
 
 static void SetMinimalItemPool() {
@@ -598,6 +630,11 @@ static void SetMinimalItemPool() {
   ReplaceMaxItem(PIECE_OF_HEART, 0);
   // Need extra heart containers when starting with 1 heart or less to be able to reach 3 hearts
   ReplaceMaxItem(HEART_CONTAINER, 2 - StartingHearts.Value<u8>());
+    // Bottles
+  if (IncludeBottles) {
+	  u8 bottleCount = 1;
+	  ReplaceBottlesInPool(bottleCount);
+  }
 }
 
 void GenerateItemPool() {

--- a/source/settings.cpp
+++ b/source/settings.cpp
@@ -396,11 +396,13 @@ namespace Settings {
 
   //Item Pool Settings
   Option ItemPoolValue         = Option::U8  ("Item Pool",             {"Minimal", "Scarce", "Balanced", "Plentiful"},                        {itemPoolMinimal, itemPoolScarce, itemPoolBalanced, itemPoolPlentiful},                                           OptionCategory::Setting,    ITEMPOOL_BALANCED);
+  Option IncludeBottles        = Option::Bool("  Include Bottles",     {"No", "Yes"},                                                         {includeBottlesOffDesc, includeBottlesOnDesc});
   Option IceTrapValue          = Option::U8  ("Ice Traps",             {"Off", "Normal", "Extra", "Mayhem", "Onslaught"},                     {iceTrapsOff, iceTrapsNormal, iceTrapsExtra, iceTrapsMayhem, iceTrapsOnslaught},                                  OptionCategory::Setting,    ICETRAPS_NORMAL);
   Option RemoveDoubleDefense   = Option::Bool("Remove Double Defense", {"No", "Yes"},                                                         {removeDDDesc});
   Option ProgressiveGoronSword = Option::Bool("Prog Goron Sword",      {"Disabled", "Enabled"},                                               {progGoronSword});
   std::vector<Option *> itemPoolOptions = {
     &ItemPoolValue,
+    &IncludeBottles,
     &IceTrapValue,
     &RemoveDoubleDefense,
     &ProgressiveGoronSword,
@@ -1427,6 +1429,7 @@ namespace Settings {
     ctx.gkDurability         = GkDurability.Value<u8>();
 
     ctx.itemPoolValue        = ItemPoolValue.Value<u8>();
+    ctx.includeBottles       = (IncludeBottles) ? 1 : 0;
     ctx.iceTrapValue         = IceTrapValue.Value<u8>();
     ctx.progressiveGoronSword = (ProgressiveGoronSword) ? 1 : 0;
 
@@ -2020,6 +2023,12 @@ namespace Settings {
         MixGrottos.SetSelectedIndex(OFF);
       }
     }
+
+    if ((ItemPoolValue.Is(ITEMPOOL_SCARCE)) || (ItemPoolValue.Is(ITEMPOOL_MINIMAL))) {
+		IncludeBottles.Unhide();
+    } else {
+		IncludeBottles.Hide();
+      }
 
     if (SetDungeonTypes) {
       for (Option *option : dungeonOptions) {

--- a/source/settings.cpp
+++ b/source/settings.cpp
@@ -396,13 +396,13 @@ namespace Settings {
 
   //Item Pool Settings
   Option ItemPoolValue         = Option::U8  ("Item Pool",             {"Minimal", "Scarce", "Balanced", "Plentiful"},                        {itemPoolMinimal, itemPoolScarce, itemPoolBalanced, itemPoolPlentiful},                                           OptionCategory::Setting,    ITEMPOOL_BALANCED);
-  Option IncludeBottles        = Option::Bool("  Include Bottles",     {"No", "Yes"},                                                         {includeBottlesOffDesc, includeBottlesOnDesc});
+  Option ReduceBottles         = Option::Bool("  Reduce Bottles",      {"No", "Yes"},                                                         {reduceBottlesOffDesc, reduceBottlesOnDesc});
   Option IceTrapValue          = Option::U8  ("Ice Traps",             {"Off", "Normal", "Extra", "Mayhem", "Onslaught"},                     {iceTrapsOff, iceTrapsNormal, iceTrapsExtra, iceTrapsMayhem, iceTrapsOnslaught},                                  OptionCategory::Setting,    ICETRAPS_NORMAL);
   Option RemoveDoubleDefense   = Option::Bool("Remove Double Defense", {"No", "Yes"},                                                         {removeDDDesc});
   Option ProgressiveGoronSword = Option::Bool("Prog Goron Sword",      {"Disabled", "Enabled"},                                               {progGoronSword});
   std::vector<Option *> itemPoolOptions = {
     &ItemPoolValue,
-    &IncludeBottles,
+    &ReduceBottles,
     &IceTrapValue,
     &RemoveDoubleDefense,
     &ProgressiveGoronSword,
@@ -1429,7 +1429,7 @@ namespace Settings {
     ctx.gkDurability         = GkDurability.Value<u8>();
 
     ctx.itemPoolValue        = ItemPoolValue.Value<u8>();
-    ctx.includeBottles       = (IncludeBottles) ? 1 : 0;
+    ctx.reduceBottles        = (ReduceBottles) ? 1 : 0;
     ctx.iceTrapValue         = IceTrapValue.Value<u8>();
     ctx.progressiveGoronSword = (ProgressiveGoronSword) ? 1 : 0;
 
@@ -2024,11 +2024,11 @@ namespace Settings {
       }
     }
 
-    if ((ItemPoolValue.Is(ITEMPOOL_SCARCE)) || (ItemPoolValue.Is(ITEMPOOL_MINIMAL))) {
-		IncludeBottles.Unhide();
+    if (ItemPoolValue.Is(ITEMPOOL_SCARCE) || ItemPoolValue.Is(ITEMPOOL_MINIMAL)) {
+      ReduceBottles.Unhide();
     } else {
-		IncludeBottles.Hide();
-      }
+      ReduceBottles.Hide();
+    }
 
     if (SetDungeonTypes) {
       for (Option *option : dungeonOptions) {

--- a/source/settings.hpp
+++ b/source/settings.hpp
@@ -433,7 +433,7 @@ namespace Settings {
   extern Option GkDurability;
 
   extern Option ItemPoolValue;
-  extern Option IncludeBottles;
+  extern Option ReduceBottles;
   extern Option IceTrapValue;
   extern Option RemoveDoubleDefense;
   extern Option ProgressiveGoronSword;

--- a/source/settings.hpp
+++ b/source/settings.hpp
@@ -433,6 +433,7 @@ namespace Settings {
   extern Option GkDurability;
 
   extern Option ItemPoolValue;
+  extern Option IncludeBottles;
   extern Option IceTrapValue;
   extern Option RemoveDoubleDefense;
   extern Option ProgressiveGoronSword;


### PR DESCRIPTION
If activated the bottles in the item pool will be reduced depending on what the item pool setting is.
Only visible if the item pool is scarce or minimal.
Scarce has 2 bottles, Minimal has 1.
Rutos Letter and Granny potion will work like before, but on minimal ruto takes priority if necessary.
![screen](https://user-images.githubusercontent.com/20690605/201523055-6b5e8cc6-4d87-47eb-8d4b-e3aab342633a.png)

