### PR TITLE
Add bunny hood description and fix unmapped read

### DIFF
--- a/source/descriptions.cpp
+++ b/source/descriptions.cpp
@@ -877,6 +877,14 @@ string_view startingHealthDesc        = "If you start with 0 hearts, Link will b
                                         "at least one heart.";                             //
                                                                                            //
 /*------------------------------                                                           //
+|      STARTING BUNNY HOOD     |                                                           //
+------------------------------*/                                                           //
+string_view startingBunnyHoodDesc     = "NOTE: Staring with the bunny hood is experimental."
+                                        "Currently the bunny hood will get overwriten when "
+                                        "you obtain the Weird Egg and you will need to get "
+                                        "it again afterwards.";                            //
+                                                                                           //
+/*------------------------------                                                           //
 |          ITEM POOL           |                                                           //
 ------------------------------*/                                                           //
 string_view itemPoolPlentiful         = "Extra major items are added to the pool.";        //

--- a/source/descriptions.hpp
+++ b/source/descriptions.hpp
@@ -281,6 +281,8 @@ extern string_view startWithMaxRupeesDesc;
 
 extern string_view startingHealthDesc;
 
+extern string_view startingBunnyHoodDesc;
+
 extern string_view itemPoolPlentiful;
 extern string_view itemPoolBalanced;
 extern string_view itemPoolScarce;

--- a/source/settings.cpp
+++ b/source/settings.cpp
@@ -504,7 +504,7 @@ Option StartingBottle2          = Option::U8  ("Bottle 2",             bottleOpt
 Option StartingBottle3          = Option::U8  ("Bottle 3",             bottleOptions,                                                                   {""});
 Option StartingBottle4          = Option::U8  ("Bottle 4",             bottleOptions,                                                                   {""});
 Option StartingRutoBottle       = Option::U8  ("Ruto's Letter",        {"Off",             "On"},                                                       {""});
-Option StartingChildTrade       = Option::U8  ("Bunny Hood",           {"Off",             "On"},                                                       {""});
+Option StartingChildTrade       = Option::U8  ("Bunny Hood",           {"Off",             "On"},                                                       {startingBunnyHoodDesc});
 std::vector<Option *> startingItemsOptions = {
     &StartingStickCapacity,
     &StartingNutCapacity,

--- a/source/starting_inventory.cpp
+++ b/source/starting_inventory.cpp
@@ -111,7 +111,7 @@ void GenerateStartingInventory() {
         AddItemToInventory(EMPTY_BOTTLE, 1);
     }
     AddItemToInventory(RUTOS_LETTER, StartingRutoBottle.Value<u8>());
-    AddItemToInventory(BUNNY_HOOD, StartingChildTrade.Value<u8>());
+    //AddItemToInventory(BUNNY_HOOD, StartingChildTrade.Value<u8>());
 
     AddItemToInventory(PROGRESSIVE_OCARINA, StartingOcarina.Value<u8>());
     AddItemToInventory(ZELDAS_LULLABY, StartingZeldasLullaby.Value<u8>());


### PR DESCRIPTION
Adds a note to the description for the bunny hood stating that the change is experimental and that players will need to reobtain the bunny hood after it gets overwritten by the weird egg. Also fixes an unmapped read that was caused by trying to add the item to the starting inventory on the logic side when logic doesn't consider it.