### PR TITLE
Fixes for MQ icon, savewarp and time of day

### DIFF
--- a/code/src/cutscenes.c
+++ b/code/src/cutscenes.c
@@ -202,6 +202,9 @@ void Cutscene_OverrideDekuTree(void) {
             gSaveContext.nextCutsceneIndex = 0xFFF1;
             return;
         }
+
+        // Skipped if wrong warping
+        gSaveContext.dayTime = 0x8000;
     }
     gGlobalContext->nextEntranceIndex = Entrance_OverrideNextIndex(0x457);
     gGlobalContext->sceneLoadFlag     = 0x14;
@@ -219,6 +222,9 @@ void Custcene_OverrideDodongosCavern(void) {
             gSaveContext.nextCutsceneIndex = 0xFFF1;
             return;
         }
+
+        // Skipped if wrong warping
+        gSaveContext.dayTime = 0x8000;
     }
     gGlobalContext->nextEntranceIndex = Entrance_OverrideNextIndex(0x47A);
     gGlobalContext->sceneLoadFlag     = 0x14;
@@ -237,6 +243,9 @@ void Custcene_OverrideJabuJabusBelly(void) {
             gSaveContext.nextCutsceneIndex = 0xFFF0;
             return;
         }
+
+        // Skipped if wrong warping
+        gSaveContext.dayTime = 0x8000;
     }
     gGlobalContext->nextEntranceIndex = Entrance_OverrideNextIndex(0x221);
     gGlobalContext->sceneLoadFlag     = 0x14;
@@ -248,6 +257,7 @@ void Custcene_OverrideForestTemple(void) {
     if (EventCheck(0x48) == 0) {
         EventSet(0x48);
         ItemOverride_PushDungeonReward(DUNGEON_FOREST_TEMPLE);
+        gSaveContext.dayTime = 0x8000;
     }
     gGlobalContext->nextEntranceIndex = Entrance_OverrideNextIndex(0x608);
     gGlobalContext->sceneLoadFlag     = 0x14;
@@ -266,6 +276,9 @@ void Cutscene_OverrideFireTemple(void) {
             gSaveContext.nextCutsceneIndex = 0xFFF3;
             return;
         }
+
+        // Skipped if wrong warping
+        gSaveContext.dayTime = 0x8000;
     }
     gGlobalContext->nextEntranceIndex = Entrance_OverrideNextIndex(0x564);
     gGlobalContext->sceneLoadFlag     = 0x14;
@@ -278,6 +291,7 @@ void Custcene_OverrideWaterTemple(void) {
         EventSet(0x4A);
         ItemOverride_PushDungeonReward(DUNGEON_WATER_TEMPLE);
         gSaveContext.eventChkInf[6] |= 0x0200; // Raise Lake Hylia's Water
+        gSaveContext.dayTime = 0x4800;
     }
     gGlobalContext->nextEntranceIndex = Entrance_OverrideNextIndex(0x60C);
     gGlobalContext->sceneLoadFlag     = 0x14;
@@ -289,6 +303,7 @@ void Custcene_OverrideSpiritTemple(void) {
     if (EventCheck(0x47) == 0) {
         EventSet(0x47);
         ItemOverride_PushDungeonReward(DUNGEON_SPIRIT_TEMPLE);
+        gSaveContext.dayTime = 0x8000;
     }
     gGlobalContext->nextEntranceIndex = Entrance_OverrideNextIndex(0x610);
     gGlobalContext->sceneLoadFlag     = 0x14;
@@ -300,6 +315,7 @@ void Custcene_OverrideShadowTemple(void) {
     if (EventCheck(0x46) == 0) {
         EventSet(0x46);
         ItemOverride_PushDungeonReward(DUNGEON_SHADOW_TEMPLE);
+        gSaveContext.dayTime = 0x8000;
     }
     gGlobalContext->nextEntranceIndex = Entrance_OverrideNextIndex(0x580);
     gGlobalContext->sceneLoadFlag     = 0x14;

--- a/code/src/entrance.c
+++ b/code/src/entrance.c
@@ -441,7 +441,7 @@ void Entrance_SetSavewarpEntrance(void) {
     } else if (scene == DUNGEON_INSIDE_GANONS_CASTLE) {
         gSaveContext.entranceIndex = GANONS_CASTLE_ENTRANCE;
     } else if (scene == DUNGEON_GANONS_TOWER || scene == DUNGEON_GANONS_CASTLE_COLLAPSING ||
-               scene == DUNGEON_GANONS_TOWER_COLLAPSING_INTERIOR || scene == 0x4F || scene == 0x1A) {
+               scene == DUNGEON_GANONS_TOWER_COLLAPSING_INTERIOR || scene == 0x4F || scene == 0x1A || scene == 0x19) {
         gSaveContext.entranceIndex = 0x041B; // Inside Ganon's Castle -> Ganon's Tower Climb
     } else if (scene == DUNGEON_THIEVES_HIDEOUT) {
         gSaveContext.entranceIndex = 0x0486; // Gerudo Fortress -> Thieve's Hideout spawn 0

--- a/code/src/gfx.c
+++ b/code/src/gfx.c
@@ -449,7 +449,8 @@ static void Gfx_DrawDungeonItems(void) {
         // Dungeon Type
         if (dungeonId <= DUNGEON_GERUDO_TRAINING_GROUNDS || dungeonId == DUNGEON_INSIDE_GANONS_CASTLE) {
             if (IsDungeonDiscovered(dungeonId)) {
-                bool isMasterQuest         = gSettingsContext.dungeonModes[dungeonId] == DUNGEONMODE_MQ;
+                u32 dungeonModeId          = (dungeonId == DUNGEON_INSIDE_GANONS_CASTLE ? 10 : dungeonId);
+                bool isMasterQuest         = (gSettingsContext.dungeonModes[dungeonModeId]) == DUNGEONMODE_MQ;
                 u32 modeIconColor          = isMasterQuest ? COLOR_ICON_MASTER_QUEST : COLOR_ICON_VANILLA;
                 Draw_IconType modeIconType = isMasterQuest ? ICON_MASTER_QUEST : ICON_VANILLA;
                 Draw_DrawIcon(10, yPos, modeIconColor, modeIconType);


### PR DESCRIPTION
- Drawing the icon for Ganon's Castle dungeon mode was reading one of the "skipped trials" settings as the dungeon mode, due to an incorrect index.
- Savewarping in Ganondorf's boss room was going back to the overworld spawn, now it will go to Ganon's Tower.
- Beating dungeons wasn't setting time of day.