### PR TITLE
Add clang-format check

### DIFF
--- a/.github/workflows/clang_format_check.yml
+++ b/.github/workflows/clang_format_check.yml
@@ -1,0 +1,16 @@
+name: clang-format Check
+
+on:
+  pull_request:
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+
+    steps:
+    - uses: actions/checkout@v3
+    - uses: DoozyX/clang-format-lint-action@v0.15
+      with:
+        source: "./code ./source"
+        extensions: 'c,h,cpp,hpp'
+        clangFormatVersion: 14


### PR DESCRIPTION
Similar to the other action, but this one's only for the clang-format check.

If it fails, one can click on `Details` and it'll show what files are wrong and how it'll looked when fixed:
![image](https://user-images.githubusercontent.com/5352197/210118306-eda09bb8-36b3-4210-9121-a39b06e805fb.png)
![image](https://user-images.githubusercontent.com/5352197/210118107-d573adeb-ce31-42e6-bb6c-15c0a8ed3e8a.png)

Something more to consider is to make it so pull requests can only be merged when this check succeeds. 
To do so, go to `Settings` -> `Branches` -> `Add branch protection rule`
(Has to be done after this is merged)