### PR TITLE
Remove boss room to dungeon entryway entrances

### DIFF
--- a/source/location_access/locacc_deku_tree.cpp
+++ b/source/location_access/locacc_deku_tree.cpp
@@ -477,6 +477,5 @@ void AreaTable_Init_DekuTree() {
              {
                  // Exits
                  Entrance(DEKU_TREE_BOSS_ENTRYWAY, { [] { return true; } }),
-                 Entrance(DEKU_TREE_ENTRYWAY, { [] { return DekuTreeClear; } }),
              });
 }

--- a/source/location_access/locacc_dodongos_cavern.cpp
+++ b/source/location_access/locacc_dodongos_cavern.cpp
@@ -626,6 +626,5 @@ void AreaTable_Init_DodongosCavern() {
              {
                  // Exits
                  Entrance(DODONGOS_CAVERN_BOSS_ENTRYWAY, { [] { return true; } }),
-                 Entrance(DODONGOS_CAVERN_ENTRYWAY, { [] { return DodongosCavernClear; } }),
              });
 }

--- a/source/location_access/locacc_fire_temple.cpp
+++ b/source/location_access/locacc_fire_temple.cpp
@@ -795,6 +795,5 @@ void AreaTable_Init_FireTemple() {
              {
                  // Exits
                  Entrance(FIRE_TEMPLE_BOSS_ENTRYWAY, { [] { return false; } }),
-                 Entrance(FIRE_TEMPLE_ENTRYWAY, { [] { return FireTempleClear; } }),
              });
 }

--- a/source/location_access/locacc_forest_temple.cpp
+++ b/source/location_access/locacc_forest_temple.cpp
@@ -789,6 +789,5 @@ void AreaTable_Init_ForestTemple() {
         {
             // Exits
             Entrance(FOREST_TEMPLE_BOSS_ENTRYWAY, { [] { return false; } }),
-            Entrance(FOREST_TEMPLE_ENTRYWAY, { [] { return ForestTempleClear; } }),
         });
 }

--- a/source/location_access/locacc_jabujabus_belly.cpp
+++ b/source/location_access/locacc_jabujabus_belly.cpp
@@ -391,6 +391,5 @@ void AreaTable_Init_JabuJabusBelly() {
              {
                  // Exits
                  Entrance(JABU_JABUS_BELLY_BOSS_ENTRYWAY, { [] { return false; } }),
-                 Entrance(JABU_JABUS_BELLY_ENTRYWAY, { [] { return JabuJabusBellyClear; } }),
              });
 }

--- a/source/location_access/locacc_shadow_temple.cpp
+++ b/source/location_access/locacc_shadow_temple.cpp
@@ -338,6 +338,5 @@ void AreaTable_Init_ShadowTemple() {
              {
                  // Exits
                  Entrance(SHADOW_TEMPLE_BOSS_ENTRYWAY, { [] { return false; } }),
-                 Entrance(SHADOW_TEMPLE_ENTRYWAY, { [] { return ShadowTempleClear; } }),
              });
 }

--- a/source/location_access/locacc_spirit_temple.cpp
+++ b/source/location_access/locacc_spirit_temple.cpp
@@ -469,6 +469,5 @@ void AreaTable_Init_SpiritTemple() {
         {
             // Exits
             Entrance(SPIRIT_TEMPLE_BOSS_ENTRYWAY, { [] { return false; } }),
-            Entrance(SPIRIT_TEMPLE_ENTRYWAY, { [] { return SpiritTempleClear; } }),
         });
 }

--- a/source/location_access/locacc_water_temple.cpp
+++ b/source/location_access/locacc_water_temple.cpp
@@ -713,6 +713,5 @@ void AreaTable_Init_WaterTemple() {
         {
             // Exits
             Entrance(WATER_TEMPLE_BOSS_ENTRYWAY, { [] { return false; } }),
-            Entrance(WATER_TEMPLE_ENTRYWAY, { [] { return WaterTempleClear; } }),
         });
 }


### PR DESCRIPTION
These entrances weren't being considered in entrance randomisation and aren't really necessary as they are equivalent to a save warp and leaving the dungeon normally