### PR TITLE
Cosmetics: Apply custom Navi colors to target reticle

### DIFF
--- a/code/include/z3D/z3D.h
+++ b/code/include/z3D/z3D.h
@@ -479,6 +479,26 @@ typedef struct {
     /* 0x03 */ u8 flags3;
 } RestrictionFlags;
 
+typedef struct TargetIndicatorModels {
+    /* 0x00 */ SkeletonAnimationModel* pointer;                 // arrow above targetable actor
+    /* 0x04 */ SkeletonAnimationModel* reticle[4];              // four arrows circling around target
+    /* 0x14 */ SkeletonAnimationModel* reticleAfterimageOne[4]; // four arrows trailing behind `reticle`
+    /* 0x24 */ SkeletonAnimationModel* reticleAfterimageTwo[4]; // four arrows trailing behind `reticleAfterimageOne`
+} TargetIndicatorModels;
+
+typedef struct TargetContext {
+    /* 0x000 */ char unk_000[0x4E];
+    /* 0x04E */ u8 reticleActorType;
+    /* 0x04F */ char unk_04F[0x61];
+    /* 0x0B0 */ TargetIndicatorModels visibleTargetIndicators; // culled when behind a wall
+    /* 0x0E4 */ TargetIndicatorModels hiddenTargetIndicators;  // drawn even when behind walls
+    /* 0x118 */ char unk_118[0x08];
+    /* 0x120 */ ZARInfo* zarInfo;
+    /* 0x124 */ char unk_120[0x04];
+    /* 0x128 */ u32 pointerActorType;
+    // ... size unknown
+} TargetContext;
+
 extern GlobalContext* gGlobalContext;
 extern const u32 ItemSlots[];
 extern const char DungeonNames[][25];

--- a/code/oot.ld
+++ b/code/oot.ld
@@ -1340,6 +1340,14 @@ SECTIONS
 		*(.patch_StoreTargetActorType)
 	}
 
+	.patch_TargetReticleColor 0x47B284 : {
+		*(.patch_TargetReticleColor)
+	}
+
+	.patch_TargetPointerColor 0x47BAE8 : {
+		*(.patch_TargetPointerColor)
+	}
+
 	.patch_FWKeepWarpPoint 0x47C3C0 : {
 		*(.patch_FWKeepWarpPoint)
 	}

--- a/code/oot_e.ld
+++ b/code/oot_e.ld
@@ -1340,6 +1340,14 @@ SECTIONS
 		*(.patch_StoreTargetActorType)
 	}
 
+	.patch_TargetReticleColor 0x47B2A4 : {
+		*(.patch_TargetReticleColor)
+	}
+
+	.patch_TargetPointerColor 0x47BB08 : {
+		*(.patch_TargetPointerColor)
+	}
+
 	.patch_FWKeepWarpPoint 0x47C3E0 : {
 		*(.patch_FWKeepWarpPoint)
 	}

