### PR TITLE
Improve build process

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -70,6 +70,9 @@ ifneq ($(debug), 0)
 	CXXFLAGS += -g -DENABLE_DEBUG
 endif
 
+# Enable this to skip building the basecode patches
+app_only ?= 0
+
 #---------------------------------------------------------------------------------
 # list of directories containing libraries, this must be the top level containing
 # include and lib
@@ -172,15 +175,21 @@ endif
 .PHONY: all clean
 
 #---------------------------------------------------------------------------------
-all: $(BUILD) $(GFXBUILD) $(DEPSDIR) $(ROMFS_T3XFILES) $(T3XHFILES)
+all: delete3DSX create_basecode $(BUILD) $(GFXBUILD) $(DEPSDIR) $(ROMFS_T3XFILES) $(T3XHFILES)
 	@$(MAKE) --no-print-directory -C $(BUILD) -f $(CURDIR)/Makefile
 
-$(BUILD):
-	$(MAKE) REGION=USA -C code
+delete3DSX:
+	@rm -fr $(TARGET).3dsx
+
+create_basecode:
+ifeq ($(app_only), 0)
+	$(MAKE) --no-print-directory REGION=USA -C code
 	@mv code/basecode_USA.ips $(ROMFS)
-	$(MAKE) clean -C code
-	$(MAKE) REGION=EUR -C code
+	$(MAKE) --no-print-directory REGION=EUR -C code
 	@mv code/basecode_EUR.ips $(ROMFS)
+endif
+
+$(BUILD):
 	@mkdir -p $@
 
 ifneq ($(GFXBUILD),$(BUILD))
@@ -196,7 +205,8 @@ endif
 #---------------------------------------------------------------------------------
 clean:
 	@echo clean ...
-	@rm -fr $(BUILD) $(TARGET).3dsx $(OUTPUT).smdh $(TARGET).elf $(GFXBUILD) $(ROMFS)/basecode.ips $(ROMFS)/basecode_USA.ips $(ROMFS)/basecode_EUR.ips
+	@rm -fr $(BUILD) $(TARGET).3dsx $(OUTPUT).smdh $(TARGET).elf $(GFXBUILD) \
+		$(ROMFS)/basecode.ips $(ROMFS)/basecode_USA.ips $(ROMFS)/basecode_EUR.ips
 	$(MAKE) clean -C code
 
 #---------------------------------------------------------------------------------

--- a/README.md
+++ b/README.md
@@ -66,7 +66,6 @@ A small portion of this project is done in python. If you decide to use the Msys
 
 
 In the root folder, use ```make``` to build ```OoT3D_Randomizer.3dsx```. Use ```make debug=1``` for extra debugging features, including extra items when starting a new file. In the case of problems, try using a ```make clean```.
-When making changes to any code in the `code` directory, you must use `make clean` before recompiling if you want your changes to be picked up.
 For faster compilation using multiple threads, you can use `make -j4` (in this example, the `4` is the number of threads being used).
 
 ## Reporting Bugs

--- a/code/Makefile
+++ b/code/Makefile
@@ -59,15 +59,21 @@ ifeq ($(USA), $(REGION))
   LINK_SCRIPT 	:= oot.ld
   ASFLAGS += -D _USA_=1 -D _EUR_=0 -D _JP_=0
   CFLAGS += -g -DVersion_USA
+  BUILD  := build_usa
+  TARGET := code_usa
 else
 ifeq ($(EUR), $(REGION))
   LINK_SCRIPT 	:= oot_e.ld
   ASFLAGS += -D _USA_=0 -D _EUR_=1 -D _JP_=0
   CFLAGS += -g -DVersion_EUR
+  BUILD  := build_eur
+  TARGET := code_eur
 ifeq ($(JP), $(REGION))
   LINK_SCRIPT 	:= oot_j.ld
   ASFLAGS += -D _USA_=0 -D _EUR_=0 -D _JP_=1
   CFLAGS += -g -DVersion_JP
+  BUILD  := build_jp
+  TARGET := code_jp
 endif
 endif
 endif
@@ -166,7 +172,7 @@ $(BUILD):
 #---------------------------------------------------------------------------------
 clean:
 	@echo clean ...
-	@rm -fr $(BUILD)  $(TARGET).elf
+	@rm -fr build build_eur build_usa *.elf ../source/patch_symbols*
 
 
 #---------------------------------------------------------------------------------


### PR DESCRIPTION
This PR edits the build scripts to introduce the following changes:
- Running `make` in the repo folder will rebuild the basecode patches and repack the 3DSX application.
This allows to rebuild the app relatively quickly after editing files in the `code` folder or the assets archive, without having to run `make clean` beforehand and then wait for all the app's source files to be rebuilt for nothing.
When the previous behavior is desired, the `app_only` flag can be passed on the command line to ignore any changes in the `code` folder (anyway, this would only save the 2 seconds required to check that there are indeed no changes).
- The Python script won't rewrite the HPP symbol files if they are already correct, to improve the app's build speed (mainly for when the basecode files don't change).

Here's a badly cropped video with some random examples (the second build spent 20 seconds on the cpp files instead of the 40 it would've spent after a `make clean`):

https://user-images.githubusercontent.com/82058772/210015604-5aaf3c9c-d7e5-4cf9-a8a5-41ad3c2b56f9.mp4

