### PR TITLE
Minor fixes: Rupees as Ammo and Makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -172,7 +172,7 @@ ifneq ($(ROMFS),)
 	export _3DSXFLAGS += --romfs=$(CURDIR)/$(ROMFS)
 endif
 
-.PHONY: all clean
+.PHONY: all clean delete3DSX create_basecode
 
 #---------------------------------------------------------------------------------
 all: delete3DSX create_basecode $(BUILD) $(GFXBUILD) $(DEPSDIR) $(ROMFS_T3XFILES) $(T3XHFILES)
@@ -183,9 +183,9 @@ delete3DSX:
 
 create_basecode:
 ifeq ($(app_only), 0)
-	$(MAKE) --no-print-directory REGION=USA -C code
+	@$(MAKE) --no-print-directory REGION=USA -C code
 	@mv code/basecode_USA.ips $(ROMFS)
-	$(MAKE) --no-print-directory REGION=EUR -C code
+	@$(MAKE) --no-print-directory REGION=EUR -C code
 	@mv code/basecode_EUR.ips $(ROMFS)
 endif
 

--- a/code/Makefile
+++ b/code/Makefile
@@ -184,7 +184,7 @@ DEPENDS	:=	$(OFILES:.o=.d)
 # main targets
 #---------------------------------------------------------------------------------
 
-$(OUTPUT).elf	:	$(OFILES)
+$(OUTPUT).elf	:	$(OFILES) $(TOPDIR)/$(LINK_SCRIPT)
 
 #---------------------------------------------------------------------------------
 # you need a rule like this for each extension you use as binary data

--- a/code/src/item_effect.c
+++ b/code/src/item_effect.c
@@ -4,6 +4,7 @@
 #include "savefile.h"
 #include "multiplayer.h"
 #include "dungeon.h"
+#include "common.h"
 
 void ItemEffect_None(SaveContext* saveCtx, s16 arg1, s16 arg2) {
 }
@@ -221,7 +222,7 @@ void ItemEffect_GiveUpgrade(SaveContext* saveCtx, s16 arg1, s16 arg2) {
 
 // Use rupees as ammo when count gets to 0 and the player has the corresponding item
 void ItemEffect_RupeeAmmo(SaveContext* saveCtx) {
-    if (gSettingsContext.retroAmmo) {
+    if (gSettingsContext.retroAmmo && IsInGameOrBossChallenge()) {
         if (saveCtx->ammo[SLOT_BOW] == 0 && saveCtx->rupees >= 4 &&
             (saveCtx->items[SLOT_BOW] == ITEM_BOW || saveCtx->items[SLOT_BOW] == ITEM_BOW_ARROW_FIRE ||
              saveCtx->items[SLOT_BOW] == ITEM_BOW_ARROW_ICE || saveCtx->items[SLOT_BOW] == ITEM_BOW_ARROW_LIGHT)) {


### PR DESCRIPTION
- Disable Rupees as Ammo on the title screen, to avoid the rupee sound playing every time it loads.
- Add the linker script as a prerequisite for the ELF, so that Make will correctly detect its changes even when it's the only modified file in the code folder.