### PR TITLE
Fixes and tweak 4

### DIFF
--- a/code/oot.ld
+++ b/code/oot.ld
@@ -576,10 +576,6 @@ SECTIONS
 		*(.patch_BoleroLocation)
 	}
 
-	.patch_BrownBoulderExplode 0x26F9F8 : {
-		*(.patch_BrownBoulderExplode)
-	}
-
 	.patch_RedBoulderExplode 0x26FE7C : {
 		*(.patch_RedBoulderExplode)
 	}

--- a/code/oot_e.ld
+++ b/code/oot_e.ld
@@ -576,10 +576,6 @@ SECTIONS
 		*(.patch_BoleroLocation)
 	}
 
-	.patch_BrownBoulderExplode 0x26F9F8 : {
-		*(.patch_BrownBoulderExplode)
-	}
-
 	.patch_RedBoulderExplode 0x26FE7C : {
 		*(.patch_RedBoulderExplode)
 	}

--- a/code/src/actors/boulder_brown.c
+++ b/code/src/actors/boulder_brown.c
@@ -1,5 +1,0 @@
-#include "z3D/z3D.h"
-
-u32 ObjBombiwa_GetFlag(Actor* thisx, GlobalContext* globalCtx) {
-    return Flags_GetSwitch(globalCtx, (u16)thisx->params & 0x3F);
-}

--- a/code/src/hooks.s
+++ b/code/src/hooks.s
@@ -1357,17 +1357,6 @@ hook_ChildCanOpenBowSubMenu:
     cmp r12,#0x0
     b 0x2EB2DC
 
