### PR TITLE
Fix Saria's hints and external texture mods

### DIFF
--- a/code/oot.ld
+++ b/code/oot.ld
@@ -348,6 +348,10 @@ SECTIONS
 		*(.patch_KotakeDontPlayBattleMusic)
 	}
 
+	.patch_GossipStoneAddSariaHint 0x1B3968 : {
+		*(.patch_GossipStoneAddSariaHint)
+	}
+
 	.patch_ReadGossipStoneHints 0x1B3A44 : {
 		*(.patch_ReadGossipStoneHints)
 	}

--- a/code/oot_e.ld
+++ b/code/oot_e.ld
@@ -348,6 +348,10 @@ SECTIONS
 		*(.patch_KotakeDontPlayBattleMusic)
 	}
 
+	.patch_GossipStoneAddSariaHint 0x1B3968 : {
+		*(.patch_GossipStoneAddSariaHint)
+	}
+
 	.patch_ReadGossipStoneHints 0x1B3A44 : {
 		*(.patch_ReadGossipStoneHints)
 	}

--- a/code/src/actors/player.c
+++ b/code/src/actors/player.c
@@ -33,18 +33,23 @@ u8 storedMask       = 0;
 void* Player_EditAndRetrieveCMB(ZARInfo* zarInfo, u32 objModelIdx) {
     void* cmbMan = ZAR_GetCMBByIndex(zarInfo, objModelIdx);
 
-    if (gSaveContext.linkAge == 0) {
-        void* cmb = (void*)(((char*)zarInfo->buf) + 0xDAE8);
-        CustomModel_EditLinkToCustomTunic(cmb);
-    } else {
-        void* cmb = (void*)(((char*)zarInfo->buf) + 0xDACC);
-        CustomModel_EditChildLinkToCustomTunic(cmb);
+    if (gSettingsContext.customTunicColors == ON) {
+        if (gSaveContext.linkAge == 0) {
+            void* cmb = (void*)(((char*)zarInfo->buf) + 0xDAE8);
+            CustomModel_EditLinkToCustomTunic(cmb);
+        } else {
+            void* cmb = (void*)(((char*)zarInfo->buf) + 0xDACC);
+            CustomModel_EditChildLinkToCustomTunic(cmb);
+        }
     }
 
     return cmbMan;
 }
 
-void* Player_GetCustomTunicCMAB(void) {
+void* Player_GetCustomTunicCMAB(ZARInfo* originalZarInfo, u32 originalIndex) {
+    if (gSettingsContext.customTunicColors == OFF) {
+        return ZAR_GetCMABByIndex(originalZarInfo, originalIndex);
+    }
     s16 exObjectBankIdx = Object_GetIndex(&rExtendedObjectCtx, OBJECT_CUSTOM_GENERAL_ASSETS);
     if (exObjectBankIdx < 0) {
         exObjectBankIdx = Object_Spawn(&rExtendedObjectCtx, OBJECT_CUSTOM_GENERAL_ASSETS);
@@ -57,6 +62,9 @@ void* Player_GetCustomTunicCMAB(void) {
 }
 
 void Player_SetChildCustomTunicCMAB(void) {
+    if (gSettingsContext.customTunicColors == OFF) {
+        return;
+    }
     s16 exObjectBankIdx = Object_GetIndex(&rExtendedObjectCtx, OBJECT_CUSTOM_GENERAL_ASSETS);
     void* cmabMan;
     if (exObjectBankIdx < 0) {

--- a/code/src/hints.c
+++ b/code/src/hints.c
@@ -30,6 +30,9 @@ u8 Hints_GetHintsSetting(void) {
 }
 
 void Hints_AddSariasSongHint(u16 textId) {
+    if ((textId & 0xFF00) != 0xA00) { // Skip non-hint texts from Gossip Stones
+        return;
+    }
     u8 textIdSceneOffset = (textId & 0xF0) >> 4;
     u8 textIdLookupBit   = textId & 0xF;
 

--- a/code/src/hooks.s
+++ b/code/src/hooks.s
@@ -577,7 +577,11 @@ hook_CanReadHints:
     ldrh r0,[r4,#0x1C]
     and r0,r0,#0xFF
     add r0,r0,#0x400
-    # Register hint for Saria's Song
+    bx lr
+
+.global hook_GossipStoneAddSariaHint
+hook_GossipStoneAddSariaHint:
+    ldrh r0,[r5,#0x16]
     push {r0-r12, lr}
     add r0,r0,#0x600
     bl Hints_AddSariasSongHint

--- a/code/src/patches.s
+++ b/code/src/patches.s
@@ -1066,6 +1066,11 @@ ReadGossipStoneHints_patch:
     nop
     nop
 
+.section .patch_GossipStoneAddSariaHint
+.global GossipStoneAddSariaHint_patch
+GossipStoneAddSariaHint_patch:
+    bl hook_GossipStoneAddSariaHint
+
 .section .patch_DecoratedChest
 .global DecoratedChest_patch
 DecoratedChest_patch:


### PR DESCRIPTION
- Saria now records hints when the player actually checks the gossip stone instead of just getting close to it.
- If Custom Tunics is off, Link's model won't be edited at all. This allows players to use external texture mods if they so choose.

Test build: 
[OoT3D_Randomizer.zip](https://github.com/gamestabled/OoT3D_Randomizer/files/10189634/OoT3D_Randomizer.zip)