### PR TITLE
CI: Use Custom Container Image + Version Fixes

### DIFF
--- a/.github/workflows/clang_format_code.yml
+++ b/.github/workflows/clang_format_code.yml
@@ -14,9 +14,9 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v3
 
-    - uses: DoozyX/clang-format-lint-action@v0.14
+    - uses: DoozyX/clang-format-lint-action@v0.15
       with:
         source: "./code ./source"
         extensions: 'h,cpp,c,hpp'

--- a/.github/workflows/create_build.yml
+++ b/.github/workflows/create_build.yml
@@ -42,7 +42,7 @@ jobs:
     name: Build CIA and 3DSX Files
     runs-on: ubuntu-latest
     container:
-      image: phlex/oot3dr-build-tools
+      image: ghcr.io/z3dr/randotools:latest
 
     steps:
       - name: Checkout Project

--- a/.github/workflows/create_build.yml
+++ b/.github/workflows/create_build.yml
@@ -29,7 +29,7 @@ jobs:
           echo "last_nightly=$(git describe --tags $(git rev-list --tags --max-count=1))" >> $GITHUB_ENV
       - name: Generate changelog
         id: changelog
-        uses: metcalfc/changelog-generator@v3.0.0
+        uses: metcalfc/changelog-generator@v4.0.1
         with:
           myToken: ${{ secrets.GITHUB_TOKEN }}
           base-ref: ${{ env.last_nightly }}
@@ -59,7 +59,7 @@ jobs:
 
       - if: ${{ github.event.inputs.build_type == 'Nightly' }}
         name: Create Pre-release
-        uses: ncipollo/release-action@v1.8.3
+        uses: ncipollo/release-action@v1.12.0
         with:
           token: "${{ secrets.GITHUB_TOKEN }}"
           artifacts: "OoT3D_Randomizer.cia,OoT3D_Randomizer.3dsx,cia.png,3dsx.png"
@@ -82,7 +82,7 @@ jobs:
 
       - if: ${{ github.event.inputs.build_type == 'Release' }}
         name: Create Release
-        uses: ncipollo/release-action@v1.8.3
+        uses: ncipollo/release-action@v1.12.0
         with:
           token: "${{ secrets.GITHUB_TOKEN }}"
           artifacts: "OoT3D_Randomizer.cia,OoT3D_Randomizer.3dsx,cia.png,3dsx.png"
@@ -432,7 +432,7 @@ jobs:
           done
 
       - name: Deploy to Gist
-        uses: exuanbo/actions-deploy-gist@v1
+        uses: exuanbo/actions-deploy-gist@v1.1.4
         with:
           token: ${{ secrets.TOKEN }}
           gist_id: fa5ea9b42b99377c63bede1cf8ddfdad


### PR DESCRIPTION
Included in this PR is a link to a new custom image to build oot3d rando from a custom image that's hosted on GHCR repos as an org instead of an individual user on Dockerhub.

Included with this PR is changes to versions for a bunch of actions that are used in CI, as these versions have become deprecated with Node 12 being phased out of use for containers.

I suppose I left this sometime ago with the intention of updating things, but realized I never created the merge request for this. This should at least ensure builds won't break in the foreseeable future :)