-.global hook_BrownBoulderExplode
-hook_BrownBoulderExplode:
-    push {r0-r12, lr}
-    cpy r0,r5
-    cpy r1,r7
-    bl ObjBombiwa_GetFlag
-    cmp r0,#0x0
-    pop {r0-r12, lr}
-    bne 0x26FA7C
-    b 0x346D94
-
 .global hook_RedBoulderExplode
 hook_RedBoulderExplode:
     ldrb r0,[r5,#0x1B5]

--- a/code/src/patches.s
+++ b/code/src/patches.s
@@ -1701,11 +1701,6 @@ LinkReflection_patch:
 ChildCanOpenBowSubMenu_patch:
     b hook_ChildCanOpenBowSubMenu
 
-.section .patch_BrownBoulderExplode
-.global BrownBoulderExplode_patch
-BrownBoulderExplode_patch:
-    bl hook_BrownBoulderExplode
-
 .section .patch_RedBoulderExplode
 .global RedBoulderExplode_patch
 RedBoulderExplode_patch:

--- a/source/cosmetics.cpp
+++ b/source/cosmetics.cpp
@@ -147,7 +147,7 @@ const std::array<std::string_view, 13> weaponTrailColors = {
 // Generate random hex color
 std::string RandomColor() {
     std::ostringstream color;
-    color << std::hex << (rand() % 0x1000000); // use default rand to not interfere with main settings
+    color << std::hex << (Random(0, 0x1000000, true));
     return color.str();
 }
 } // namespace Cosmetics

--- a/source/custom_messages.cpp
+++ b/source/custom_messages.cpp
@@ -981,61 +981,37 @@ void CreateAlwaysIncludedMessages() {
 
     // Ruto picking up the dungeon reward
     {
-        std::string itemColor;
+        u8 itemColor;
         switch (Location(BARINADE)->GetPlacedItem().GetHintKey()) {
             case KOKIRI_EMERALD:
             case FOREST_MEDALLION:
-                itemColor = COLOR(QM_GREEN);
+                itemColor = QM_GREEN;
                 break;
             case ZORA_SAPPHIRE:
             case WATER_MEDALLION:
-                itemColor = COLOR(QM_BLUE);
+                itemColor = QM_BLUE;
                 break;
             case SHADOW_MEDALLION:
-                itemColor = COLOR(QM_PINK);
+                itemColor = QM_PINK;
                 break;
             case LIGHT_MEDALLION:
             case SPIRIT_MEDALLION:
             case GOLD_SKULLTULA_TOKEN:
-                itemColor = COLOR(QM_YELLOW);
+                itemColor = QM_YELLOW;
                 break;
             default:
-                itemColor = COLOR(QM_RED);
+                itemColor = QM_RED;
                 break;
         }
-        CreateMessage(0x4050, 0, 2, 3,
-                      UNSKIPPABLE() + INSTANT_TEXT_ON() + "Princess Ruto got the " + NEWLINE() + itemColor +
-                          Location(BARINADE)->GetPlacedItemName().GetNAEnglish() + COLOR(QM_WHITE) + "!" +
-                          WAIT_FOR_INPUT() + INSTANT_TEXT_OFF() + "But why Princess Ruto?" + MESSAGE_END(),
 
-                      UNSKIPPABLE() + INSTANT_TEXT_ON() + "La princesse Ruto a trouvé la " + NEWLINE() + itemColor +
-                          Location(BARINADE)->GetPlacedItemName().GetNAFrench() + COLOR(QM_WHITE) + "!" +
-                          WAIT_FOR_INPUT() + INSTANT_TEXT_OFF() + "Mais pourquoi la princesse Ruto?" + MESSAGE_END(),
+        Text rutoDialog = Text{ "Princess Ruto got #", "La princesse Ruto a trouvé #", "¡La princesa Ruto tiene #",
+                                "La Principessa Ruto ha recuperato #", "Prinzessin Ruto hat #" } +
+                          Location(BARINADE)->GetPlacedItem().GetHint().GetClear() +
+                          Text{ "#!^But why Princess Ruto?", "#!^Mais pourquoi la princesse Ruto?",
+                                "#!^Tú te quedas con las ganas...", "#...", "#!^Aber warum Prinzessin Ruto?" };
 
-                      UNSKIPPABLE() + INSTANT_TEXT_ON() + CENTER_TEXT() + "¡La princesa Ruto tiene la " + NEWLINE() +
-                          itemColor + Location(BARINADE)->GetPlacedItemName().GetNASpanish() + COLOR(QM_WHITE) + "!" +
-                          WAIT_FOR_INPUT() + INSTANT_TEXT_OFF() + "Tú te quedas sin ella..." + MESSAGE_END(),
-
-                      UNSKIPPABLE() + INSTANT_TEXT_ON() + "Princess Ruto got the " + NEWLINE() + itemColor +
-                          Location(BARINADE)->GetPlacedItemName().GetEUREnglish() + COLOR(QM_WHITE) + "!" +
-                          WAIT_FOR_INPUT() + INSTANT_TEXT_OFF() + "But why Princess Ruto?" + MESSAGE_END(),
-
-                      UNSKIPPABLE() + INSTANT_TEXT_ON() + CENTER_TEXT() + "La princesse Ruto trouve" + NEWLINE() +
-                          "la " + itemColor + Location(BARINADE)->GetPlacedItemName().GetEURFrench() + COLOR(QM_WHITE) +
-                          " !" + WAIT_FOR_INPUT() + INSTANT_TEXT_OFF() + "Mais pourquoi la princesse Ruto ?" +
-                          MESSAGE_END(),
-
-                      UNSKIPPABLE() + INSTANT_TEXT_ON() + CENTER_TEXT() + "¡La princesa Ruto tiene la " + NEWLINE() +
-                          itemColor + Location(BARINADE)->GetPlacedItemName().GetEURSpanish() + COLOR(QM_WHITE) + "!" +
-                          WAIT_FOR_INPUT() + INSTANT_TEXT_OFF() + "Tú te quedas con las ganas..." + MESSAGE_END(),
-
-                      UNSKIPPABLE() + INSTANT_TEXT_ON() + "La Principessa Ruto ha recuperato" + NEWLINE() + "la " +
-                          itemColor + Location(BARINADE)->GetPlacedItemName().GetEURItalian() + COLOR(QM_WHITE) +
-                          "..." + INSTANT_TEXT_OFF() + MESSAGE_END(),
-
-                      UNSKIPPABLE() + INSTANT_TEXT_ON() + "Prinzessin Ruto hat den" + NEWLINE() + itemColor +
-                          Location(BARINADE)->GetPlacedItemName().GetEURGerman() + COLOR(QM_WHITE) + " wieder!" +
-                          WAIT_FOR_INPUT() + INSTANT_TEXT_OFF() + "Aber warum Prinzessin Ruto?" + MESSAGE_END());
+        rutoDialog.Replace("$", ""); // Plural marker
+        CreateMessageFromTextObject(0x4050, 0, 2, 3, AddColorsAndFormat(rutoDialog, { itemColor }));
     }
 }
 

--- a/source/custom_messages.cpp
+++ b/source/custom_messages.cpp
@@ -978,6 +978,65 @@ void CreateAlwaysIncludedMessages() {
                           COLOR(QM_RED) + "Schlüsselbund " + COLOR(QM_WHITE) + "der" + NEWLINE() + COLOR(QM_RED) +
                           "Truhenlotterie " + COLOR(QM_WHITE) + "erhalten!" + INSTANT_TEXT_OFF() + MESSAGE_END());
     }
