### PR TITLE
Fix list of valid Epona entrances

### DIFF
--- a/code/src/entrance.c
+++ b/code/src/entrance.c
@@ -494,7 +494,7 @@ void Entrance_CheckEpona(void) {
     // unset the Epona flag to avoid Master glitch, and restore temp B.
     if (gSettingsContext.shuffleOverworldEntrances && (PLAYER->stateFlags1 & 0x00800000)) {
 
-        static const s16 validEponaEntrances[] = {
+        s16 validEponaEntrances[] = {
             0x0102, // Hyrule Field -> Lake Hylia
             0x0189, // Lake Hylia -> Hyrule Field
             0x0309, // LH Fishing Hole -> LH Fishing Island

--- a/code/src/entrance.c
+++ b/code/src/entrance.c
@@ -493,8 +493,12 @@ void Entrance_CheckEpona(void) {
     // If Link is riding Epona but he's about to go through an entrance where she can't spawn,
     // unset the Epona flag to avoid Master glitch, and restore temp B.
     if (gSettingsContext.shuffleOverworldEntrances && (PLAYER->stateFlags1 & 0x00800000)) {
+        // Allow Master glitch to be performed on the Thieves Hideout entrance
+        if (entrance == Entrance_GetOverride(0x0496)) {
+            return;
+        }
 
-        s16 validEponaEntrances[] = {
+        static const s16 validEponaEntrances[] = {
             0x0102, // Hyrule Field -> Lake Hylia
             0x0189, // Lake Hylia -> Hyrule Field
             0x0309, // LH Fishing Hole -> LH Fishing Island
@@ -516,8 +520,6 @@ void Entrance_CheckEpona(void) {
             0x028E, // LLR Western Fence Jump
             0x0292, // LLR Eastern Fence Jump
             0x0476, // LLR Front Gate Jump
-            // Allow Master glitch to be performed on the Thieves Hideout entrance
-            Entrance_GetOverride(0x0496), // Gerudo Fortress -> Thieves Hideout
             // The following indices currently aren't randomized, but we'll list
             // them in case they ever are. They're all Theives Hideout -> Gerudo Fortress
             0x231,

--- a/code/src/entrance.c
+++ b/code/src/entrance.c
@@ -504,12 +504,11 @@ void Entrance_CheckEpona(void) {
             0x0157, // Hyrule Field -> Lon Lon Ranch
             0x01F9, // Lon Lon Ranch -> Hyrule Field
             0x01FD, // Market Entrance -> Hyrule Field
-            0x00EA, // ZR Front -> Hyrule Field
-            0x0181, // LW Bridge -> Hyrule Field
+            0x0181, // ZR Front -> Hyrule Field
+            0x0185, // LW Bridge -> Hyrule Field
             0x0129, // GV Fortress Side -> Gerudo Fortress
             0x022D, // Gerudo Fortress -> GV Fortress Side
             0x03D0, // GV Carpenter Tent -> GV Fortress Side
-            0x0496, // Gerudo Fortress -> Thieves Hideout
             0x042F, // LLR Stables -> Lon Lon Ranch
             0x05D4, // LLR Tower -> Lon Lon Ranch
             0x0378, // LLR Talons House -> Lon Lon Ranch

--- a/code/src/entrance.c
+++ b/code/src/entrance.c
@@ -516,6 +516,8 @@ void Entrance_CheckEpona(void) {
             0x028E, // LLR Western Fence Jump
             0x0292, // LLR Eastern Fence Jump
             0x0476, // LLR Front Gate Jump
+            // Allow Master glitch to be performed on the Thieves Hideout entrance
+            Entrance_GetOverride(0x0496), // Gerudo Fortress -> Thieves Hideout
             // The following indices currently aren't randomized, but we'll list
             // them in case they ever are. They're all Theives Hideout -> Gerudo Fortress
             0x231,


### PR DESCRIPTION
- ZR -> HF was actually HF -> ZR
- LW -> HF was actually ZR -> HF
- GF -> Thieves Hideout is not a valid Epona entrance