### PR TITLE
Add missing hint text for Medigoron and Granny shop shuffle

### DIFF
--- a/source/hint_list/hint_list_exclude_overworld.cpp
+++ b/source/hint_list/hint_list_exclude_overworld.cpp
@@ -393,6 +393,15 @@ void HintTable_Init_Exclude_Overworld() {
                        Text{"a #carpet guru# sells", /*french*/"#un marchand du désert# vend", /*spanish*/"el #genio de una alfombra# vende", /*italian*/"il #mercante volante# vende", /*german*/"die Ware des #fliegenden Einsiedlers#, |wäre|wären|"},
     });
 
+    hintTable[GC_MEDIGORON] = HintText::Exclude({
+                       //obscure text
+                       Text{"#Medigoron# sells", /*french*/"#Medigoron# vend", /*spanish*/"#Medigoron# vende", /*italian*/"#Medigoron# vende", /*german*/"#Medigoron#, |wäre|wären|"},
+    });
+
+    hintTable[KAK_GRANNYS_SHOP] = HintText::Exclude({
+                       // obscure text
+                       Text{"the #potion shop lady# sells", /*french*/"la #gribiche du magasin de potion# vend", /*spanish*/"la #señora de la tienda de pociones# vende", /*italian*/"la #vecchietta del negozio di pozioni# vende", /*german*/"#Omas Allerlei#, |wäre|wären|"},
+    });
 
     hintTable[KAK_IMPAS_HOUSE_FREESTANDING_POH] = HintText::Exclude({
                        // obscure text


### PR DESCRIPTION
I had a seed gen crash due to medigoron not having hint text, here where `GetHint()` is a zeroed `HintText` and calling `GetText()` results in a bad access:

https://github.com/gamestabled/OoT3D_Randomizer/blob/a14bf45d14b8965945a023fbf7ed739c78ee5e87/source/hints.cpp#L207

The carpet guy had a hint text, but not medigoron or granny potion shop. For Medigoron, N64 rando just has "Medigoron sells", so I used that here. For granny merchant text, I took the other granny hint text for odd potion and swapped the "entrusts" with the translated "sells" (I hope this is fine, not sure what the proper translation process is).

I didn't bother looking if there was any other item locations with a missing hint text (thats too much to search 😛)