--- a/code/src/actors/player.c
+++ b/code/src/actors/player.c
@@ -104,7 +104,7 @@ void PlayerActor_rUpdate(Actor* thisx, GlobalContext* globalCtx) {
     Arrow_HandleSwap(this, globalCtx);
 
     if (this->naviActor != 0) {
-        updateNaviColors((EnElf*)this->naviActor);
+        Fairy_UpdateRainbowNaviColors((EnElf*)this->naviActor);
     }
 
     if (IceTrap_ActiveCurse == ICETRAP_CURSE_SWORD && PLAYER->meleeWeaponState != 0 &&

--- a/code/src/colors.c
+++ b/code/src/colors.c
@@ -1,0 +1,17 @@
+#include "z3D/z3D.h"
+#include "colors.h"
+
+void Colors_ChangeRainbowColorRGBAf(Color_RGBAf* color, float speed, float max) {
+    if (color->r >= max && color->g < max && color->b <= 0)
+        color->g += speed;
+    else if (color->r > 0 && color->g >= max && color->b <= 0)
+        color->r -= speed;
+    else if (color->r <= 0 && color->g >= max && color->b < max)
+        color->b += speed;
+    else if (color->r <= 0 && color->g > 0 && color->b >= max)
+        color->g -= speed;
+    else if (color->r < max && color->g <= 0 && color->b >= max)
+        color->r += speed;
+    else if (color->r >= max && color->g <= 0 && color->b > 0)
+        color->b -= speed;
+}

--- a/code/src/colors.h
+++ b/code/src/colors.h
@@ -9,4 +9,6 @@ typedef struct {
     f32 r, g, b, a;
 } Color_RGBAf;
 
+void Colors_ChangeRainbowColorRGBAf(Color_RGBAf* color, float speed, float max);
+
 #endif //_COLORS_H_

--- a/code/src/fairy.c
+++ b/code/src/fairy.c
@@ -1,10 +1,17 @@
 #include "z3D/z3D.h"
 #include "fairy.h"
 #include "settings.h"
+#include "objects.h"
 
-#define FAIRY_COLOR_SPEED 17 // 255 = 3*17*5
+#define NAVI_COLORS_ARRAY ((Color_RGBA8*)0x50C998)
+#define FAIRY_COLOR_SPEED 17   // 255 = 3*17*5
+#define FAIRY_COLOR_MAX 255.0f // max value for RGB components
 
 static u8 lastTargetActorType = 0;
+// Data to manage the rainbow colors
+static void* staticRainbowPointerCMAB = 0;
+static void* staticRainbowReticleCMAB = 0;
+static Color_RGBA8 staticRainbowColor = { 0 };
 
 void Fairy_StoreTargetActorType(u8 targetActorType) {
     lastTargetActorType = targetActorType;
@@ -38,11 +45,75 @@ u8 Fairy_IsNaviOuterRainbowForActorType(u8 type) {
     }
 }
 
+void Fairy_ApplyColorToTargetCMAB(void* cmab, Color_RGBA8 color) {
+    // keyframe 1
+    *(f32*)(cmab + 0x6C) = color.r / 255.0f;
+    *(f32*)(cmab + 0xAC) = color.g / 255.0f;
+    *(f32*)(cmab + 0xEC) = color.b / 255.0f;
+    // keyframe 2
+    *(f32*)(cmab + 0x7C) = color.r / 255.0f;
+    *(f32*)(cmab + 0xBC) = color.g / 255.0f;
+    *(f32*)(cmab + 0xFC) = color.b / 255.0f;
+    // keyframe 3
+    *(f32*)(cmab + 0x8C)  = color.r / 255.0f;
+    *(f32*)(cmab + 0xCC)  = color.g / 255.0f;
+    *(f32*)(cmab + 0x10C) = color.b / 255.0f;
+}
+
 void Fairy_UpdateRainbowNaviColors(EnElf* navi) {
     if (Fairy_IsNaviInnerRainbowForActorType(lastTargetActorType)) {
-        Colors_ChangeRainbowColorRGBAf(&(navi->innerColor), FAIRY_COLOR_SPEED, 255.0f);
+        Colors_ChangeRainbowColorRGBAf(&(navi->innerColor), FAIRY_COLOR_SPEED, FAIRY_COLOR_MAX);
+        staticRainbowColor.r = navi->innerColor.r;
+        staticRainbowColor.g = navi->innerColor.g;
+        staticRainbowColor.b = navi->innerColor.b;
+        staticRainbowColor.a = 0xFF;
     }
     if (Fairy_IsNaviOuterRainbowForActorType(lastTargetActorType)) {
-        Colors_ChangeRainbowColorRGBAf(&(navi->outerColor), FAIRY_COLOR_SPEED, 255.0f);
+        Colors_ChangeRainbowColorRGBAf(&(navi->outerColor), FAIRY_COLOR_SPEED, FAIRY_COLOR_MAX);
     }
+
+    // Handle target pointer color
+    if (staticRainbowPointerCMAB != 0) {
+        Fairy_ApplyColorToTargetCMAB(staticRainbowPointerCMAB, staticRainbowColor);
+    }
+    if (staticRainbowReticleCMAB != 0) {
+        Fairy_ApplyColorToTargetCMAB(staticRainbowReticleCMAB, staticRainbowColor);
+    }
+}
+
+s32 Fairy_SetTargetPointerColor(TargetContext* targetCtx, Actor* targetActor) {
+    if (gSettingsContext.customNaviColors == OFF) {
+        return 0;
+    }
+
+    void** cmabManager = ZAR_GetCMABByIndex(targetCtx->zarInfo, 37); // mark_model_white.cmab as base for all colors
+    Fairy_ApplyColorToTargetCMAB(*cmabManager, NAVI_COLORS_ARRAY[targetActor->type * 2]); // get inner color
+    staticRainbowPointerCMAB = Fairy_IsNaviInnerRainbowForActorType(targetActor->type) ? *cmabManager : 0;
+
+    TexAnim_Spawn(targetCtx->visibleTargetIndicators.pointer->unk_0C, cmabManager);
+    TexAnim_Spawn(targetCtx->hiddenTargetIndicators.pointer->unk_0C, cmabManager);
+    targetCtx->pointerActorType = targetActor->type;
+
+    return 1;
+}
+
+s32 Fairy_SetTargetReticleColor(TargetContext* targetCtx) {
+    if (gSettingsContext.customNaviColors == OFF) {
+        return 0;
+    }
+
+    void** cmabManager = ZAR_GetCMABByIndex(targetCtx->zarInfo, 41); // target_model_white.cmab as base for all colors
+    Fairy_ApplyColorToTargetCMAB(*cmabManager, NAVI_COLORS_ARRAY[targetCtx->reticleActorType * 2]); // get inner color
+    staticRainbowReticleCMAB = Fairy_IsNaviInnerRainbowForActorType(targetCtx->reticleActorType) ? *cmabManager : 0;
+
+    for (s32 i = 0; i < 4; i++) {
+        TexAnim_Spawn(targetCtx->visibleTargetIndicators.reticle[i]->unk_0C, cmabManager);
+        TexAnim_Spawn(targetCtx->visibleTargetIndicators.reticleAfterimageOne[i]->unk_0C, cmabManager);
+        TexAnim_Spawn(targetCtx->visibleTargetIndicators.reticleAfterimageTwo[i]->unk_0C, cmabManager);
+        TexAnim_Spawn(targetCtx->hiddenTargetIndicators.reticle[i]->unk_0C, cmabManager);
+        TexAnim_Spawn(targetCtx->hiddenTargetIndicators.reticleAfterimageOne[i]->unk_0C, cmabManager);
+        TexAnim_Spawn(targetCtx->hiddenTargetIndicators.reticleAfterimageTwo[i]->unk_0C, cmabManager);
+    }
+
+    return 1;
 }

--- a/code/src/fairy.c
+++ b/code/src/fairy.c
@@ -2,49 +2,47 @@
 #include "fairy.h"
 #include "settings.h"
 
+#define FAIRY_COLOR_SPEED 17 // 255 = 3*17*5
+
 static u8 lastTargetActorType = 0;
 
 void Fairy_StoreTargetActorType(u8 targetActorType) {
     lastTargetActorType = targetActorType;
 }
 
-void changeRainbowColorRGBAf(Color_RGBAf* color) {
-#define COLOR_SPEED 17 // 255 = 3*17*5
-    if (color->r == 255.0f && color->g != 255.0f && color->b == 0)
-        color->g += COLOR_SPEED;
-    else if (color->r != 0 && color->g == 255.0f && color->b == 0)
-        color->r -= COLOR_SPEED;
-    else if (color->r == 0 && color->g == 255.0f && color->b != 255.0f)
-        color->b += COLOR_SPEED;
-    else if (color->r == 0 && color->g != 0 && color->b == 255.0f)
-        color->g -= COLOR_SPEED;
-    else if (color->r != 255.0f && color->g == 0 && color->b == 255.0f)
-        color->r += COLOR_SPEED;
-    else if (color->r == 255.0f && color->g == 0 && color->b != 0)
-        color->b -= COLOR_SPEED;
+u8 Fairy_IsNaviInnerRainbowForActorType(u8 type) {
+    switch (type) {
+        case ACTORTYPE_PLAYER:
+            return gSettingsContext.rainbowIdleNaviInnerColor;
+        case ACTORTYPE_NPC:
+            return gSettingsContext.rainbowNPCNaviInnerColor;
+        case ACTORTYPE_ENEMY:
+        case ACTORTYPE_BOSS:
+            return gSettingsContext.rainbowEnemyNaviInnerColor;
+        default:
+            return gSettingsContext.rainbowPropNaviInnerColor;
+    }
 }
 
-void updateNaviColors(EnElf* navi) {
+u8 Fairy_IsNaviOuterRainbowForActorType(u8 type) {
+    switch (type) {
+        case ACTORTYPE_PLAYER:
+            return gSettingsContext.rainbowIdleNaviOuterColor;
+        case ACTORTYPE_NPC:
+            return gSettingsContext.rainbowNPCNaviOuterColor;
+        case ACTORTYPE_ENEMY:
+        case ACTORTYPE_BOSS:
+            return gSettingsContext.rainbowEnemyNaviOuterColor;
+        default:
+            return gSettingsContext.rainbowPropNaviOuterColor;
+    }
+}
 
-    if (lastTargetActorType == ACTORTYPE_PLAYER) {
-        if (gSettingsContext.rainbowIdleNaviInnerColor)
-            changeRainbowColorRGBAf(&(navi->innerColor));
-        if (gSettingsContext.rainbowIdleNaviOuterColor)
-            changeRainbowColorRGBAf(&(navi->outerColor));
-    } else if (lastTargetActorType == ACTORTYPE_NPC) {
-        if (gSettingsContext.rainbowNPCNaviInnerColor)
-            changeRainbowColorRGBAf(&(navi->innerColor));
-        if (gSettingsContext.rainbowNPCNaviOuterColor)
-            changeRainbowColorRGBAf(&(navi->outerColor));
-    } else if (lastTargetActorType == ACTORTYPE_ENEMY || lastTargetActorType == ACTORTYPE_BOSS) {
-        if (gSettingsContext.rainbowEnemyNaviInnerColor)
-            changeRainbowColorRGBAf(&(navi->innerColor));
-        if (gSettingsContext.rainbowEnemyNaviOuterColor)
-            changeRainbowColorRGBAf(&(navi->outerColor));
-    } else {
-        if (gSettingsContext.rainbowPropNaviInnerColor)
-            changeRainbowColorRGBAf(&(navi->innerColor));
-        if (gSettingsContext.rainbowPropNaviOuterColor)
-            changeRainbowColorRGBAf(&(navi->outerColor));
+void Fairy_UpdateRainbowNaviColors(EnElf* navi) {
+    if (Fairy_IsNaviInnerRainbowForActorType(lastTargetActorType)) {
+        Colors_ChangeRainbowColorRGBAf(&(navi->innerColor), FAIRY_COLOR_SPEED, 255.0f);
+    }
+    if (Fairy_IsNaviOuterRainbowForActorType(lastTargetActorType)) {
+        Colors_ChangeRainbowColorRGBAf(&(navi->outerColor), FAIRY_COLOR_SPEED, 255.0f);
     }
 }

--- a/code/src/fairy.h
+++ b/code/src/fairy.h
@@ -13,6 +13,6 @@ typedef struct EnElf {
 
 #define gNaviColorList ((NaviColor*)0x50C998)
 
-void updateNaviColors(EnElf* navi);
+void Fairy_UpdateRainbowNaviColors(EnElf* navi);
 
 #endif //_FAIRY_H_

--- a/code/src/hooks.s
+++ b/code/src/hooks.s
@@ -1737,6 +1737,37 @@ hook_GoronPotGuaranteeReward:
     pop {r0-r12, lr}
     bx lr
 
+.global hook_TargetReticleColor
+hook_TargetReticleColor:
+    mov r4,#0x0
+    push {r0-r12,lr}
+    cpy r0,r6 @ Target Context
+    bl Fairy_SetTargetReticleColor
+    cmp r0,#0x0
+    pop {r0-r12,lr}
+    bxeq lr    @ no custom Navi colors, return to original code
+.if _EUR_==1   @ colors applied, skip original code
+    b 0x47B308
+.else
+    b 0x47B2E8
+.endif
+
+.global hook_TargetPointerColor
+hook_TargetPointerColor:
+    ldr r0,[r6,#0x120]
+    push {r0-r12,lr}
+    cpy r0,r6 @ Target Context
+    cpy r1,r4 @ Targeted actor
+    bl Fairy_SetTargetPointerColor
+    cmp r0,#0x0
+    pop {r0-r12,lr}
+    bxeq lr    @ no custom Navi colors, return to original code
+.if _EUR_==1   @ colors applied, skip original code
+    b 0x47BB50
+.else
+    b 0x47BB30
+.endif
+
 @ ----------------------------------
 @ ----------------------------------
 

--- a/code/src/patches.s
+++ b/code/src/patches.s
@@ -2001,6 +2001,16 @@ AboutToPickUpActor_patch:
 GoronPotGuaranteeReward_patch:
     bl hook_GoronPotGuaranteeReward
 
+.section .patch_TargetReticleColor
+.global TargetReticleColor_patch
+TargetReticleColor_patch:
+    bl hook_TargetReticleColor
+
+.section .patch_TargetPointerColor
+.global TargetPointerColor_patch
+TargetPointerColor_patch:
+    bl hook_TargetPointerColor
+
 @ ----------------------------------
 @ ----------------------------------
 

--- a/source/cosmetics.cpp
+++ b/source/cosmetics.cpp
@@ -72,7 +72,7 @@ const std::array<std::string_view, 28> tunicColors = {
     "7E705B", // Beige
     "583923", // Brown
     "72602B", // Sand
-    "6b7E5D", // Tea Green
+    "6B7E5D", // Tea Green
     "3C5800", // Dark Green
     "6CFFF8", // Powder Blue
     "005A4B", // Teal


### PR DESCRIPTION
Following through with PR #519, I edited the "CMAB stuff", so now the target pointer and reticle will be the same color as Navi.

![2022-12-27_14-09-26 885_top](https://user-images.githubusercontent.com/82058772/209874148-c933a997-cecf-494d-9706-5033da23ae32.png)