+
+    // Ruto picking up the dungeon reward
+    {
+        std::string itemColor;
+        switch (Location(BARINADE)->GetPlacedItem().GetHintKey()) {
+            case KOKIRI_EMERALD:
+            case FOREST_MEDALLION:
+                itemColor = COLOR(QM_GREEN);
+                break;
+            case ZORA_SAPPHIRE:
+            case WATER_MEDALLION:
+                itemColor = COLOR(QM_BLUE);
+                break;
+            case SHADOW_MEDALLION:
+                itemColor = COLOR(QM_PINK);
+                break;
+            case LIGHT_MEDALLION:
+            case SPIRIT_MEDALLION:
+            case GOLD_SKULLTULA_TOKEN:
+                itemColor = COLOR(QM_YELLOW);
+                break;
+            default:
+                itemColor = COLOR(QM_RED);
+                break;
+        }
+        CreateMessage(0x4050, 0, 2, 3,
+                      UNSKIPPABLE() + INSTANT_TEXT_ON() + "Princess Ruto got the " + NEWLINE() + itemColor +
+                          Location(BARINADE)->GetPlacedItemName().GetNAEnglish() + COLOR(QM_WHITE) + "!" +
+                          WAIT_FOR_INPUT() + INSTANT_TEXT_OFF() + "But why Princess Ruto?" + MESSAGE_END(),
+
+                      UNSKIPPABLE() + INSTANT_TEXT_ON() + "La princesse Ruto a trouvé la " + NEWLINE() + itemColor +
+                          Location(BARINADE)->GetPlacedItemName().GetNAFrench() + COLOR(QM_WHITE) + "!" +
+                          WAIT_FOR_INPUT() + INSTANT_TEXT_OFF() + "Mais pourquoi la princesse Ruto?" + MESSAGE_END(),
+
+                      UNSKIPPABLE() + INSTANT_TEXT_ON() + CENTER_TEXT() + "¡La princesa Ruto tiene la " + NEWLINE() +
+                          itemColor + Location(BARINADE)->GetPlacedItemName().GetNASpanish() + COLOR(QM_WHITE) + "!" +
+                          WAIT_FOR_INPUT() + INSTANT_TEXT_OFF() + "Tú te quedas sin ella..." + MESSAGE_END(),
+
+                      UNSKIPPABLE() + INSTANT_TEXT_ON() + "Princess Ruto got the " + NEWLINE() + itemColor +
+                          Location(BARINADE)->GetPlacedItemName().GetEUREnglish() + COLOR(QM_WHITE) + "!" +
+                          WAIT_FOR_INPUT() + INSTANT_TEXT_OFF() + "But why Princess Ruto?" + MESSAGE_END(),
+
+                      UNSKIPPABLE() + INSTANT_TEXT_ON() + CENTER_TEXT() + "La princesse Ruto trouve" + NEWLINE() +
+                          "la " + itemColor + Location(BARINADE)->GetPlacedItemName().GetEURFrench() + COLOR(QM_WHITE) +
+                          " !" + WAIT_FOR_INPUT() + INSTANT_TEXT_OFF() + "Mais pourquoi la princesse Ruto ?" +
+                          MESSAGE_END(),
+
+                      UNSKIPPABLE() + INSTANT_TEXT_ON() + CENTER_TEXT() + "¡La princesa Ruto tiene la " + NEWLINE() +
+                          itemColor + Location(BARINADE)->GetPlacedItemName().GetEURSpanish() + COLOR(QM_WHITE) + "!" +
+                          WAIT_FOR_INPUT() + INSTANT_TEXT_OFF() + "Tú te quedas con las ganas..." + MESSAGE_END(),
+
+                      UNSKIPPABLE() + INSTANT_TEXT_ON() + "La Principessa Ruto ha recuperato" + NEWLINE() + "la " +
+                          itemColor + Location(BARINADE)->GetPlacedItemName().GetEURItalian() + COLOR(QM_WHITE) +
+                          "..." + INSTANT_TEXT_OFF() + MESSAGE_END(),
+
+                      UNSKIPPABLE() + INSTANT_TEXT_ON() + "Prinzessin Ruto hat den" + NEWLINE() + itemColor +
+                          Location(BARINADE)->GetPlacedItemName().GetEURGerman() + COLOR(QM_WHITE) + " wieder!" +
+                          WAIT_FOR_INPUT() + INSTANT_TEXT_OFF() + "Aber warum Prinzessin Ruto?" + MESSAGE_END());
+    }
 }
 
 Text AddColorsAndFormat(Text text, const std::vector<u8>& colors /*= {}*/) {

--- a/source/music.cpp
+++ b/source/music.cpp
@@ -1,4 +1,5 @@
 #include "music.hpp"
+#include "random.hpp"
 #include <3ds.h>
 #include <cstdlib>
 
@@ -114,7 +115,7 @@ void ShuffleSequences(int type) {
 
     // Shuffle the vector...
     for (std::size_t i = 0; i < seqs.size(); i++) {
-        std::swap(seqs[i], seqs[rand() % seqs.size()]);
+        std::swap(seqs[i], seqs[Random(0, seqs.size(), true)]);
     }
 
     // ...and feed it back into the overrides array

--- a/source/random.cpp
+++ b/source/random.cpp
@@ -4,26 +4,34 @@
 
 static bool init = false;
 static std::mt19937_64 generator;
+static std::mt19937_64 generator_C;
 
 // Initialize with seed specified
 void Random_Init(uint32_t seed) {
-    init      = true;
-    generator = std::mt19937_64{ seed };
+    init        = true;
+    generator   = std::mt19937_64{ seed };
+    generator_C = std::mt19937_64{ seed };
 }
 
 // Returns a random integer in range [min, max-1]
-uint32_t Random(int min, int max) {
+uint32_t Random(int min, int max, bool forCosmetic /*= false*/) {
     if (!init) {
         // No seed given, get a random number from device to seed
         const auto seed = static_cast<uint32_t>(std::random_device{}());
         Random_Init(seed);
     }
     std::uniform_int_distribution<uint32_t> distribution(min, max - 1);
+    if (forCosmetic) {
+        return distribution(generator_C);
+    }
     return distribution(generator);
 }
 
 // Returns a random floating point number in [0.0, 1.0]
-double RandomDouble() {
+double RandomDouble(bool forCosmetic /*= false*/) {
     std::uniform_real_distribution<double> distribution(0.0, 1.0);
+    if (forCosmetic) {
+        return distribution(generator_C);
+    }
     return distribution(generator);
 }

--- a/source/random.hpp
+++ b/source/random.hpp
@@ -7,8 +7,8 @@
 #include <vector>
 
 void Random_Init(uint32_t seed);
-uint32_t Random(int min, int max);
-double RandomDouble();
+uint32_t Random(int min, int max, bool forCosmetic = false);
+double RandomDouble(bool forCosmetic = false);
 
 // Get a random element from a vector or array
 template <typename T> T RandomElement(std::vector<T>& vector, bool erase) {

--- a/source/settings.cpp
+++ b/source/settings.cpp
@@ -2590,7 +2590,7 @@ static void ChooseFinalColor(Option& cosmeticOption, std::string& colorStr, cons
     if (cosmeticOption.Is(CUSTOM_COLOR)) {
         colorStr = GetCustomColor(cosmeticOption.GetSelectedOptionText());
     } else if (cosmeticOption.Is(RANDOM_CHOICE)) {
-        size_t randomIndex = rand() % colors.size(); // use default rand to not interfere with seed
+        size_t randomIndex = Random(0, colors.size(), true);
         cosmeticOption.SetSelectedIndex(
             randomIndex + NON_COLOR_COUNT); // set index so it can be copied for other settings (Navi outer color)
         colorStr = colors[randomIndex];

--- a/source/sound_effects.cpp
+++ b/source/sound_effects.cpp
@@ -1,5 +1,6 @@
 #include "sound_effects.hpp"
 #include "settings.hpp"
+#include "random.hpp"
 #include <3ds.h>
 #include <cstdlib>
 
@@ -1453,7 +1454,7 @@ void ShuffleSequences(bool shuffleCategorically) {
 
             // Shuffle the vector...
             for (size_t i = 0; i < seqs.size(); i++) {
-                std::swap(seqs[i], seqs[rand() % seqs.size()]);
+                std::swap(seqs[i], seqs[Random(0, seqs.size(), true)]);
             }
 
             // ...and feed it back into the overrides arrays
@@ -1481,7 +1482,7 @@ void ShuffleSequences(bool shuffleCategorically) {
 
         // Shuffle the vector...
         for (size_t i = 0; i < seqs.size(); i++) {
-            std::swap(seqs[i], seqs[rand() % seqs.size()]);
+            std::swap(seqs[i], seqs[Random(0, seqs.size(), true)]);
         }
 
         // ...and feed it back into the overrides arrays


### PR DESCRIPTION
- Make random cosmetics consistent using a separate generator.
In other words, generating the same seed with the same cosmetic settings multiple times generates the same results every time.
- Remove patch for brown boulders that was intended for multiplayer.
It caused all boulders with the same flag to get destroyed at the same time which was something I didn't consider, like the ones in MQ Dodongo's Cavern.
- Update the item text of Ruto's pickup message in Jabu.
![image](https://user-images.githubusercontent.com/5352197/205145850-18f65b4a-d07b-4f5a-aa76-cd73169ab089.png)
It looks ugly but I decided to add a newline before the item name so all of them can fit, like the infamous GTG Small Key.
