### PR TITLE
Remove ZR Waterfall Cutscene

### DIFF
--- a/code/oot.ld
+++ b/code/oot.ld
@@ -1068,6 +1068,10 @@ SECTIONS
 		*(.patch_RainbowBridge)
 	}
 
+	.patch_RemoveWaterfallCS 0x3E7F64 : {
+		*(.patch_RemoveWaterfallCS)
+	}
+
 	.patch_DekuTheaterSkullMask 0x3EAF38 : {
 		*(.patch_DekuTheaterSkullMask)
 	}

--- a/code/oot_e.ld
+++ b/code/oot_e.ld
@@ -1068,6 +1068,10 @@ SECTIONS
 		*(.patch_RainbowBridge)
 	}
 
+	.patch_RemoveWaterfallCS 0x3E7F64 : {
+		*(.patch_RemoveWaterfallCS)
+	}
+
 	.patch_DekuTheaterSkullMask 0x3EAF38 : {
 		*(.patch_DekuTheaterSkullMask)
 	}

--- a/code/src/patches.s
+++ b/code/src/patches.s
@@ -1132,6 +1132,16 @@ SkipDaruniaDanceThree_patch:
 ShortenRainbowBridgeCS_patch:
     bl hook_ShortenRainbowBridgeCS
 
+.section .patch_RemoveWaterfallCS
+.global RemoveWaterfallCS_patch
+RemoveWaterfallCS_patch:
+    nop
+    cpy r0,r10
+    add r1,r10,#0x800
+    add r1,r1,#0x2E8
+    ldr r2,[r6,#0x1A4]
+    bl 0x36B940
+
 .section .patch_OwlMagicCheck
 .global OwlMagicCheck_patch
 OwlMagicCheck_patch:


### PR DESCRIPTION
Fun fact, the hitbox is actually not removed until the middle of the waterfall has completely faded away. The assembly code written makes it so the hitbox is removed immediately.

https://user-images.githubusercontent.com/5352197/211149267-e04ca343-4bc6-48ee-960e-ba94028eba91.mp4
