### PR TITLE
Fix: Entrance playthrough not printing in spoiler log for vanilla logic

### DIFF
--- a/source/fill.cpp
+++ b/source/fill.cpp
@@ -956,6 +956,8 @@ void VanillaFill() {
         ShuffleAllEntrances();
         printf("\x1b[7;32HDone");
     }
+    // Populate the playthrough for entrances so they are placed in the spoiler log
+    GeneratePlaythrough();
     // Finish up
     CreateItemOverrides();
     CreateEntranceOverrides();


### PR DESCRIPTION
I noticed that although entrance rando was supported for vanilla logic, the entrance playthrough information was blank in the spoiler log. It seems calling `GeneratePlaythrough()` is enough to populate the entrance playthrough so that it gets placed in the spoiler log correctly.

Since this is vanilla logic, and that means entrance validation is forced to true (similar to no logic), and items are placed vanilla, I don't think we need to check the result of `GeneratePlaythrough()` for a beatable seed to do a retry, unlike `Fill()`. If my assumption is wrong, let me know. But the blurb for vanilla logic does call out that entrance rando can make a vanilla logic seed impossible.