### PR TITLE
Fix remaining decoupled entrances in spoiler log

### DIFF
--- a/source/fill.cpp
+++ b/source/fill.cpp
@@ -312,13 +312,9 @@ std::vector<LocationKey> GetAccessibleLocations(const std::vector<LocationKey>& 
                     !noRandomEntrances) {
                     entranceSphere.push_back(&exit);
                     exit.AddToPool();
-                    if (exit.GetReplacement()->GetReverse() != nullptr &&
-                        !exit.GetReplacement()->GetReverse()->IsAddedToPool()) {
+                    // Don't list a coupled entrance from both directions
+                    if (exit.GetReplacement()->GetReverse() != nullptr && !Settings::DecoupleEntrances) {
                         exit.GetReplacement()->GetReverse()->AddToPool();
-                        // When decoupled, list the reverse direction too, unless the entrance is one-way
-                        if (Settings::DecoupleEntrances && exit.GetReverse() != nullptr) {
-                            entranceSphere.push_back(exit.GetReplacement()->GetReverse());
-                        }
                     }
                 }
             }


### PR DESCRIPTION
One of the previous fixes for the spoiler log was preventing some decoupled entrances from being listed if a one-way entrance was listed first.

In trying to fix this, I realized that the original listing of decoupled entrances I did was done the wrong way. Looking at the logic from before decoupled entrances were added, the proper fix was to prevent adding reverse entrances to the pool when decoupled is off, otherwise the reverse will be handled later on in the fill process and have the proper `IsShuffled()` and `IsAddedToPool()` checks from the top level condition. This PR goes back to the original logic and actually implements the check for decoupled entrances.

This should preserve the actual playthrough sphere order when decoupled and all entrances are listed.
(As of right now, with all entrance options available set to max, there should be 243 entrances listed in the spoiler log, and 126 when not decoupled)

---
The only exception I have is one seed that puts Dampes house behind leaving Dampes house (impossible closed loop). This entrance doesn't seem to get added to the spoiler log. I'm not sure if this impossible loop is an issue for entrance shuffling, or if its permitted since Dampes house is effectively worthless so it doesn't matter if its missing from the spoiler log.

```
Setting Graveyard Dampes House -> Graveyard Dampes House
	Original: 853
	Replacement 781
```