### PR TITLE
Guarantee Goron Pot Reward on First Try

### DIFF
--- a/code/oot.ld
+++ b/code/oot.ld
@@ -968,6 +968,10 @@ SECTIONS
 		*(.patch_ForestTempleBasementPuzzleDelay)
 	}
 
+	.patch_GoronPotGuaranteeReward 0x3C148C : {
+		*(.patch_GoronPotGuaranteeReward)
+	}
+
 	.patch_GerudoArcheryTwo 0x3C2D80 : {
 		*(.patch_GerudoArcheryTwo)
 	}

--- a/code/oot_e.ld
+++ b/code/oot_e.ld
@@ -968,6 +968,10 @@ SECTIONS
 		*(.patch_ForestTempleBasementPuzzleDelay)
 	}
 
+	.patch_GoronPotGuaranteeReward 0x3C148C : {
+		*(.patch_GoronPotGuaranteeReward)
+	}
+
 	.patch_GerudoArcheryTwo 0x3C2D80 : {
 		*(.patch_GerudoArcheryTwo)
 	}

--- a/code/src/actors/goron_pot.c
+++ b/code/src/actors/goron_pot.c
@@ -1,0 +1,8 @@
+#include "goron_pot.h"
+
+void BgSpot18Basket_SetRotation(GoronPot* this) {
+    if (!this->dropped_reward && !Flags_GetCollectible(gGlobalContext, this->base.params & 0x3F)) {
+        // The result is based on the pot's y rotation when the bomb explodes
+        this->base.shape.rot.y = 0;
+    }
+}

--- a/code/src/actors/goron_pot.h
+++ b/code/src/actors/goron_pot.h
@@ -1,0 +1,19 @@
+#ifndef _GORON_POT_H_
+#define _GORON_POT_H_
+
+#include "z3D/z3D.h"
+
+typedef struct {
+    Actor base;
+    char dyna[24];
+    char collider[32];
+    char collider_element[160];
+    void* action_fn;
+    float unk_float;
+    s16 unk_shorts[5];
+    s16 timer;
+    s16 spin_result;
+    u8 dropped_reward;
+} GoronPot;
+
+#endif //_GORON_POT_H_

--- a/code/src/hooks.s
+++ b/code/src/hooks.s
@@ -1728,6 +1728,15 @@ hook_AboutToPickUpActor:
     subeq lr,lr,#0x8
     bx lr
 
+.global hook_GoronPotGuaranteeReward
+hook_GoronPotGuaranteeReward:
+    mov r3,#0x0
+    push {r0-r12, lr}
+    cpy r0,r4
+    bl BgSpot18Basket_SetRotation
+    pop {r0-r12, lr}
+    bx lr
+
 @ ----------------------------------
 @ ----------------------------------
 

--- a/code/src/patches.s
+++ b/code/src/patches.s
@@ -1996,6 +1996,11 @@ SetFWPlayerParams_patch:
 AboutToPickUpActor_patch:
     bl hook_AboutToPickUpActor
 
+.section .patch_GoronPotGuaranteeReward
+.global GoronPotGuaranteeReward_patch
+GoronPotGuaranteeReward_patch:
+    bl hook_GoronPotGuaranteeReward
+
 @ ----------------------------------
 @ ----------------------------------
 


### PR DESCRIPTION
Only applies when the reward isn't already dropped by the pot, and the reward hasn't been picked up before.