### PR TITLE
Undo hint change for exact location hints

### DIFF
--- a/source/hints.cpp
+++ b/source/hints.cpp
@@ -204,7 +204,7 @@ static void CreateLocationHint(const std::vector<LocationKey>& possibleHintLocat
     Location(hintedLocation)->SetAsHinted();
 
     // make hint text
-    Text locationHintText = GetHintRegion(Location(hintedLocation)->GetParentRegionKey())->GetHint().GetText();
+    Text locationHintText = Location(hintedLocation)->GetHint().GetText();
     Text itemHintText     = Location(hintedLocation)->GetPlacedItem().GetHint().GetText();
     Text prefix           = Hint(PREFIX).GetText();
 


### PR DESCRIPTION
This shouldn't have been changed since this is supposed to use the exact locations