### PR TITLE
Another fix for spoilerlog with one-way entrances

### DIFF
--- a/source/fill.cpp
+++ b/source/fill.cpp
@@ -312,8 +312,9 @@ std::vector<LocationKey> GetAccessibleLocations(const std::vector<LocationKey>& 
                     !noRandomEntrances) {
                     entranceSphere.push_back(&exit);
                     exit.AddToPool();
-                    // Don't list a coupled entrance from both directions
-                    if (exit.GetReplacement()->GetReverse() != nullptr && !exit.IsDecoupled()) {
+                    // Don't list a two-way coupled entrance from both directions
+                    if (exit.GetReverse() != nullptr && exit.GetReplacement()->GetReverse() != nullptr &&
+                        !exit.IsDecoupled()) {
                         exit.GetReplacement()->GetReverse()->AddToPool();
                     }
                 }


### PR DESCRIPTION
This was sorta previously fixed, but then the fix was refactor and this regressed. Where a one-way entrance (like spawn) coming first in the playthrough sphere would cause the "replaced reverse" entrance to not show in the spoiler log.

This should finally address that plus all the other previous decoupled edge cases fixed before.

(I promise this is fixed for real this time 😅)