### PR TITLE
Adjust Ganon's Castle and Courtyard exits for dungeon shuffle

### DIFF
--- a/code/src/entrance.c
+++ b/code/src/entrance.c
@@ -312,6 +312,13 @@ s16 Entrance_OverrideNextIndex(s16 nextEntranceIndex) {
         gGlobalContext->actorCtx.flags.tempSwch    = 0;
         gGlobalContext->actorCtx.flags.tempCollect = 0;
     }
+
+    // Exiting through the crawl space from Hyrule Castle courtyard is the same exit as leaving Ganon's castle
+    // Don't override the entrance if we came from the Castle courtyard (day and night scenes)
+    if ((gGlobalContext->sceneNum == 69 || gGlobalContext->sceneNum == 70) && nextEntranceIndex == 0x023D) {
+        return nextEntranceIndex;
+    }
+
     SaveFile_SetEntranceDiscovered(nextEntranceIndex);
     return Grotto_CheckSpecialEntrance(Entrance_GetOverride(nextEntranceIndex));
 }
@@ -1003,6 +1010,16 @@ void Entrance_OverrideSpawnScene(void) {
     if (!IsInGame()) {
         return;
     }
+
+    if (gSettingsContext.shuffleDungeonEntrances == SHUFFLEDUNGEONS_GANON) {
+        // Move Hyrule's Castle Courtyard exit spawn to be before the crates so players don't skip Talon
+        if (gGlobalContext->sceneNum == 95 && gGlobalContext->curSpawn == 1) {
+            gGlobalContext->linkActorEntry->pos.x = 0x033A;
+            gGlobalContext->linkActorEntry->pos.y = 0x0623;
+            gGlobalContext->linkActorEntry->pos.z = 0xFF22;
+        }
+    }
+
     // Repair the authentically bugged scene/spawn info for leaving Barinade's boss room -> JabuJabu's belly
     // to load the correct room outside the boss room, and slightly adjust Link's position
     // to prevent him from falling through the floor


### PR DESCRIPTION
When Ganon's castle is shuffle, exiting as child would place link right outside the courtyard crawlspace. This would allow a player to then enter the courtyard while skipping waking up Talon.

This makes it so the Ganon's castle exit for child places link before the crates on the other side of the moat so you can't bypass Talon. This takes advantage of the new scene/spawn modify func.

If skip child stealth was turned off and Ganon's castle shuffle was turned on, then entering the courtyard and exiting via the crawlspace would place you outside where Ganon's castle entrance is, spoiling the location and potentially breaking logic. This is because leaving the courtyard uses the same entrance index as leaving Ganon's castle.

A check was added in the override logic for the courtyard scene/entrance combination so if you are leaving the courtyard, the you are placed outside the castle by the moat as expected.

This brings parity with N64 rando.
An extra thing that N64 rando does is modify adult Links spawn position when exiting Ganon's castle while the rainbow bridge isn't spawned so that link doesn't get soft locked falling into the lava and voiding out repeatedly. It seems in 3DS OoT, the ground ledge outside Ganon's castle is larger so this problem doesn't occur.