### PR TITLE
Add Custom Music Support, with new way of shuffling music by recreating the sound archive

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -55,7 +55,7 @@ CFLAGS	:=	-g -Wall -O2 -mword-relocations \
 
 CFLAGS	+=	$(INCLUDE) -D__3DS__
 
-CXXFLAGS	:= $(CFLAGS) -fno-rtti -fno-exceptions -fno-var-tracking-assignments -std=gnu++17 -Wreorder
+CXXFLAGS	:= $(CFLAGS) -fno-exceptions -fno-var-tracking-assignments -std=gnu++17 -Wreorder
 
 ASFLAGS	:=	-g $(ARCH)
 LDFLAGS	=	-specs=3dsx.specs -g $(ARCH) -Wl,-Map,$(notdir $*.map)

--- a/code/src/settings.h
+++ b/code/src/settings.h
@@ -368,6 +368,13 @@ typedef enum {
 } StartingBiggoronSwordSetting;
 
 typedef enum {
+    SHUFFLEMUSIC_OFF,
+    SHUFFLEMUSIC_MIXED,
+    SHUFFLEMUSIC_GROUPED,
+    SHUFFLEMUSIC_OWN,
+} ShuffleMusicSetting;
+
+typedef enum {
     SHUFFLESFX_OFF,
     SHUFFLESFX_ALL,
     SHUFFLESFX_SCENESPECIFIC,

--- a/source/custom_music/common_structures.hpp
+++ b/source/custom_music/common_structures.hpp
@@ -1,0 +1,154 @@
+#pragma once
+
+#include <3ds.h>
+
+// Code ported from Gota7's Citric Composer
+
+class ReferenceTypes {
+  public:
+    // Base types.
+    static const u16 Tables     = 0x100;
+    static const u16 Parameters = 0x200;
+    static const u16 Codecs     = 0x300;
+    static const u16 General    = 0x1F00;
+
+    static const u16 SAR_Blocks       = 0x2000;
+    static const u16 SAR_InfoSections = 0x2100;
+    static const u16 SAR_ItemInfos    = 0x2200;
+    static const u16 SAR_Parameters   = 0x2300;
+    static const u16 SAR_General      = 0x2400;
+
+    static const u16 STRM_Blocks    = 0x4000;
+    static const u16 STRM_ItemInfos = 0x4100;
+
+    static const u16 WSF_Blocks    = 0x4800;
+    static const u16 WSF_ItemInfos = 0x4900;
+
+    static const u16 SEQ_Blocks    = 0x5000;
+    static const u16 SEQ_ItemInfos = 0x5100;
+
+    static const u16 BNK_Blocks     = 0x5800;
+    static const u16 BNK_Items      = 0x5900;
+    static const u16 BNK_ItemTables = 0x6000;
+
+    static const u16 WAR_Blocks = 0x6800;
+
+    static const u16 WAV_Blocks    = 0x7000;
+    static const u16 WAV_ItemInfos = 0x7100;
+
+    static const u16 GRP_Blocks    = 0x7800;
+    static const u16 GRP_ItemInfos = 0x7900;
+
+    static const u16 ASF_Blocks = 0x8000;
+    static const u16 ASF_Items  = 0x8100;
+
+    // Common sound.
+    static const u16 Table_Embedding         = Tables;
+    static const u16 Table_Reference         = Tables + 1;
+    static const u16 Table_ReferenceWithSize = Tables + 2;
+
+    static const u16 Param_Sound3D      = Parameters;
+    static const u16 Param_Sends        = Parameters + 1;
+    static const u16 Param_Envelope     = Parameters + 2;
+    static const u16 Param_AdshrEnvelop = Parameters + 3;
+
+    static const u16 Codec_DspAdpcmInfo = Codecs;
+    static const u16 Codec_ImaAdpcmInfo = Codecs + 1;
+
+    static const u16 General_ByteStream = General;
+    static const u16 String             = General + 1;
+
+    // Sound archive file.
+    static const u16 SAR_Block_String = SAR_Blocks;
+    static const u16 SAR_Block_Info   = SAR_Blocks + 1;
+    static const u16 SAR_Block_File   = SAR_Blocks + 2;
+
+    static const u16 SAR_Section_SoundInfo       = SAR_InfoSections;
+    static const u16 SAR_Section_BankInfo        = SAR_InfoSections + 1;
+    static const u16 SAR_Section_PlayerInfo      = SAR_InfoSections + 2;
+    static const u16 SAR_Section_WaveArchiveInfo = SAR_InfoSections + 3;
+    static const u16 SAR_Section_SoundGroupInfo  = SAR_InfoSections + 4;
+    static const u16 SAR_Section_GroupInfo       = SAR_InfoSections + 5;
+    static const u16 SAR_Section_FileInfo        = SAR_InfoSections + 6;
+
+    static const u16 SAR_Info_Sound                = SAR_ItemInfos;
+    static const u16 SAR_Info_StreamSound          = SAR_ItemInfos + 1;
+    static const u16 SAR_Info_WaveSound            = SAR_ItemInfos + 2;
+    static const u16 SAR_Info_SequenceSound        = SAR_ItemInfos + 3;
+    static const u16 SAR_Info_SoundGroup           = SAR_ItemInfos + 4;
+    static const u16 SAR_Info_WaveSoundGroup       = SAR_ItemInfos + 5;
+    static const u16 SAR_Info_Bank                 = SAR_ItemInfos + 6;
+    static const u16 SAR_Info_WaveArchive          = SAR_ItemInfos + 7;
+    static const u16 SAR_Info_Group                = SAR_ItemInfos + 8;
+    static const u16 SAR_Info_Player               = SAR_ItemInfos + 9;
+    static const u16 SAR_Info_File                 = SAR_ItemInfos + 10;
+    static const u16 SAR_Info_Project              = SAR_ItemInfos + 11;
+    static const u16 SAR_Info_InternalFile         = SAR_ItemInfos + 12;
+    static const u16 SAR_Info_ExternalFile         = SAR_ItemInfos + 13;
+    static const u16 SAR_Info_StreamSoundTrack     = SAR_ItemInfos + 14;
+    static const u16 SAR_Info_Send                 = SAR_ItemInfos + 15;
+    static const u16 SAR_Info_StreamSoundExtension = SAR_ItemInfos + 16;
+
+    static const u16 SAR_StringTable  = SAR_General;
+    static const u16 SAR_PatriciaTree = SAR_General + 1;
+
+    // Stream file.
+    static const u16 STRM_Block_Info         = STRM_Blocks;
+    static const u16 STRM_Block_Seek         = STRM_Blocks + 1;
+    static const u16 STRM_Block_Data         = STRM_Blocks + 2;
+    static const u16 STRM_Block_Region       = STRM_Blocks + 3;
+    static const u16 STRM_Block_PrefetchData = STRM_Blocks + 4;
+
+    static const u16 STRM_Info_StreamSound = STRM_ItemInfos;
+    static const u16 STRM_Info_Track       = STRM_ItemInfos + 1;
+    static const u16 STRM_Info_Channel     = STRM_ItemInfos + 2;
+
+    // Wave sound file.
+    static const u16 WSF_Block_Info = WSF_Blocks;
+
+    static const u16 WSF_WaveSoundMetaData = WSF_ItemInfos;
+    static const u16 WSF_WaveSoundInfo     = WSF_ItemInfos + 1;
+    static const u16 WSF_NoteInfo          = WSF_ItemInfos + 2;
+    static const u16 WSF_TrackInfo         = WSF_ItemInfos + 3;
+    static const u16 WSF_NoteEvent         = WSF_ItemInfos + 4;
+
+    // Wave archive file.
+    static const u16 WAR_Block_Info = WAR_Blocks;
+    static const u16 WAR_Block_File = WAR_Blocks + 1;
+
+    // Wave file.
+    static const u16 WAV_Block_Info = WAV_Blocks;
+    static const u16 WAV_Block_Data = WAV_Blocks + 1;
+
+    static const u16 WAV_ChannelInfo = WAV_ItemInfos;
+
+    // Sequence file.
+    static const u16 SEQ_Block_Data  = SEQ_Blocks;
+    static const u16 SEQ_Block_Label = SEQ_Blocks + 1;
+
+    static const u16 SEQ_LabelInfo = SEQ_ItemInfos;
+
+    // Bank file.
+    static const u16 BNK_Block_Info = BNK_Blocks;
+
+    static const u16 BNK_Info_Instrument     = BNK_Items;
+    static const u16 BNK_Info_KeyRegion      = BNK_Items + 1;
+    static const u16 BNK_Info_VelocityRegion = BNK_Items + 2;
+    static const u16 BNK_Info_Null           = BNK_Items + 3;
+
+    static const u16 BNK_RefTable_Direct = BNK_ItemTables;
+    static const u16 BNK_RefTable_Index  = BNK_ItemTables + 1;
+    static const u16 BNK_RefTable_Range  = BNK_ItemTables + 2;
+
+    // Group file.
+    static const u16 GRP_Block_Info = GRP_Blocks;
+    static const u16 GRP_Block_File = GRP_Blocks + 1;
+    static const u16 GRP_Block_Infx = GRP_Blocks + 2;
+
+    static const u16 GRP_Info_Item = GRP_ItemInfos;
+    static const u16 GRP_Infx_Item = GRP_ItemInfos + 1;
+
+    // Animation sound file.
+    static const u16 ASF_Block_Data = ASF_Blocks;
+    static const u16 ASF_EventInfo  = ASF_Items;
+};

--- a/source/custom_music/ctr_binary_data.cpp
+++ b/source/custom_music/ctr_binary_data.cpp
@@ -1,0 +1,151 @@
+#include "ctr_binary_data.hpp"
+
+// Handler
+
+BinaryDataHandler::BinaryDataHandler() {
+}
+
+BinaryDataHandler::~BinaryDataHandler() = default;
+
+void BinaryDataHandler::Close() {
+    FSFILE_Close(fsHandle);
+}
+
+bool BinaryDataHandler::SuccessfullyInitialized() {
+    return init;
+}
+
+// Reader
+
+BinaryDataReader::BinaryDataReader(FS_Archive archive_, std::string filePath_) {
+    if (!R_SUCCEEDED(FSUSER_OpenFile(&fsHandle, archive_, fsMakePath(PATH_ASCII, filePath_.c_str()), FS_OPEN_READ,
+                                     FS_ATTRIBUTE_ARCHIVE))) {
+        return;
+    }
+    FSFILE_GetSize(fsHandle, &fileSize);
+    init = true;
+}
+
+BinaryDataReader::~BinaryDataReader() = default;
+
+u64 BinaryDataReader::GetFileSize() {
+    return fileSize;
+}
+
+u8 BinaryDataReader::ReadByte() {
+    u32 bytesRead = 0;
+    u8 value      = 0;
+
+    FSFILE_Read(fsHandle, &bytesRead, position, &value, sizeof(u8));
+    BinaryDataReader::position += sizeof(u8);
+
+    return value;
+}
+
+std::vector<char> BinaryDataReader::ReadChars(u32 count) {
+    u32 bytesRead = 0;
+    std::vector<char> chars(count, 0);
+
+    FSFILE_Read(fsHandle, &bytesRead, position, &chars[0], count);
+    position += bytesRead;
+
+    return chars;
+}
+
+std::vector<u8> BinaryDataReader::ReadBytes(u32 count) {
+    u32 bytesRead = 0;
+    std::vector<u8> bytes(count, 0);
+
+    FSFILE_Read(fsHandle, &bytesRead, position, &bytes[0], count);
+    position += bytesRead;
+
+    return bytes;
+}
+
+s16 BinaryDataReader::ReadS16() {
+    u32 bytesRead = 0;
+    s16 value     = 0;
+
+    FSFILE_Read(fsHandle, &bytesRead, position, &value, sizeof(s16));
+    BinaryDataReader::position += sizeof(s16);
+
+    return value;
+}
+
+u16 BinaryDataReader::ReadU16() {
+    return (u16)ReadS16();
+}
+
+s32 BinaryDataReader::ReadS32() {
+    u32 bytesRead = 0;
+    u32 value     = 0;
+
+    FSFILE_Read(fsHandle, &bytesRead, position, &value, sizeof(s32));
+    BinaryDataReader::position += sizeof(s32);
+
+    return value;
+}
+
+u32 BinaryDataReader::ReadU32() {
+    return (u32)ReadS32();
+}
+
+std::vector<u8> BinaryDataReader::ReadAll() {
+    position = 0;
+    FSFILE_GetSize(fsHandle, &fileSize);
+    return ReadBytes(fileSize);
+}
+
+// Writer
+
+BinaryDataWriter::BinaryDataWriter(FS_Archive archive_, std::string filePath_) {
+    if (!R_SUCCEEDED(FSUSER_OpenFile(&fsHandle, archive_, fsMakePath(PATH_ASCII, filePath_.c_str()),
+                                     FS_OPEN_WRITE | FS_OPEN_CREATE, FS_ATTRIBUTE_ARCHIVE))) {
+        return;
+    }
+    init = true;
+}
+
+BinaryDataWriter::~BinaryDataWriter() = default;
+
+void BinaryDataWriter::Write(char buf) {
+    Write((u8)buf);
+}
+
+void BinaryDataWriter::Write(u8 buf) {
+    u32 bytesWritten = 0;
+    FSFILE_Write(fsHandle, &bytesWritten, position, &buf, sizeof(buf), FS_WRITE_UPDATE_TIME);
+    position += bytesWritten;
+}
+
+void BinaryDataWriter::Write(std::vector<char> buf) {
+    u32 bytesWritten = 0;
+    FSFILE_Write(fsHandle, &bytesWritten, position, &buf[0], buf.size(), FS_WRITE_UPDATE_TIME);
+    position += bytesWritten;
+}
+
+void BinaryDataWriter::Write(std::vector<u8> buf) {
+    u32 bytesWritten = 0;
+    FSFILE_Write(fsHandle, &bytesWritten, position, &buf[0], buf.size(), FS_WRITE_UPDATE_TIME);
+    position += bytesWritten;
+}
+
+void BinaryDataWriter::Write(s16 buf) {
+    u32 bytesWritten = 0;
+    FSFILE_Write(fsHandle, &bytesWritten, position, &buf, sizeof(buf), FS_WRITE_UPDATE_TIME);
+    position += bytesWritten;
+}
+
+void BinaryDataWriter::Write(u16 buf) {
+    Write((s16)buf);
+}
+
+void BinaryDataWriter::Write(s32 buf) {
+    u32 bytesWritten = 0;
+    FSFILE_Write(fsHandle, &bytesWritten, position, &buf, sizeof(buf), FS_WRITE_UPDATE_TIME);
+    position += bytesWritten;
+}
+
+void BinaryDataWriter::Write(u32 buf) {
+    Write((s32)buf);
+}

--- a/source/custom_music/ctr_binary_data.hpp
+++ b/source/custom_music/ctr_binary_data.hpp
@@ -1,0 +1,59 @@
+#pragma once
+
+#include <3ds.h>
+#include <string>
+#include <vector>
+
+class BinaryDataHandler {
+  public:
+    void Close();
+    bool SuccessfullyInitialized();
+
+    u32 position = 0;
+
+  protected:
+    BinaryDataHandler();
+    ~BinaryDataHandler();
+
+    bool init = false;
+
+    Handle fsHandle = 0;
+};
+
+class BinaryDataReader : public BinaryDataHandler {
+  public:
+    BinaryDataReader(FS_Archive archive_, std::string filePath_);
+    ~BinaryDataReader();
+
+    u64 GetFileSize();
+
+    u8 ReadByte();
+    std::vector<char> ReadChars(u32 count);
+    std::vector<u8> ReadBytes(u32 count);
+    s16 ReadS16();
+    u16 ReadU16();
+    s32 ReadS32();
+    u32 ReadU32();
+
+    std::vector<u8> ReadAll();
+
+  private:
+    u64 fileSize;
+};
+
+class BinaryDataWriter : public BinaryDataHandler {
+  public:
+    BinaryDataWriter(FS_Archive archive_, std::string filePath_);
+    ~BinaryDataWriter();
+
+    void Write(char buf);
+    void Write(u8 buf);
+    void Write(std::vector<char> buf);
+    void Write(std::vector<u8> buf);
+    void Write(s16 buf);
+    void Write(u16 buf);
+    void Write(s32 buf);
+    void Write(u32 buf);
+
+  private:
+};

--- a/source/custom_music/file_reader.cpp
+++ b/source/custom_music/file_reader.cpp
@@ -1,0 +1,72 @@
+#include "file_reader.hpp"
+#include "ctr_binary_data.hpp"
+
+// Code ported from Gota7's Citric Composer
+
+FileReader::FileReader(BinaryDataReader& br) {
+    fileStartPos = br.position;
+
+    br.position += 4; // Magic
+    br.position += 2; // Byte Order
+    u16 headerSize = br.ReadU16();
+    br.position += 4; // Version
+    br.position += 4; // File Size
+    u16 numBlocks = br.ReadU16();
+    br.position += 2; // Padding
+
+    for (size_t i = 0; i < numBlocks; i++) {
+        br.position += 4;
+        blockOffsets.push_back(br.ReadU32());
+        br.position += 4;
+    }
+
+    br.position = fileStartPos + headerSize;
+}
+
+FileReader::~FileReader() = default;
+
+void FileReader::OpenBlock(BinaryDataReader& br, u32 blockNum) {
+    br.position = fileStartPos + blockOffsets[blockNum];
+    blockPos    = br.position;
+    br.ReadU32(); // Magic
+    blockSize    = br.ReadU32();
+    structurePos = br.position;
+}
+
+void FileReader::StartStructure(BinaryDataReader& br) {
+    structurePositions.push_back(structurePos);
+    structurePos = br.position;
+}
+
+void FileReader::EndStructure() {
+    structurePos = structurePositions.back();
+    structurePositions.pop_back();
+}
+
+void FileReader::OpenReference(BinaryDataReader& br, std::string name) {
+    references[name] = new ReferenceInfo(br);
+}
+
+void FileReader::JumpToReference(BinaryDataReader& br, std::string name) {
+    br.position = structurePos + references[name]->offset;
+}
+
+void FileReader::CloseReference(std::string name) {
+    references.erase(name);
+}
+
+void FileReader::OpenReferenceTable(BinaryDataReader& br, std::string name) {
+    referenceTables[name] = new ReferenceTableInfo(br);
+}
+
+u32 FileReader::ReferenceTableCount(std::string name) {
+    return referenceTables[name]->count;
+}
+
+void FileReader::ReferenceTableJumpToReference(BinaryDataReader& br, u32 index, std::string name) {
+    br.position = structurePos + referenceTables[name]->offsets[index];
+}
+
+void FileReader::CloseReferenceTable(std::string name) {
+    referenceTables.erase(name);
+}

--- a/source/custom_music/file_reader.hpp
+++ b/source/custom_music/file_reader.hpp
@@ -1,0 +1,44 @@
+#pragma once
+
+#include <3ds.h>
+#include <vector>
+#include <string>
+#include <unordered_map>
+
+#include "reference_structures.hpp"
+
+// Code ported from Gota7's Citric Composer
+
+class FileReader {
+  public:
+    FileReader(BinaryDataReader& br);
+    ~FileReader();
+
+    void OpenBlock(BinaryDataReader& br, u32 blockNum);
+
+    void StartStructure(BinaryDataReader& br);
+    void EndStructure();
+
+    void OpenReference(BinaryDataReader& br, std::string name);
+    void JumpToReference(BinaryDataReader& br, std::string name);
+    void CloseReference(std::string name);
+
+    void OpenReferenceTable(BinaryDataReader& br, std::string name);
+    u32 ReferenceTableCount(std::string name);
+    void ReferenceTableJumpToReference(BinaryDataReader& br, u32 index, std::string name);
+    void CloseReferenceTable(std::string name);
+
+  private:
+    std::vector<u32> blockOffsets;
+    u32 fileStartPos;
+    u32 fileSize;
+    u32 blockPos;
+    u32 blockSize;
+    u32 structurePos;
+    std::vector<u32> structurePositions;
+
+    std::unordered_map<std::string, ReferenceInfo*> references;
+    std::unordered_map<std::string, SizedReferenceInfo*> sizedReferences;
+    std::unordered_map<std::string, ReferenceTableInfo*> referenceTables;
+    std::unordered_map<std::string, SizedReferenceTableInfo*> sizedReferenceTables;
+};

--- a/source/custom_music/reference_structures.cpp
+++ b/source/custom_music/reference_structures.cpp
@@ -1,0 +1,45 @@
+#include "reference_structures.hpp"
+
+// Code ported from Gota7's Citric Composer
+
+ReferenceInfo::ReferenceInfo(BinaryDataReader& br) {
+    referenceType = br.ReadU16();
+    br.position += 2; // Padding
+    offset = br.ReadS32();
+}
+
+ReferenceInfo::~ReferenceInfo() = default;
+
+SizedReferenceInfo::SizedReferenceInfo(BinaryDataReader& br) {
+    referenceType = br.ReadU16();
+    br.position += 2; // Padding
+    offset = br.ReadS32();
+    size   = br.ReadU32();
+}
+
+SizedReferenceInfo::~SizedReferenceInfo() = default;
+
+ReferenceTableInfo::ReferenceTableInfo(BinaryDataReader& br) {
+    tablePos = br.position;
+    count    = br.ReadU32();
+    for (size_t i = 0; i < count; i++) {
+        referenceTypes.push_back(br.ReadU16());
+        br.position += 2; // Padding
+        offsets.push_back(br.ReadS32());
+    }
+}
+
+ReferenceTableInfo::~ReferenceTableInfo() = default;
+
+SizedReferenceTableInfo::SizedReferenceTableInfo(BinaryDataReader& br) {
+    tablePos = br.position;
+    count    = br.ReadU32();
+    for (size_t i = 0; i < count; i++) {
+        referenceTypes.push_back(br.ReadU16());
+        br.position += 2; // Padding
+        offsets.push_back(br.ReadS32());
+        sizes.push_back(br.ReadU32());
+    }
+}
+
+SizedReferenceTableInfo::~SizedReferenceTableInfo() = default;

--- a/source/custom_music/reference_structures.hpp
+++ b/source/custom_music/reference_structures.hpp
@@ -1,0 +1,50 @@
+#pragma once
+
+#include <3ds.h>
+#include <vector>
+
+#include "ctr_binary_data.hpp"
+
+// Code ported from Gota7's Citric Composer
+
+class ReferenceInfo {
+  public:
+    ReferenceInfo(BinaryDataReader& br);
+    ~ReferenceInfo();
+
+    u16 referenceType;
+    s32 offset;
+};
+
+class SizedReferenceInfo {
+  public:
+    SizedReferenceInfo(BinaryDataReader& br);
+    ~SizedReferenceInfo();
+
+    u16 referenceType;
+    s32 offset;
+    u32 size;
+};
+
+class ReferenceTableInfo {
+  public:
+    ReferenceTableInfo(BinaryDataReader& br);
+    ~ReferenceTableInfo();
+
+    std::vector<u16> referenceTypes;
+    std::vector<s32> offsets;
+    u32 count;
+    u32 tablePos;
+};
+
+class SizedReferenceTableInfo {
+  public:
+    SizedReferenceTableInfo(BinaryDataReader& br);
+    ~SizedReferenceTableInfo();
+
+    std::vector<u16> referenceTypes;
+    std::vector<s32> offsets;
+    std::vector<u32> sizes;
+    u32 count;
+    u32 tablePos;
+};

--- a/source/custom_music/sequence_data.cpp
+++ b/source/custom_music/sequence_data.cpp
@@ -1,0 +1,209 @@
+#include <filesystem>
+
+#include "sequence_data.hpp"
+#include "ctr_binary_data.hpp"
+#include "random.hpp"
+
+namespace fs = std::filesystem;
+
+static const std::string bcseqExtension = ".bcseq";
+static const std::string cmetaExtension = ".cmeta";
+
+// Sequence Data
+
+SequenceData::SequenceData() : dataType(DataType_Raw), rawBytesPtr(nullptr), bankNum(0), chFlags(0) {
+}
+
+SequenceData::SequenceData(std::vector<u8>* rawBytesPtr_, u32 bankNum_, u16 chFlags_)
+    : dataType(DataType_Raw), rawBytesPtr(rawBytesPtr_), bankNum(bankNum_), chFlags(chFlags_) {
+}
+
+SequenceData::SequenceData(std::string filePath_, u32 bankNum_, u16 chFlags_)
+    : dataType(DataType_Path), filePath(filePath_), bankNum(bankNum_), chFlags(chFlags_) {
+}
+
+SequenceData::~SequenceData() = default;
+
+std::vector<u8> SequenceData::GetData(FS_Archive archive_) {
+    // Pointer to original file
+    if (dataType == DataType_Raw && rawBytesPtr != nullptr) {
+        return *rawBytesPtr;
+    }
+    // External sequence, or empty data
+    else {
+        if (dataType == DataType_Path && rawBytes.empty()) {
+            BinaryDataReader br(archive_, filePath);
+            rawBytes = br.ReadAll();
+            br.Close();
+        }
+        return rawBytes;
+    }
+}
+
+u16 SequenceData::GetChFlags() {
+    return chFlags;
+}
+
+u32 SequenceData::GetBank() {
+    return bankNum;
+}
+
+// Audio Category
+
+AudioCategory::AudioCategory(std::string Name_, std::vector<AudioCategory*> children_)
+    : Name(Name_), children(children_) {
+    for (auto& child : children) {
+        child->SetParent(this);
+    }
+}
+
+AudioCategory::~AudioCategory() = default;
+
+void AudioCategory::CreateDirectories(FS_Archive sdmcArchive) {
+    FSUSER_CreateDirectory(sdmcArchive, fsMakePath(PATH_ASCII, GetFullPath().c_str()), FS_ATTRIBUTE_DIRECTORY);
+    for (auto& child : children) {
+        child->CreateDirectories(sdmcArchive);
+    }
+}
+
+std::string AudioCategory::GetFullPath() {
+    if (fullPath.empty()) {
+        std::string finalPath = Name + '/';
+        if (parent != nullptr) {
+            finalPath.insert(0, parent->GetFullPath());
+        } else {
+            finalPath.insert(0, CustomMusicRootPath);
+        }
+        fullPath = finalPath;
+    }
+    return fullPath;
+}
+
+void AudioCategory::SetParent(AudioCategory* parent_) {
+    parent = parent_;
+}
+
+bool AudioCategory::HasAncestor(AudioCategory* parent_) {
+    AudioCategory* curParent = parent;
+
+    while (curParent != nullptr) {
+        if (curParent == parent_) {
+            return true;
+        } else {
+            curParent = curParent->parent;
+        }
+    }
+
+    return false;
+}
+
+void AudioCategory::AddNewSeqData(SequenceData seqData) {
+    seqDatas.push_back(seqData);
+}
+
+void AudioCategory::AddExternalSeqDatas(FS_Archive sdmcArchive) {
+    for (const auto& bcseq : fs::directory_iterator(GetFullPath())) {
+        if (bcseq.is_regular_file() && bcseq.path().extension().string() == bcseqExtension) {
+            u8 bank     = 7;  // Set bank to Orchestra by default
+            u16 chFlags = -1; // Enable all channel flags by default
+
+            // Check for cmeta file
+            auto fileName = bcseq.path().stem().string();
+            for (const auto& cmeta : fs::directory_iterator(GetFullPath())) {
+                if (cmeta.is_regular_file() && cmeta.path().stem().string() == fileName &&
+                    cmeta.path().extension().string() == cmetaExtension) {
+
+                    BinaryDataReader br(sdmcArchive, cmeta.path().string());
+                    // Bank
+                    if (br.GetFileSize() >= 1) {
+                        bank = br.ReadByte();
+                        br.position += 3; // Only one bank can be set for now, jump over the extra bytes
+
+                        // Channel Flags
+                        if (br.GetFileSize() >= 6) {
+                            chFlags = br.ReadU16();
+                        }
+                    }
+                    br.Close();
+                    break;
+                }
+            }
+
+            seqDatas.push_back(SequenceData(bcseq.path().string(), bank, chFlags));
+        }
+    }
+    for (auto child : children) {
+        child->AddExternalSeqDatas(sdmcArchive);
+    }
+}
+
+std::vector<std::pair<AudioCategory*, SequenceData*>> AudioCategory::GetSeqDatas() {
+    std::vector<std::pair<AudioCategory*, SequenceData*>> allSoundFiles;
+    for (auto& soundFile : seqDatas) {
+        allSoundFiles.push_back(std::make_pair(this, &soundFile));
+    }
+    if (parent != nullptr) {
+        auto seqDatas = parent->GetSeqDatas();
+        allSoundFiles.insert(allSoundFiles.end(), seqDatas.begin(), seqDatas.end());
+    }
+    return allSoundFiles;
+}
+
+SequenceData AudioCategory::GetAndRemoveRandomSeqData() {
+    auto allSoundFiles = GetSeqDatas();
+
+    // All out, do nothing
+    if (allSoundFiles.empty()) {
+        return SequenceData();
+    }
+
+    auto idx = Random(0, allSoundFiles.size(), true);
+
+    auto owner      = allSoundFiles.at(idx).first;
+    auto seqDataPtr = allSoundFiles.at(idx).second;
+    auto seqData    = *seqDataPtr;
+
+    owner->RemoveSeqData(seqDataPtr);
+
+    return seqData;
+}
+
+void AudioCategory::RemoveSeqData(SequenceData* seqDataPtr) {
+    for (size_t i = 0; i < seqDatas.size(); i++) {
+        if (&seqDatas.at(i) == seqDataPtr) {
+            seqDatas.erase(seqDatas.begin() + i);
+            return;
+        }
+    }
+}
+
+void AudioCategory::ClearSeqDatas() {
+    seqDatas.clear();
+    for (auto child : children) {
+        child->ClearSeqDatas();
+    }
+}
+
+std::vector<AudioCategoryLeaf*> AudioCategory::GetAllLeaves() {
+    std::vector<AudioCategoryLeaf*> leaves;
+    for (auto child : children) {
+        // Assume child is leaf if it has no children
+        if (child->children.empty()) {
+            leaves.push_back(dynamic_cast<AudioCategoryLeaf*>(child));
+        } else {
+            auto newLeaves = child->GetAllLeaves();
+            leaves.insert(leaves.begin(), newLeaves.begin(), newLeaves.end());
+        }
+    }
+    return leaves;
+}
+
+void AudioCategory::ForDynamicCast() {
+}
+
+// AudioCategoryLeaf
+
+AudioCategoryLeaf::AudioCategoryLeaf(std::string Name_, u16 fileRep_) : AudioCategory(Name_, {}), FileRep(fileRep_) {
+}
+
+AudioCategoryLeaf::~AudioCategoryLeaf() = default;

--- a/source/custom_music/sequence_data.hpp
+++ b/source/custom_music/sequence_data.hpp
@@ -45,28 +45,29 @@ class SequenceData {
 };
 
 // Forward declaration
-class AudioCategoryLeaf;
+class MusicCategoryLeaf;
 
-class AudioCategory {
+class MusicCategoryNode {
   public:
-    AudioCategory(std::string Name_, std::vector<AudioCategory*> children_);
-    ~AudioCategory();
+    MusicCategoryNode(std::string Name_, std::vector<MusicCategoryNode*> children_);
+    ~MusicCategoryNode();
 
     /// Creates it's folder in it's parent's, and then calls each child to do the same.
     void CreateDirectories(FS_Archive sdmcArchive);
     /// Returns the full path of this node.
     std::string GetFullPath();
     /// Sets this node's parent node.
-    void SetParent(AudioCategory* parent_);
+    void SetParent(MusicCategoryNode* parent_);
     /// Returns true if this node has the given node as an ancestor.
-    bool HasAncestor(AudioCategory* ancestor);
+    bool HasAncestor(MusicCategoryNode* ancestor);
 
     /// Copies the given Sequence Data into it's vector.
     void AddNewSeqData(SequenceData seqData);
-    /// Adds all external Sequence Datas in this node's personal folder.
+    /// Adds all external Sequence Datas in this node's personal folder, and
+    /// then recursively calls it's children to do the same
     void AddExternalSeqDatas(FS_Archive sdmcArchive);
     /// Returns a vector of this node's and it's ancestor's Sequence Datas, and which node owns it.
-    std::vector<std::pair<AudioCategory*, SequenceData*>> GetSeqDatas();
+    std::vector<std::pair<MusicCategoryNode*, SequenceData*>> GetSeqDatas();
     /// Returns a random Sequence Data of this node or it's ancestors, and remove it from the owner.
     SequenceData GetAndRemoveRandomSeqData();
     /// Removes the Sequence Data in the vector matching the address, if found.
@@ -74,14 +75,14 @@ class AudioCategory {
     /// Clears the Sequence Data vector.
     void ClearSeqDatas();
 
-    /// Returns all leaves in this node.
-    std::vector<AudioCategoryLeaf*> GetAllLeaves();
+    /// Returns all leaves in this node's children.
+    std::vector<MusicCategoryLeaf*> GetAllLeaves();
 
     const std::string Name;
 
   protected:
-    AudioCategory* parent = nullptr;
-    std::vector<AudioCategory*> children;
+    MusicCategoryNode* parent = nullptr;
+    std::vector<MusicCategoryNode*> children;
     std::vector<SequenceData> seqDatas;
 
     std::string fullPath;
@@ -90,10 +91,10 @@ class AudioCategory {
     virtual void ForDynamicCast();
 };
 
-class AudioCategoryLeaf : public AudioCategory {
+class MusicCategoryLeaf : public MusicCategoryNode {
   public:
-    AudioCategoryLeaf(std::string Name_, u16 fileRep_);
-    ~AudioCategoryLeaf();
+    MusicCategoryLeaf(std::string Name_, u16 fileRep_);
+    ~MusicCategoryLeaf();
 
     /// ID of which file this node represents.
     const u16 FileRep;

--- a/source/custom_music/sequence_data.hpp
+++ b/source/custom_music/sequence_data.hpp
@@ -9,8 +9,8 @@ static const std::string CustomMusicRootPath = "/OoT3DR/Custom Music/";
 class SequenceData {
   public:
     SequenceData();
-    SequenceData(std::vector<u8>* rawBytesPtr_, u32 bankNum_, u16 chFlags_);
-    SequenceData(std::string filePath_, u32 bankNum_, u16 chFlags_);
+    SequenceData(std::vector<u8>* rawBytesPtr_, u32 bankNum_, u16 chFlags_, u8 volume_);
+    SequenceData(std::string filePath_, u32 bankNum_, u16 chFlags_, u8 volume_);
     ~SequenceData();
 
     /// Returns the raw bytes of the sequence.
@@ -19,10 +19,12 @@ class SequenceData {
     /// - PATH Type: Returns the raw bytes of the external sequence.
     ///   Reads the file only the first time this is called.
     std::vector<u8> GetData(FS_Archive archive_);
-    /// Returns the bits of the set flags.
-    u16 GetChFlags();
     /// Returns the bank index.
     u32 GetBank();
+    /// Returns the bits of the set flags.
+    u16 GetChFlags();
+    /// Returns the volume.
+    u8 GetVolume();
 
   private:
     enum DataType {
@@ -42,6 +44,7 @@ class SequenceData {
 
     u32 bankNum;
     u16 chFlags;
+    u8 volume;
 };
 
 // Forward declaration

--- a/source/custom_music/sequence_data.hpp
+++ b/source/custom_music/sequence_data.hpp
@@ -1,0 +1,100 @@
+#pragma once
+
+#include <3ds.h>
+#include <vector>
+#include <string>
+
+static const std::string CustomMusicRootPath = "/OoT3DR/Custom Music/";
+
+class SequenceData {
+  public:
+    SequenceData();
+    SequenceData(std::vector<u8>* rawBytesPtr_, u32 bankNum_, u16 chFlags_);
+    SequenceData(std::string filePath_, u32 bankNum_, u16 chFlags_);
+    ~SequenceData();
+
+    /// Returns the raw bytes of the sequence.
+    /// - RAW Type: Dereferences and returns a copy.
+    ///   If this Sequence Data is empty, returns an empty byte vector.
+    /// - PATH Type: Returns the raw bytes of the external sequence.
+    ///   Reads the file only the first time this is called.
+    std::vector<u8> GetData(FS_Archive archive_);
+    /// Returns the bits of the set flags.
+    u16 GetChFlags();
+    /// Returns the bank index.
+    u32 GetBank();
+
+  private:
+    enum DataType {
+        DataType_Raw,
+        DataType_Path,
+    };
+
+    DataType dataType;
+
+    /// RAW Type: Pointer to original sequence in the sound archive
+    std::vector<u8>* rawBytesPtr;
+
+    /// PATH Type: The full path to the external sequence
+    std::string filePath;
+    /// PATH Type: The raw bytes of the external sequence
+    std::vector<u8> rawBytes;
+
+    u32 bankNum;
+    u16 chFlags;
+};
+
+// Forward declaration
+class AudioCategoryLeaf;
+
+class AudioCategory {
+  public:
+    AudioCategory(std::string Name_, std::vector<AudioCategory*> children_);
+    ~AudioCategory();
+
+    /// Creates it's folder in it's parent's, and then calls each child to do the same.
+    void CreateDirectories(FS_Archive sdmcArchive);
+    /// Returns the full path of this node.
+    std::string GetFullPath();
+    /// Sets this node's parent node.
+    void SetParent(AudioCategory* parent_);
+    /// Returns true if this node has the given node as an ancestor.
+    bool HasAncestor(AudioCategory* ancestor);
+
+    /// Copies the given Sequence Data into it's vector.
+    void AddNewSeqData(SequenceData seqData);
+    /// Adds all external Sequence Datas in this node's personal folder.
+    void AddExternalSeqDatas(FS_Archive sdmcArchive);
+    /// Returns a vector of this node's and it's ancestor's Sequence Datas, and which node owns it.
+    std::vector<std::pair<AudioCategory*, SequenceData*>> GetSeqDatas();
+    /// Returns a random Sequence Data of this node or it's ancestors, and remove it from the owner.
+    SequenceData GetAndRemoveRandomSeqData();
+    /// Removes the Sequence Data in the vector matching the address, if found.
+    void RemoveSeqData(SequenceData* seqDataPtr);
+    /// Clears the Sequence Data vector.
+    void ClearSeqDatas();
+
+    /// Returns all leaves in this node.
+    std::vector<AudioCategoryLeaf*> GetAllLeaves();
+
+    const std::string Name;
+
+  protected:
+    AudioCategory* parent = nullptr;
+    std::vector<AudioCategory*> children;
+    std::vector<SequenceData> seqDatas;
+
+    std::string fullPath;
+
+    /// Exists only to allow dynamic_cast
+    virtual void ForDynamicCast();
+};
+
+class AudioCategoryLeaf : public AudioCategory {
+  public:
+    AudioCategoryLeaf(std::string Name_, u16 fileRep_);
+    ~AudioCategoryLeaf();
+
+    /// ID of which file this node represents.
+    const u16 FileRep;
+};

--- a/source/custom_music/sound_archive.cpp
+++ b/source/custom_music/sound_archive.cpp
@@ -1,0 +1,237 @@
+#include "sound_archive.hpp"
+#include "ctr_binary_data.hpp"
+#include "reference_structures.hpp"
+#include "file_reader.hpp"
+#include "common_structures.hpp"
+
+SoundArchive::SoundArchive(FS_Archive archive_, const std::string& filePath_) {
+    BinaryDataReader br(archive_, filePath_);
+
+    if (!br.SuccessfullyInitialized()) {
+        return;
+    }
+
+    // HEADER
+    sarHeader.magic      = br.ReadChars(4);
+    sarHeader.byteOrder  = br.ReadU16();
+    sarHeader.headerSize = br.ReadU16();
+    sarHeader.version    = br.ReadU32();
+    sarHeader.fileSize   = br.ReadU32();
+
+    sarHeader.numBlocks = br.ReadU16();
+    br.position += 2; // Padding
+    for (size_t i = 0; i < sarHeader.numBlocks; i++) {
+        sarHeader.blockOffsets.push_back(SizedReferenceInfo(br));
+    }
+
+    // HEADER + BLOCKS
+    br.position = 0;
+    mainHeader  = br.ReadBytes(64);
+
+    br.position = sarHeader.blockOffsets[STRING_BLOCK].offset;
+    stringBlock = br.ReadBytes(sarHeader.blockOffsets[STRING_BLOCK].size);
+
+    br.position = sarHeader.blockOffsets[INFO_BLOCK].offset;
+    infoBlock   = br.ReadBytes(sarHeader.blockOffsets[INFO_BLOCK].size);
+
+    br.position = sarHeader.blockOffsets[FILE_BLOCK].offset;
+    // The file block will be created from a vector of raw bytes.
+
+    // Get file reference offsets and sequence info offsets
+    {
+        br.position = 0;
+        FileReader fileReader(br);
+        fileReader.OpenBlock(br, 1);
+
+        fileReader.OpenReference(br, "SoundRefTableRef");
+        fileReader.OpenReference(br, "SoundGroupRefTableRef");
+        fileReader.OpenReference(br, "BankRefTableRef");
+        fileReader.OpenReference(br, "WaveArchiveRefTableRef");
+        fileReader.OpenReference(br, "GroupRefTableRef");
+        fileReader.OpenReference(br, "PlayerRefTableRef");
+        fileReader.OpenReference(br, "FileRefTableRef");
+        fileReader.OpenReference(br, "ProjectInfo");
+
+        // File Reference Offsets
+        fileReader.JumpToReference(br, "FileRefTableRef");
+        fileReader.StartStructure(br);
+        fileReader.OpenReferenceTable(br, "SoundGroupRefTable");
+        for (size_t i = 0; i < fileReader.ReferenceTableCount("SoundGroupRefTable"); i++) {
+            fileReader.ReferenceTableJumpToReference(br, i, "SoundGroupRefTable");
+            fileReader.StartStructure(br);
+            fileReader.OpenReference(br, "FileRef");
+            fileReader.JumpToReference(br, "FileRef");
+            fileReader.StartStructure(br);
+
+            fileRefGlobalOffsets.push_back(br.position);
+            fileRefs.push_back(SizedReferenceInfo(br));
+
+            fileReader.EndStructure();
+            fileReader.CloseReference("FileRef");
+            fileReader.EndStructure();
+        }
+        fileReader.CloseReferenceTable("SoundGroupRefTable");
+        fileReader.EndStructure();
+
+        // Sequence Info Offsets
+        fileReader.JumpToReference(br, "SoundRefTableRef");
+        fileReader.StartStructure(br);
+        fileReader.OpenReferenceTable(br, "SoundRefTable");
+
+        // Read the info of the music sequences
+        for (size_t i = 1413; i <= 1497; i++) {
+            fileReader.ReferenceTableJumpToReference(br, i, "SoundRefTable");
+            fileReader.StartStructure(br);
+
+            br.position += 4; // File ID
+            br.position += 4; // ID
+            br.position += 1; // Volume
+            br.position += 1; // Remote Filter
+            br.position += 2; // Padding
+
+            fileReader.OpenReference(br, "DetSoundRef");
+            {
+                fileReader.JumpToReference(br, "DetSoundRef");
+                fileReader.StartStructure(br);
+                fileReader.OpenReference(br, "BnkTableRef");
+
+                // Skip the dummy sequence
+                if (i != 1483) {
+                    chFlagsGlobalOffsets.push_back(br.position);
+                    originalChFlags.push_back(br.ReadU16());
+                }
+
+                fileReader.JumpToReference(br, "BnkTableRef");
+                br.position += 4;
+
+                // Skip the dummy sequence
+                if (i != 1483) {
+                    seqBnkGlobalOffsets.push_back(br.position);
+                    originalBanks.push_back(br.ReadU32() & 0xFF'FF'FF);
+                }
+
+                fileReader.EndStructure();
+            }
+
+            fileReader.EndStructure();
+        }
+
+        fileReader.CloseReferenceTable("SoundRefTable");
+        fileReader.EndStructure();
+    }
+
+    // Store the files themselves
+    for (size_t i = 0; i < fileRefs.size(); i++) {
+        br.position = sarHeader.blockOffsets[FILE_BLOCK].offset + fileRefs[i].offset + 8;
+        rawFiles.push_back(br.ReadBytes(fileRefs[i].size));
+    }
+
+    br.Close();
+    init = true;
+
+    newFiles = rawFiles;
+
+    originalChFlags.insert(originalChFlags.begin(), 9, -1);
+    originalBanks.insert(originalBanks.begin(), 9, -1);
+
+    newChFlags = originalChFlags;
+    newBanks   = originalBanks;
+}
+
+SoundArchive::~SoundArchive() = default;
+
+bool SoundArchive::SuccessfullyInitialized() {
+    return init;
+}
+
+std::vector<u8>* SoundArchive::GetRawFilePtr(u16 index) {
+    return &rawFiles.at(index);
+}
+
+u16 SoundArchive::GetOriginalChFlags(u16 index) {
+    return originalChFlags.at(index);
+}
+
+u32 SoundArchive::GetOriginalBank(u16 index) {
+    return originalBanks.at(index);
+}
+
+void SoundArchive::ReplaceSeq(FS_Archive archive_, u16 fileIndex, SequenceData& seqData) {
+    if (seqData.GetData(archive_).empty()) {
+        // Empty received, no change
+        return;
+    }
+    newFiles.at(fileIndex)   = seqData.GetData(archive_);
+    newChFlags.at(fileIndex) = seqData.GetChFlags();
+    newBanks.at(fileIndex)   = seqData.GetBank();
+}
+
+void SoundArchive::Write(FS_Archive archive_, const std::string& filePath_) {
+    BinaryDataWriter bw(archive_, filePath_);
+
+    if (!bw.SuccessfullyInitialized()) {
+        return;
+    }
+
+    const auto bwAlign = [&](u32 alignment) {
+        while (bw.position % alignment != 0) {
+            bw.Write((u8)0);
+        }
+    };
+
+    bw.position = 0;
+    bw.Write(mainHeader);
+
+    bw.position = sarHeader.blockOffsets[STRING_BLOCK].offset;
+    bw.Write(stringBlock);
+
+    bw.position = sarHeader.blockOffsets[INFO_BLOCK].offset;
+    bw.Write(infoBlock);
+
+    // File Block
+    bw.position = sarHeader.blockOffsets[FILE_BLOCK].offset;
+    bw.Write(std::vector<char>{ 'F', 'I', 'L', 'E' });
+    bw.position += 4;
+    u32 offsetStartPos = bw.position;
+    bw.position += 24;
+
+    u32 fileBlockSize = 24; // Alignment + Files...
+    u32 lastPos       = bw.position;
+    for (size_t i = 0; i < rawFiles.size(); i++) {
+        // Write new ref
+        u32 tmpPos  = bw.position;
+        bw.position = fileRefGlobalOffsets.at(i) + 4;
+        bw.Write((s32)(tmpPos - offsetStartPos)); // Offset
+        bw.Write((u32)newFiles.at(i).size());     // Size
+        bw.position = tmpPos;
+
+        // Write file
+        bw.Write(newFiles.at(i));
+        bwAlign(0x20);
+
+        // Calculate new size
+        fileBlockSize += bw.position - lastPos;
+        lastPos = bw.position;
+
+        // Set channel flags and bank for sequences
+        if (i >= 9 && i <= 92) {
+            tmpPos      = bw.position;
+            bw.position = chFlagsGlobalOffsets.at(i - 9);
+            bw.Write((u16)newChFlags.at(i));
+            bw.position = seqBnkGlobalOffsets.at(i - 9);
+            bw.Write((u32)((3 << 24) | (newBanks.at(i) & 0xFF'FF'FF)));
+            bw.position = tmpPos;
+        }
+    }
+    // Write size of file block
+    bw.position = sarHeader.blockOffsets[FILE_BLOCK].offset + 4;
+    bw.Write(fileBlockSize);
+
+    // Write new header values
+    bw.position = 0xC;
+    bw.Write(sarHeader.blockOffsets[FILE_BLOCK].offset + fileBlockSize);
+    bw.position = 0x34;
+    bw.Write(fileBlockSize);
+
+    bw.Close();
+}

--- a/source/custom_music/sound_archive.hpp
+++ b/source/custom_music/sound_archive.hpp
@@ -1,0 +1,64 @@
+#pragma once
+
+#include <3ds.h>
+#include <string>
+#include <vector>
+
+#include "reference_structures.hpp"
+#include "sequence_data.hpp"
+
+#define STRING_BLOCK 0
+#define INFO_BLOCK 1
+#define FILE_BLOCK 2
+
+class SoundArchive {
+  public:
+    SoundArchive(FS_Archive archive_, const std::string& filePath_);
+    ~SoundArchive();
+
+    /// Returns true if the original archive was properly open and read.
+    bool SuccessfullyInitialized();
+
+    /// Returns a pointer to the original file.
+    std::vector<u8>* GetRawFilePtr(u16 index);
+    /// Returns the channel flags of the original sequence at the given file index.
+    u16 GetOriginalChFlags(u16 index);
+    /// Returns the bank index of the original sequence at the given file index.
+    u32 GetOriginalBank(u16 index);
+    /// Replaces a sequence in the files-to-write vector.
+    void ReplaceSeq(FS_Archive archive_, u16 fileIndex, SequenceData& seqData);
+
+    /// Writes the new archive to the given directory.
+    void Write(FS_Archive archive_, const std::string& filePath_);
+
+  private:
+    bool init = false;
+
+    struct SarHeader {
+        std::vector<char> magic;
+        u16 byteOrder;
+        u16 headerSize;
+        u32 version;
+        u32 fileSize;
+        u16 numBlocks;
+        std::vector<SizedReferenceInfo> blockOffsets;
+    } sarHeader;
+
+    std::vector<u8> mainHeader;
+    std::vector<u8> stringBlock;
+    std::vector<u8> infoBlock;
+    // std::vector<u8> fileBlock;
+
+    std::vector<SizedReferenceInfo> fileRefs;
+    std::vector<u16> originalChFlags;
+    std::vector<u32> originalBanks;
+    std::vector<std::vector<u8>> rawFiles;
+
+    std::vector<u32> fileRefGlobalOffsets;
+    std::vector<u32> chFlagsGlobalOffsets;
+    std::vector<u32> seqBnkGlobalOffsets;
+
+    std::vector<u16> newChFlags;
+    std::vector<u32> newBanks;
+    std::vector<std::vector<u8>> newFiles;
+};

--- a/source/custom_music/sound_archive.hpp
+++ b/source/custom_music/sound_archive.hpp
@@ -21,6 +21,8 @@ class SoundArchive {
 
     /// Returns a pointer to the original file.
     std::vector<u8>* GetRawFilePtr(u16 index);
+    /// Returns the volume of the original sequence at the given file index.
+    u16 GetOriginalVolume(u16 index);
     /// Returns the channel flags of the original sequence at the given file index.
     u16 GetOriginalChFlags(u16 index);
     /// Returns the bank index of the original sequence at the given file index.
@@ -50,14 +52,17 @@ class SoundArchive {
     // std::vector<u8> fileBlock;
 
     std::vector<SizedReferenceInfo> fileRefs;
+    std::vector<u8> originalVolumes;
     std::vector<u16> originalChFlags;
     std::vector<u32> originalBanks;
     std::vector<std::vector<u8>> rawFiles;
 
     std::vector<u32> fileRefGlobalOffsets;
+    std::vector<u32> volumeGlobalOffsets;
     std::vector<u32> chFlagsGlobalOffsets;
     std::vector<u32> seqBnkGlobalOffsets;
 
+    std::vector<u8> newVolumes;
     std::vector<u16> newChFlags;
     std::vector<u32> newBanks;
     std::vector<std::vector<u8>> newFiles;

--- a/source/descriptions.cpp
+++ b/source/descriptions.cpp
@@ -1126,16 +1126,23 @@ string_view mirrorWorldRandomDesc     = "Whether the world is mirrored may chang
 |        SHUFFLE MUSIC         |                                                           //
 ------------------------------*/                                                           //
 string_view musicRandoDesc            = "Randomize the music in the game.";                //
-string_view shuffleBGMDesc            = "Randomize area background music, either\n"        //
-                                        "grouped into categories or all mixed together.\n" //
-                                        "The group categories are World, Event, and Battle.";
-string_view fanfaresOffDesc           = "Fanfares are not shuffled.";                      //
-string_view onlyFanfaresDesc          = "Fanfares and ocarina songs are shuffled in\n"     //
-                                        "separate pools.";                                 //
-string_view fanfaresOcarinaDesc       = "Fanfares and ocarina songs are shuffled together\n"
-                                        "in the same pool.";                               //
-string_view shuffleOcaMusicDesc       = "The music that plays back after you play an\n"    //
-                                        "ocarina song is randomized.";                     //
+string_view shuffleBGMDesc            = "Shuffle background music.\n"                      //
+                                        "Mixed allows any BGM to appear anywhere.\n"       //
+                                        "The group categories are Area Themes, Event Music,"
+                                        "and Battle Themes.\n"                             //
+                                        "\"Own\" is for Custom Music, limiting the original\n"
+                                        "music to only appear at it's original place.\n";  //
+string_view shuffleMelodiesDesc       = "Shuffle played-once music.\n"                     //
+                                        "Mixed allows any melody to appear anywhere.\n"    //
+                                        "The group categories are Fanfares,\n"             //
+                                        "and Ocarina Songs.\n"                             //
+                                        "\"Own\" is for Custom Music, limiting the original\n"
+                                        "music to only appear at it's original place.\n";  //
+string_view customMusicDesc           = "Add custom music to the pool. The sound archive\n"//
+                                        "has to be placed in the Custom Music folder.";    //
+string_view customMusicOnlyDesc       = "Excludes the game's original music from the pool.\n"
+                                        "If there's not enough custom music, the original\n"
+                                        "song with be used.";                              //
 /*------------------------------                                                           //
 |         SHUFFLE SFX          |                                                           //
 ------------------------------*/                                                           //

--- a/source/descriptions.hpp
+++ b/source/descriptions.hpp
@@ -354,10 +354,9 @@ extern string_view mirrorWorldRandomDesc;
 
 extern string_view musicRandoDesc;
 extern string_view shuffleBGMDesc;
-extern string_view fanfaresOffDesc;
-extern string_view onlyFanfaresDesc;
-extern string_view fanfaresOcarinaDesc;
-extern string_view shuffleOcaMusicDesc;
+extern string_view shuffleMelodiesDesc;
+extern string_view customMusicDesc;
+extern string_view customMusicOnlyDesc;
 
 extern string_view shuffleSFXOff;
 extern string_view shuffleSFXAll;

--- a/source/main.cpp
+++ b/source/main.cpp
@@ -5,6 +5,7 @@
 #include "item_list.hpp"
 #include "item_location.hpp"
 #include "location_access.hpp"
+#include "music.hpp"
 
 #define TICKS_PER_SEC 268123480.0
 
@@ -14,6 +15,7 @@ int main() {
     ItemTable_Init();
     LocationTable_Init();
     MenuInit();
+    Music::CreateMusicDirectories();
 
     u64 initialHoldTime = svcGetSystemTick();
     u64 intervalTime    = initialHoldTime;

--- a/source/menu.cpp
+++ b/source/menu.cpp
@@ -16,6 +16,7 @@
 #include "spoiler_log.hpp"
 #include "location_access.hpp"
 #include "debug.hpp"
+#include "music.hpp"
 
 namespace {
 bool seedChanged;
@@ -720,21 +721,37 @@ void GenerateRandomizer() {
             return;
         }
     }
-    printf("\x1b[12;10HWriting Patch...");
+
+    if (Settings::ShuffleMusic) {
+        printf("\x1b[12;10HShuffling Music...");
+        auto musicRes = Music::ShuffleMusic_Archive();
+        if (musicRes == Music::SARSHUFFLE_SUCCESS) {
+            printf("Done");
+        } else {
+            if (musicRes == Music::SARSHUFFLE_BCSAR_NOT_FOUND && !Settings::CustomMusic) {
+                // Inform that the original music shuffle system is used
+                printf("Legacy");
+            } else {
+                printf("Error %d", musicRes);
+            }
+        }
+    }
+
+    printf("\x1b[13;10HWriting Patch...");
     if (WriteAllPatches()) {
         printf("Done");
         if (Settings::PlayOption == PATCH_CONSOLE) {
-            printf("\x1b[14;10HQuit out using the home menu. Then\n");
-            printf("\x1b[15;10Henable game patching and launch OoT3D!\n");
+            printf("\x1b[15;10HQuit out using the home menu. Then\n");
+            printf("\x1b[16;10Henable game patching and launch OoT3D!\n");
         } else if (Settings::PlayOption == PATCH_CITRA) {
-            printf("\x1b[14;10HCopy code.ips, exheader.bin and romfs to\n");
-            printf("\x1b[15;10Hthe OoT3D mods folder, then launch OoT3D!\n");
+            printf("\x1b[15;10HCopy code.ips, exheader.bin and romfs to\n");
+            printf("\x1b[16;10Hthe OoT3D mods folder, then launch OoT3D!\n");
         }
 
         const auto& randomizerHash = GetRandomizerHash();
-        printf("\x1b[17;10HHash:");
+        printf("\x1b[18;10HHash:");
         for (size_t i = 0; i < randomizerHash.size(); i++) {
-            printf("\x1b[%zu;11H- %s", i + 18, randomizerHash[i].c_str());
+            printf("\x1b[%zu;11H- %s", i + 19, randomizerHash[i].c_str());
         }
     } else {
         printf("Failed\nPress Select to exit.\n");

--- a/source/music.cpp
+++ b/source/music.cpp
@@ -404,7 +404,7 @@ int ShuffleMusic_Archive() {
     if (!Settings::CustomMusicOnly) {
         const auto musicNodeAddSeq = [&sar](MusicCategoryNode& audioCat, u16 fileIdx) {
             audioCat.AddNewSeqData(SequenceData(sar.GetRawFilePtr(fileIdx), sar.GetOriginalBank(fileIdx),
-                                                sar.GetOriginalChFlags(fileIdx)));
+                                                sar.GetOriginalChFlags(fileIdx), sar.GetOriginalVolume(fileIdx)));
         };
         const auto fillNodeWithOriginals = [&](MusicCategoryNode& node) {
             for (auto leaf : allAudioCatLeaves) {

--- a/source/music.cpp
+++ b/source/music.cpp
@@ -2,6 +2,9 @@
 #include "random.hpp"
 #include <3ds.h>
 #include <cstdlib>
+#include "settings.hpp"
+#include "sound_archive.hpp"
+#include "sequence_data.hpp"
 
 namespace Music {
 // clang-format off
@@ -125,5 +128,347 @@ void ShuffleSequences(int type) {
             seqs.pop_back();
         }
     }
+}
+
+// BGM: Overworld
+static AudioCategoryLeaf acBgm_HyruleField("Hyrule Field", 9);
+static AudioCategoryLeaf acBgm_KakarikoAdult("Kakariko Adult", 11);
+static AudioCategoryLeaf acBgm_Market("Market", 15);
+static AudioCategoryLeaf acBgm_KakarikoChild("Kakariko Child", 25);
+static AudioCategoryLeaf acBgm_LonLonRanch("Lon Lon Ranch", 33);
+static AudioCategoryLeaf acBgm_GoronCity("Goron City", 34);
+static AudioCategoryLeaf acBgm_KokiriForest("Kokiri Forest", 45);
+static AudioCategoryLeaf acBgm_LostWoods("Lost Woods", 47);
+static AudioCategoryLeaf acBgm_ZorasDomain("Zora's Domain", 65);
+static AudioCategoryLeaf acBgm_GerudoValley("Gerudo Valley", 79);
+// BGM: Interiors
+static AudioCategoryLeaf acBgm_HouseTheme("House Theme", 17);
+static AudioCategoryLeaf acBgm_FairyFountain("Fairy Fountain", 26);
+static AudioCategoryLeaf acBgm_TempleTime("Temple of Time", 43);
+static AudioCategoryLeaf acBgm_Windmill("Windmill", 61);
+static AudioCategoryLeaf acBgm_ShopTheme("Shop Theme", 70);
+static AudioCategoryLeaf acBgm_GrannysPotionShop("Granny's Potion Shop", 80);
+static AudioCategoryLeaf acBgm_Underground("Underground", 83);
+// BGM: Dungeons
+static AudioCategoryLeaf acBgm_MiscDungeon("Misc Dungeon", 10);
+static AudioCategoryLeaf acBgm_InsideDekuTree("Deku Tree", 14);
+static AudioCategoryLeaf acBgm_JabuJabu("Jabu Jabu", 24);
+static AudioCategoryLeaf acBgm_FireTemple("Fire Temple", 28);
+static AudioCategoryLeaf acBgm_ForestTemple("Forest Temple", 30);
+static AudioCategoryLeaf acBgm_GanonsTower("Ganon's Tower", 32);
+static AudioCategoryLeaf acBgm_SpiritTemple("Spirit Temple", 48);
+static AudioCategoryLeaf acBgm_IceCavern("Ice Cavern", 73);
+static AudioCategoryLeaf acBgm_ShadowTemple("Shadow Temple", 76);
+static AudioCategoryLeaf acBgm_WaterTemple("Water Temple", 77);
+// BGM: Area Themes
+static AudioCategory acBgm_Overworld("Overworld", {
+                                                      &acBgm_HyruleField,
+                                                      &acBgm_KakarikoAdult,
+                                                      &acBgm_Market,
+                                                      &acBgm_KakarikoChild,
+                                                      &acBgm_LonLonRanch,
+                                                      &acBgm_GoronCity,
+                                                      &acBgm_KokiriForest,
+                                                      &acBgm_LostWoods,
+                                                      &acBgm_ZorasDomain,
+                                                      &acBgm_GerudoValley,
+                                                  });
+static AudioCategory acBgm_Interiors("Interiors", {
+                                                      &acBgm_HouseTheme,
+                                                      &acBgm_FairyFountain,
+                                                      &acBgm_TempleTime,
+                                                      &acBgm_Windmill,
+                                                      &acBgm_ShopTheme,
+                                                      &acBgm_GrannysPotionShop,
+                                                      &acBgm_Underground,
+                                                  });
+static AudioCategory acBgm_Dungeons("Dungeons", {
+                                                    &acBgm_MiscDungeon,
+                                                    &acBgm_InsideDekuTree,
+                                                    &acBgm_JabuJabu,
+                                                    &acBgm_FireTemple,
+                                                    &acBgm_ForestTemple,
+                                                    &acBgm_GanonsTower,
+                                                    &acBgm_SpiritTemple,
+                                                    &acBgm_IceCavern,
+                                                    &acBgm_ShadowTemple,
+                                                    &acBgm_WaterTemple,
+                                                });
+// BGM: Event Music
+static AudioCategoryLeaf acBgm_TitleScreen("Title Screen", 16);
+static AudioCategoryLeaf acBgm_ZeldasTheme("Zelda's Theme", 27);
+static AudioCategoryLeaf acBgm_CastleCourtyard("Castle Courtyard", 31);
+static AudioCategoryLeaf acBgm_HorseRace("Horse Race", 49);
+static AudioCategoryLeaf acBgm_IngosTheme("Ingo's Theme", 51);
+static AudioCategoryLeaf acBgm_NaviIntro("Navi Intro", 59);
+static AudioCategoryLeaf acBgm_DekuTreeTheme("Deku Tree's Theme", 60);
+static AudioCategoryLeaf acBgm_MinigameTheme01("Minigame Theme 1", 63);
+static AudioCategoryLeaf acBgm_SheiksTheme("Sheik's Theme", 64);
+static AudioCategoryLeaf acBgm_AdultLink("Adult Link", 67); // Should probably be renamed
+static AudioCategoryLeaf acBgm_GanondorfsTheme("Ganondorf's Theme", 69);
+static AudioCategoryLeaf acBgm_GoddessTheme("Goddess Theme", 71);
+static AudioCategoryLeaf acBgm_FileSelect("File Select", 72);
+static AudioCategoryLeaf acBgm_OwlsTheme("Owl's Theme", 75);
+static AudioCategoryLeaf acBgm_KotakeKoume("Kotake & Koume", 81);
+static AudioCategoryLeaf acBgm_TowerEscape("Tower Escape", 82);
+static AudioCategoryLeaf acBgm_MinigameTheme02("Minigame Theme 2", 92);
+// BGM: Battle Themes
+static AudioCategoryLeaf acBgm_Enemy("Enemy Theme", 12);
+static AudioCategoryLeaf acBgm_Boss00("Boss Theme 1", 13);
+static AudioCategoryLeaf acBgm_MiniBoss("Mini Boss", 41);
+static AudioCategoryLeaf acBgm_GanondorfBattle("Ganondorf Battle", 84);
+static AudioCategoryLeaf acBgm_GanonBattle("Ganon Battle", 85);
+static AudioCategoryLeaf acBgm_Boss01("Boss Theme 2", 91);
+// BGM: Root
+static AudioCategory acBgm_AreaThemes("Area Themes", { &acBgm_Overworld, &acBgm_Interiors, &acBgm_Dungeons });
+static AudioCategory acBgm_EventMusic("Event Music", {
+                                                         &acBgm_TitleScreen,
+                                                         &acBgm_ZeldasTheme,
+                                                         &acBgm_CastleCourtyard,
+                                                         &acBgm_HorseRace,
+                                                         &acBgm_IngosTheme,
+                                                         &acBgm_NaviIntro,
+                                                         &acBgm_DekuTreeTheme,
+                                                         &acBgm_MinigameTheme01,
+                                                         &acBgm_SheiksTheme,
+                                                         &acBgm_AdultLink,
+                                                         &acBgm_GanondorfsTheme,
+                                                         &acBgm_GoddessTheme,
+                                                         &acBgm_FileSelect,
+                                                         &acBgm_OwlsTheme,
+                                                         &acBgm_KotakeKoume,
+                                                         &acBgm_TowerEscape,
+                                                         &acBgm_MinigameTheme02,
+                                                     });
+static AudioCategory acBgm_BattleThemes("Battle Themes", {
+                                                             &acBgm_Enemy,
+                                                             &acBgm_Boss00,
+                                                             &acBgm_MiniBoss,
+                                                             &acBgm_GanondorfBattle,
+                                                             &acBgm_GanonBattle,
+                                                             &acBgm_Boss01,
+                                                         });
+// BGM
+static AudioCategory acBgm_Root("Background Music", { &acBgm_AreaThemes, &acBgm_EventMusic, &acBgm_BattleThemes });
+
+// Melodies: Item Jingles
+static AudioCategoryLeaf acMelodies_ItemGet("Item Get", 20);
+static AudioCategoryLeaf acMelodies_HeartContainerGet("Heart Container Get", 22);
+static AudioCategoryLeaf acMelodies_TreasureChestOpening("Treasure Chest Opening", 29);
+static AudioCategoryLeaf acMelodies_SpiritualStoneGet("Spiritual Stone Get", 35);
+static AudioCategoryLeaf acMelodies_SmallItemGet("Small Item Get", 42);
+static AudioCategoryLeaf acMelodies_SongLearned("Song Learned", 46);
+static AudioCategoryLeaf acMelodies_MedallionGet("Medallion Get", 52);
+// Melodies: Misc Fanfares
+static AudioCategoryLeaf acMelodies_GameOver("Game Over", 18);
+static AudioCategoryLeaf acMelodies_BossClear("Boss Clear", 19);
+static AudioCategoryLeaf acMelodies_GanonAppears("Ganon Appears", 21);
+static AudioCategoryLeaf acMelodies_EventClear("Event Clear", 44);
+static AudioCategoryLeaf acMelodies_HorseGoal("Horse Goal", 50);
+static AudioCategoryLeaf acMelodies_Appearance("Appearance", 66);
+static AudioCategoryLeaf acMelodies_MasterSword("Master Sword", 68);
+static AudioCategoryLeaf acMelodies_DoorTimeOpened("Door of Time Opened", 74);
+static AudioCategoryLeaf acMelodies_RainbowBridge("Rainbow Bridge", 78);
+// Melodies: Fanfares
+static AudioCategory acMelodies_ItemJingles("Item Jingles", {
+                                                                &acMelodies_ItemGet,
+                                                                &acMelodies_HeartContainerGet,
+                                                                &acMelodies_TreasureChestOpening,
+                                                                &acMelodies_SpiritualStoneGet,
+                                                                &acMelodies_SmallItemGet,
+                                                                &acMelodies_SongLearned,
+                                                                &acMelodies_MedallionGet,
+                                                            });
+static AudioCategory acMelodies_MiscFanfares("Misc Fanfares", {
+                                                                  &acMelodies_GameOver,
+                                                                  &acMelodies_BossClear,
+                                                                  &acMelodies_GanonAppears,
+                                                                  &acMelodies_EventClear,
+                                                                  &acMelodies_HorseGoal,
+                                                                  &acMelodies_Appearance,
+                                                                  &acMelodies_MasterSword,
+                                                                  &acMelodies_DoorTimeOpened,
+                                                                  &acMelodies_RainbowBridge,
+                                                              });
+// Melodies: Child Songs
+static AudioCategoryLeaf acMelodies_SariasSong("Saria's Song", 53);
+static AudioCategoryLeaf acMelodies_EponasSong("Epona's Song", 54);
+static AudioCategoryLeaf acMelodies_ZeldasLullaby("Zelda's Lullaby", 55);
+// static AudioCategoryLeaf acMelodies_SunsSong("Sun's Song", 56); // Still unshuffled because of bugs
+static AudioCategoryLeaf acMelodies_SongTime("Song of Time", 57);
+static AudioCategoryLeaf acMelodies_SongStorms("Song of Storms", 58);
+// Melodies: Warp Songs
+static AudioCategoryLeaf acMelodies_PreludeLight("Prelude of Light", 23);
+static AudioCategoryLeaf acMelodies_BoleroFire("Bolero of Fire", 36);
+static AudioCategoryLeaf acMelodies_MinuetForest("Minuet of Forest", 37);
+static AudioCategoryLeaf acMelodies_SerenadeWater("Serenade of Water", 38);
+static AudioCategoryLeaf acMelodies_RequiemSpirit("Requiem of Spirit", 39);
+static AudioCategoryLeaf acMelodies_NoctureShadow("Nocture of Shadow", 40);
+// Melodies: Ocarina Songs
+static AudioCategory acMelodies_ChildSongs("Child Songs", {
+                                                              &acMelodies_SariasSong,
+                                                              &acMelodies_EponasSong,
+                                                              &acMelodies_ZeldasLullaby,
+                                                              //&acMelodies_SunsSong,
+                                                              &acMelodies_SongTime,
+                                                              &acMelodies_SongStorms,
+                                                          });
+static AudioCategory acMelodies_WarpSongs("Warp Songs", {
+                                                            &acMelodies_PreludeLight,
+                                                            &acMelodies_BoleroFire,
+                                                            &acMelodies_MinuetForest,
+                                                            &acMelodies_SerenadeWater,
+                                                            &acMelodies_RequiemSpirit,
+                                                            &acMelodies_NoctureShadow,
+                                                        });
+// Melodies: Root
+static AudioCategory acMelodies_Fanfares("Fanfares", { &acMelodies_ItemJingles, &acMelodies_MiscFanfares });
+static AudioCategory acMelodies_OcarinaSongs("Ocarina Songs", { &acMelodies_ChildSongs, &acMelodies_WarpSongs });
+// Melodies
+static AudioCategory acMelodies_Root("Melodies", { &acMelodies_Fanfares, &acMelodies_OcarinaSongs });
+
+bool archiveFound     = false;
+bool musicDirsCreated = false;
+
+void CreateMusicDirectories() {
+    FS_Archive sdmcArchive;
+
+    // Open SD archive
+    if (!R_SUCCEEDED(FSUSER_OpenArchive(&sdmcArchive, ARCHIVE_SDMC, fsMakePath(PATH_EMPTY, "")))) {
+        return;
+    }
+
+    // Create all dirs
+    FSUSER_CreateDirectory(sdmcArchive, fsMakePath(PATH_ASCII, "/OoT3DR"), FS_ATTRIBUTE_DIRECTORY);
+    FSUSER_CreateDirectory(sdmcArchive, fsMakePath(PATH_ASCII, CustomMusicRootPath.c_str()), FS_ATTRIBUTE_DIRECTORY);
+    acBgm_Root.CreateDirectories(sdmcArchive);
+    acMelodies_Root.CreateDirectories(sdmcArchive);
+
+    musicDirsCreated = true;
+    FSUSER_CloseArchive(sdmcArchive);
+}
+
+int ShuffleMusic_Archive() {
+    if (!musicDirsCreated) {
+        return SARSHUFFLE_NO_DIRS;
+    }
+
+    FS_Archive sdmcArchive;
+    if (!R_SUCCEEDED(FSUSER_OpenArchive(&sdmcArchive, ARCHIVE_SDMC, fsMakePath(PATH_EMPTY, "")))) {
+        return SARSHUFFLE_SDMC_ARCHIVE_FAIL;
+    }
+
+    // Title ID
+    std::string titleId;
+    if (Settings::Region == REGION_EUR) {
+        titleId = "0004000000033600";
+    } else { // REGION_NA
+        titleId = "0004000000033500";
+    }
+
+    // Archive Paths
+    static const std::string bcsarPath    = CustomMusicRootPath + "QueenSound.bcsar";
+    static const std::string newBcsarPath = "/luma/titles/" + titleId + "/romfs/sound/QueenSound.bcsar";
+
+    // Delete previous
+    FSUSER_DeleteFile(sdmcArchive, fsMakePath(PATH_ASCII, newBcsarPath.c_str()));
+
+    // Create new archive
+    SoundArchive sar(sdmcArchive, bcsarPath);
+
+    if (!sar.SuccessfullyInitialized()) {
+        FSUSER_CloseArchive(sdmcArchive);
+        archiveFound = false;
+        return SARSHUFFLE_BCSAR_NOT_FOUND;
+    }
+    archiveFound = true;
+
+    // Clear any previous sequence data
+    acBgm_Root.ClearSeqDatas();
+    acMelodies_Root.ClearSeqDatas();
+
+    // Find all leaves of the tree
+    static std::vector<AudioCategoryLeaf*> allAudioCatLeaves;
+    if (allAudioCatLeaves.empty()) {
+        for (auto* root : { &acBgm_Root, &acMelodies_Root }) {
+            auto newLeaves = root->GetAllLeaves();
+            allAudioCatLeaves.insert(allAudioCatLeaves.begin(), newLeaves.begin(), newLeaves.end());
+        }
+    }
+
+    // Add original sequences
+    if (!Settings::CustomMusicOnly) {
+        const auto audioCatAddSeq = [&sar](AudioCategory& audioCat, u16 fileIdx) {
+            audioCat.AddNewSeqData(SequenceData(sar.GetRawFilePtr(fileIdx), sar.GetOriginalBank(fileIdx),
+                                                sar.GetOriginalChFlags(fileIdx)));
+        };
+        const auto fillNodeWithOriginals = [&](AudioCategory& node) {
+            for (auto leaf : allAudioCatLeaves) {
+                if (leaf->HasAncestor(&node)) {
+                    audioCatAddSeq(node, leaf->FileRep);
+                }
+            }
+        };
+        // BGM
+        if (Settings::ShuffleBGM.Is(SHUFFLEMUSIC_MIXED)) {
+            fillNodeWithOriginals(acBgm_Root);
+        } else if (Settings::ShuffleBGM.Is(SHUFFLEMUSIC_GROUPED)) {
+            fillNodeWithOriginals(acBgm_AreaThemes);
+            fillNodeWithOriginals(acBgm_EventMusic);
+            fillNodeWithOriginals(acBgm_BattleThemes);
+        } else if (Settings::ShuffleBGM.Is(SHUFFLEMUSIC_OWN)) {
+            for (auto leaf : allAudioCatLeaves) {
+                if (leaf->HasAncestor(&acBgm_Root)) {
+                    audioCatAddSeq(*leaf, leaf->FileRep);
+                }
+            }
+        }
+        // Melodies
+        if (Settings::ShuffleMelodies.Is(SHUFFLEMUSIC_MIXED)) {
+            fillNodeWithOriginals(acMelodies_Root);
+        } else if (Settings::ShuffleMelodies.Is(SHUFFLEMUSIC_GROUPED)) {
+            fillNodeWithOriginals(acMelodies_Fanfares);
+            fillNodeWithOriginals(acMelodies_OcarinaSongs);
+        } else if (Settings::ShuffleBGM.Is(SHUFFLEMUSIC_OWN)) {
+            for (auto leaf : allAudioCatLeaves) {
+                if (leaf->HasAncestor(&acMelodies_Root)) {
+                    audioCatAddSeq(*leaf, leaf->FileRep);
+                }
+            }
+        }
+    }
+
+    // Add external sequences
+    if (Settings::CustomMusic) {
+        acBgm_Root.AddExternalSeqDatas(sdmcArchive);
+        acMelodies_Root.AddExternalSeqDatas(sdmcArchive);
+    }
+
+    // Shuffle
+    auto leavesCopy = allAudioCatLeaves;
+    Shuffle(leavesCopy);
+    for (auto leaf : leavesCopy) {
+        auto fileId  = leaf->FileRep;
+        auto seqData = leaf->GetAndRemoveRandomSeqData();
+        if (!seqData.GetData(sdmcArchive).empty()) {
+            sar.ReplaceSeq(sdmcArchive, fileId, seqData);
+        }
+    }
+
+    // Create output dirs
+    FSUSER_CreateDirectory(sdmcArchive, fsMakePath(PATH_ASCII, "/luma"), FS_ATTRIBUTE_DIRECTORY);
+    FSUSER_CreateDirectory(sdmcArchive, fsMakePath(PATH_ASCII, "/luma/titles"), FS_ATTRIBUTE_DIRECTORY);
+    FSUSER_CreateDirectory(sdmcArchive, fsMakePath(PATH_ASCII, ("/luma/titles/" + titleId).c_str()),
+                           FS_ATTRIBUTE_DIRECTORY);
+    FSUSER_CreateDirectory(sdmcArchive, fsMakePath(PATH_ASCII, ("/luma/titles/" + titleId + "/romfs").c_str()),
+                           FS_ATTRIBUTE_DIRECTORY);
+    FSUSER_CreateDirectory(sdmcArchive, fsMakePath(PATH_ASCII, ("/luma/titles/" + titleId + "/romfs/sound").c_str()),
+                           FS_ATTRIBUTE_DIRECTORY);
+
+    // Create new archive
+    sar.Write(sdmcArchive, newBcsarPath);
+
+    FSUSER_CloseArchive(sdmcArchive);
+    return SARSHUFFLE_SUCCESS;
 }
 } // namespace Music

--- a/source/music.cpp
+++ b/source/music.cpp
@@ -131,201 +131,205 @@ void ShuffleSequences(int type) {
 }
 
 // BGM: Overworld
-static AudioCategoryLeaf acBgm_HyruleField("Hyrule Field", 9);
-static AudioCategoryLeaf acBgm_KakarikoAdult("Kakariko Adult", 11);
-static AudioCategoryLeaf acBgm_Market("Market", 15);
-static AudioCategoryLeaf acBgm_KakarikoChild("Kakariko Child", 25);
-static AudioCategoryLeaf acBgm_LonLonRanch("Lon Lon Ranch", 33);
-static AudioCategoryLeaf acBgm_GoronCity("Goron City", 34);
-static AudioCategoryLeaf acBgm_KokiriForest("Kokiri Forest", 45);
-static AudioCategoryLeaf acBgm_LostWoods("Lost Woods", 47);
-static AudioCategoryLeaf acBgm_ZorasDomain("Zora's Domain", 65);
-static AudioCategoryLeaf acBgm_GerudoValley("Gerudo Valley", 79);
+static MusicCategoryLeaf mcBgm_HyruleField("Hyrule Field", 9);
+static MusicCategoryLeaf mcBgm_KakarikoAdult("Kakariko Adult", 11);
+static MusicCategoryLeaf mcBgm_Market("Market", 15);
+static MusicCategoryLeaf mcBgm_KakarikoChild("Kakariko Child", 25);
+static MusicCategoryLeaf mcBgm_LonLonRanch("Lon Lon Ranch", 33);
+static MusicCategoryLeaf mcBgm_GoronCity("Goron City", 34);
+static MusicCategoryLeaf mcBgm_KokiriForest("Kokiri Forest", 45);
+static MusicCategoryLeaf mcBgm_LostWoods("Lost Woods", 47);
+static MusicCategoryLeaf mcBgm_ZorasDomain("Zora's Domain", 65);
+static MusicCategoryLeaf mcBgm_GerudoValley("Gerudo Valley", 79);
 // BGM: Interiors
-static AudioCategoryLeaf acBgm_HouseTheme("House Theme", 17);
-static AudioCategoryLeaf acBgm_FairyFountain("Fairy Fountain", 26);
-static AudioCategoryLeaf acBgm_TempleTime("Temple of Time", 43);
-static AudioCategoryLeaf acBgm_Windmill("Windmill", 61);
-static AudioCategoryLeaf acBgm_ShopTheme("Shop Theme", 70);
-static AudioCategoryLeaf acBgm_GrannysPotionShop("Granny's Potion Shop", 80);
-static AudioCategoryLeaf acBgm_Underground("Underground", 83);
+static MusicCategoryLeaf mcBgm_HouseTheme("House Theme", 17);
+static MusicCategoryLeaf mcBgm_FairyFountain("Fairy Fountain", 26);
+static MusicCategoryLeaf mcBgm_TempleTime("Temple of Time", 43);
+static MusicCategoryLeaf mcBgm_Windmill("Windmill", 61);
+static MusicCategoryLeaf mcBgm_ShopTheme("Shop Theme", 70);
+static MusicCategoryLeaf mcBgm_Drugstore("Drugstore", 80);
+static MusicCategoryLeaf mcBgm_Underground("Underground", 83);
 // BGM: Dungeons
-static AudioCategoryLeaf acBgm_MiscDungeon("Misc Dungeon", 10);
-static AudioCategoryLeaf acBgm_InsideDekuTree("Deku Tree", 14);
-static AudioCategoryLeaf acBgm_JabuJabu("Jabu Jabu", 24);
-static AudioCategoryLeaf acBgm_FireTemple("Fire Temple", 28);
-static AudioCategoryLeaf acBgm_ForestTemple("Forest Temple", 30);
-static AudioCategoryLeaf acBgm_GanonsTower("Ganon's Tower", 32);
-static AudioCategoryLeaf acBgm_SpiritTemple("Spirit Temple", 48);
-static AudioCategoryLeaf acBgm_IceCavern("Ice Cavern", 73);
-static AudioCategoryLeaf acBgm_ShadowTemple("Shadow Temple", 76);
-static AudioCategoryLeaf acBgm_WaterTemple("Water Temple", 77);
+static MusicCategoryLeaf mcBgm_MiscDungeon("Misc Dungeon", 10);
+static MusicCategoryLeaf mcBgm_InsideDekuTree("Deku Tree", 14);
+static MusicCategoryLeaf mcBgm_JabuJabu("Jabu Jabu", 24);
+static MusicCategoryLeaf mcBgm_FireTemple("Fire Temple", 28);
+static MusicCategoryLeaf mcBgm_ForestTemple("Forest Temple", 30);
+static MusicCategoryLeaf mcBgm_GanonsTower("Ganon's Tower", 32);
+static MusicCategoryLeaf mcBgm_SpiritTemple("Spirit Temple", 48);
+static MusicCategoryLeaf mcBgm_IceCavern("Ice Cavern", 73);
+static MusicCategoryLeaf mcBgm_ShadowTemple("Shadow Temple", 76);
+static MusicCategoryLeaf mcBgm_WaterTemple("Water Temple", 77);
 // BGM: Area Themes
-static AudioCategory acBgm_Overworld("Overworld", {
-                                                      &acBgm_HyruleField,
-                                                      &acBgm_KakarikoAdult,
-                                                      &acBgm_Market,
-                                                      &acBgm_KakarikoChild,
-                                                      &acBgm_LonLonRanch,
-                                                      &acBgm_GoronCity,
-                                                      &acBgm_KokiriForest,
-                                                      &acBgm_LostWoods,
-                                                      &acBgm_ZorasDomain,
-                                                      &acBgm_GerudoValley,
-                                                  });
-static AudioCategory acBgm_Interiors("Interiors", {
-                                                      &acBgm_HouseTheme,
-                                                      &acBgm_FairyFountain,
-                                                      &acBgm_TempleTime,
-                                                      &acBgm_Windmill,
-                                                      &acBgm_ShopTheme,
-                                                      &acBgm_GrannysPotionShop,
-                                                      &acBgm_Underground,
-                                                  });
-static AudioCategory acBgm_Dungeons("Dungeons", {
-                                                    &acBgm_MiscDungeon,
-                                                    &acBgm_InsideDekuTree,
-                                                    &acBgm_JabuJabu,
-                                                    &acBgm_FireTemple,
-                                                    &acBgm_ForestTemple,
-                                                    &acBgm_GanonsTower,
-                                                    &acBgm_SpiritTemple,
-                                                    &acBgm_IceCavern,
-                                                    &acBgm_ShadowTemple,
-                                                    &acBgm_WaterTemple,
-                                                });
+static MusicCategoryNode mcBgm_Overworld("Overworld", {
+                                                          &mcBgm_HyruleField,
+                                                          &mcBgm_KakarikoAdult,
+                                                          &mcBgm_Market,
+                                                          &mcBgm_KakarikoChild,
+                                                          &mcBgm_LonLonRanch,
+                                                          &mcBgm_GoronCity,
+                                                          &mcBgm_KokiriForest,
+                                                          &mcBgm_LostWoods,
+                                                          &mcBgm_ZorasDomain,
+                                                          &mcBgm_GerudoValley,
+                                                      });
+static MusicCategoryNode mcBgm_Interiors("Interiors", {
+                                                          &mcBgm_HouseTheme,
+                                                          &mcBgm_FairyFountain,
+                                                          &mcBgm_TempleTime,
+                                                          &mcBgm_Windmill,
+                                                          &mcBgm_ShopTheme,
+                                                          &mcBgm_Drugstore,
+                                                          &mcBgm_Underground,
+                                                      });
+static MusicCategoryNode mcBgm_Dungeons("Dungeons", {
+                                                        &mcBgm_MiscDungeon,
+                                                        &mcBgm_InsideDekuTree,
+                                                        &mcBgm_JabuJabu,
+                                                        &mcBgm_FireTemple,
+                                                        &mcBgm_ForestTemple,
+                                                        &mcBgm_GanonsTower,
+                                                        &mcBgm_SpiritTemple,
+                                                        &mcBgm_IceCavern,
+                                                        &mcBgm_ShadowTemple,
+                                                        &mcBgm_WaterTemple,
+                                                    });
 // BGM: Event Music
-static AudioCategoryLeaf acBgm_TitleScreen("Title Screen", 16);
-static AudioCategoryLeaf acBgm_ZeldasTheme("Zelda's Theme", 27);
-static AudioCategoryLeaf acBgm_CastleCourtyard("Castle Courtyard", 31);
-static AudioCategoryLeaf acBgm_HorseRace("Horse Race", 49);
-static AudioCategoryLeaf acBgm_IngosTheme("Ingo's Theme", 51);
-static AudioCategoryLeaf acBgm_NaviIntro("Navi Intro", 59);
-static AudioCategoryLeaf acBgm_DekuTreeTheme("Deku Tree's Theme", 60);
-static AudioCategoryLeaf acBgm_MinigameTheme01("Minigame Theme 1", 63);
-static AudioCategoryLeaf acBgm_SheiksTheme("Sheik's Theme", 64);
-static AudioCategoryLeaf acBgm_AdultLink("Adult Link", 67); // Should probably be renamed
-static AudioCategoryLeaf acBgm_GanondorfsTheme("Ganondorf's Theme", 69);
-static AudioCategoryLeaf acBgm_GoddessTheme("Goddess Theme", 71);
-static AudioCategoryLeaf acBgm_FileSelect("File Select", 72);
-static AudioCategoryLeaf acBgm_OwlsTheme("Owl's Theme", 75);
-static AudioCategoryLeaf acBgm_KotakeKoume("Kotake & Koume", 81);
-static AudioCategoryLeaf acBgm_TowerEscape("Tower Escape", 82);
-static AudioCategoryLeaf acBgm_MinigameTheme02("Minigame Theme 2", 92);
+static MusicCategoryLeaf mcBgm_TitleScreen("Title Screen", 16);
+static MusicCategoryLeaf mcBgm_ZeldasTheme("Zelda's Theme", 27);
+static MusicCategoryLeaf mcBgm_CastleCourtyard("Castle Courtyard", 31);
+static MusicCategoryLeaf mcBgm_HorseRace("Horse Race", 49);
+static MusicCategoryLeaf mcBgm_IngosTheme("Ingo's Theme", 51);
+static MusicCategoryLeaf mcBgm_NaviIntro("Navi Intro", 59);
+static MusicCategoryLeaf mcBgm_DekuTreeStorytime("Deku Tree Storytime", 60);
+static MusicCategoryLeaf mcBgm_MinigameTheme01("Minigame Theme 1", 63);
+static MusicCategoryLeaf mcBgm_SheiksTheme("Sheik's Theme", 64);
+static MusicCategoryLeaf mcBgm_AdultLink("Adult Link", 67);
+static MusicCategoryLeaf mcBgm_GanondorfsTheme("Ganondorf's Theme", 69);
+static MusicCategoryLeaf mcBgm_GoddessTheme("Goddess Theme", 71);
+static MusicCategoryLeaf mcBgm_FileSelect("File Select", 72);
+static MusicCategoryLeaf mcBgm_OwlsTheme("Owl's Theme", 75);
+static MusicCategoryLeaf mcBgm_KotakeKoume("Kotake & Koume", 81);
+static MusicCategoryLeaf mcBgm_TowerEscape("Tower Escape", 82);
+static MusicCategoryLeaf mcBgm_MinigameTheme02("Minigame Theme 2", 92);
+// BGM: Boss Themes
+static MusicCategoryLeaf mcBgm_Boss00("Boss Theme 1", 13);
+static MusicCategoryLeaf mcBgm_Boss01("Boss Theme 2", 91);
 // BGM: Battle Themes
-static AudioCategoryLeaf acBgm_Enemy("Enemy Theme", 12);
-static AudioCategoryLeaf acBgm_Boss00("Boss Theme 1", 13);
-static AudioCategoryLeaf acBgm_MiniBoss("Mini Boss", 41);
-static AudioCategoryLeaf acBgm_GanondorfBattle("Ganondorf Battle", 84);
-static AudioCategoryLeaf acBgm_GanonBattle("Ganon Battle", 85);
-static AudioCategoryLeaf acBgm_Boss01("Boss Theme 2", 91);
-// BGM: Root
-static AudioCategory acBgm_AreaThemes("Area Themes", { &acBgm_Overworld, &acBgm_Interiors, &acBgm_Dungeons });
-static AudioCategory acBgm_EventMusic("Event Music", {
-                                                         &acBgm_TitleScreen,
-                                                         &acBgm_ZeldasTheme,
-                                                         &acBgm_CastleCourtyard,
-                                                         &acBgm_HorseRace,
-                                                         &acBgm_IngosTheme,
-                                                         &acBgm_NaviIntro,
-                                                         &acBgm_DekuTreeTheme,
-                                                         &acBgm_MinigameTheme01,
-                                                         &acBgm_SheiksTheme,
-                                                         &acBgm_AdultLink,
-                                                         &acBgm_GanondorfsTheme,
-                                                         &acBgm_GoddessTheme,
-                                                         &acBgm_FileSelect,
-                                                         &acBgm_OwlsTheme,
-                                                         &acBgm_KotakeKoume,
-                                                         &acBgm_TowerEscape,
-                                                         &acBgm_MinigameTheme02,
-                                                     });
-static AudioCategory acBgm_BattleThemes("Battle Themes", {
-                                                             &acBgm_Enemy,
-                                                             &acBgm_Boss00,
-                                                             &acBgm_MiniBoss,
-                                                             &acBgm_GanondorfBattle,
-                                                             &acBgm_GanonBattle,
-                                                             &acBgm_Boss01,
+static MusicCategoryLeaf mcBgm_Enemy("Enemy Theme", 12);
+static MusicCategoryLeaf mcBgm_MiniBoss("Mini Boss", 41);
+static MusicCategoryNode mcBgm_BossThemes("Boss Themes", {
+                                                             &mcBgm_Boss00,
+                                                             &mcBgm_Boss01,
                                                          });
+static MusicCategoryLeaf mcBgm_GanondorfBattle("Ganondorf Battle", 84);
+static MusicCategoryLeaf mcBgm_GanonBattle("Ganon Battle", 85);
+// BGM: Root
+static MusicCategoryNode mcBgm_AreaThemes("Area Themes", { &mcBgm_Overworld, &mcBgm_Interiors, &mcBgm_Dungeons });
+static MusicCategoryNode mcBgm_EventMusic("Event Music", {
+                                                             &mcBgm_TitleScreen,
+                                                             &mcBgm_ZeldasTheme,
+                                                             &mcBgm_CastleCourtyard,
+                                                             &mcBgm_HorseRace,
+                                                             &mcBgm_IngosTheme,
+                                                             &mcBgm_NaviIntro,
+                                                             &mcBgm_DekuTreeStorytime,
+                                                             &mcBgm_MinigameTheme01,
+                                                             &mcBgm_SheiksTheme,
+                                                             &mcBgm_AdultLink,
+                                                             &mcBgm_GanondorfsTheme,
+                                                             &mcBgm_GoddessTheme,
+                                                             &mcBgm_FileSelect,
+                                                             &mcBgm_OwlsTheme,
+                                                             &mcBgm_KotakeKoume,
+                                                             &mcBgm_TowerEscape,
+                                                             &mcBgm_MinigameTheme02,
+                                                         });
+static MusicCategoryNode mcBgm_BattleThemes("Battle Themes", {
+                                                                 &mcBgm_Enemy,
+                                                                 &mcBgm_MiniBoss,
+                                                                 &mcBgm_BossThemes,
+                                                                 &mcBgm_GanondorfBattle,
+                                                                 &mcBgm_GanonBattle,
+                                                             });
 // BGM
-static AudioCategory acBgm_Root("Background Music", { &acBgm_AreaThemes, &acBgm_EventMusic, &acBgm_BattleThemes });
+static MusicCategoryNode mcBgm_Root("Background Music", { &mcBgm_AreaThemes, &mcBgm_EventMusic, &mcBgm_BattleThemes });
 
 // Melodies: Item Jingles
-static AudioCategoryLeaf acMelodies_ItemGet("Item Get", 20);
-static AudioCategoryLeaf acMelodies_HeartContainerGet("Heart Container Get", 22);
-static AudioCategoryLeaf acMelodies_TreasureChestOpening("Treasure Chest Opening", 29);
-static AudioCategoryLeaf acMelodies_SpiritualStoneGet("Spiritual Stone Get", 35);
-static AudioCategoryLeaf acMelodies_SmallItemGet("Small Item Get", 42);
-static AudioCategoryLeaf acMelodies_SongLearned("Song Learned", 46);
-static AudioCategoryLeaf acMelodies_MedallionGet("Medallion Get", 52);
+static MusicCategoryLeaf mcMelodies_ItemGet("Item Get", 20);
+static MusicCategoryLeaf mcMelodies_HeartContainerGet("Heart Container Get", 22);
+static MusicCategoryLeaf mcMelodies_TreasureChestOpening("Treasure Chest Opening", 29);
+static MusicCategoryLeaf mcMelodies_SpiritualStoneGet("Spiritual Stone Get", 35);
+static MusicCategoryLeaf mcMelodies_SmallItemGet("Small Item Get", 42);
+static MusicCategoryLeaf mcMelodies_SongLearned("Song Learned", 46);
+static MusicCategoryLeaf mcMelodies_MedallionGet("Medallion Get", 52);
 // Melodies: Misc Fanfares
-static AudioCategoryLeaf acMelodies_GameOver("Game Over", 18);
-static AudioCategoryLeaf acMelodies_BossClear("Boss Clear", 19);
-static AudioCategoryLeaf acMelodies_GanonAppears("Ganon Appears", 21);
-static AudioCategoryLeaf acMelodies_EventClear("Event Clear", 44);
-static AudioCategoryLeaf acMelodies_HorseGoal("Horse Goal", 50);
-static AudioCategoryLeaf acMelodies_Appearance("Appearance", 66);
-static AudioCategoryLeaf acMelodies_MasterSword("Master Sword", 68);
-static AudioCategoryLeaf acMelodies_DoorTimeOpened("Door of Time Opened", 74);
-static AudioCategoryLeaf acMelodies_RainbowBridge("Rainbow Bridge", 78);
+static MusicCategoryLeaf mcMelodies_GameOver("Game Over", 18);
+static MusicCategoryLeaf mcMelodies_BossClear("Boss Clear", 19);
+static MusicCategoryLeaf mcMelodies_GanonAppears("Ganon Appears", 21);
+static MusicCategoryLeaf mcMelodies_EventClear("Event Clear", 44);
+static MusicCategoryLeaf mcMelodies_HorseGoal("Horse Goal", 50);
+static MusicCategoryLeaf mcMelodies_Appearance("Appearance", 66);
+static MusicCategoryLeaf mcMelodies_MasterSword("Master Sword", 68);
+static MusicCategoryLeaf mcMelodies_DoorTimeOpened("Door of Time Opened", 74);
+static MusicCategoryLeaf mcMelodies_RainbowBridge("Rainbow Bridge", 78);
 // Melodies: Fanfares
-static AudioCategory acMelodies_ItemJingles("Item Jingles", {
-                                                                &acMelodies_ItemGet,
-                                                                &acMelodies_HeartContainerGet,
-                                                                &acMelodies_TreasureChestOpening,
-                                                                &acMelodies_SpiritualStoneGet,
-                                                                &acMelodies_SmallItemGet,
-                                                                &acMelodies_SongLearned,
-                                                                &acMelodies_MedallionGet,
-                                                            });
-static AudioCategory acMelodies_MiscFanfares("Misc Fanfares", {
-                                                                  &acMelodies_GameOver,
-                                                                  &acMelodies_BossClear,
-                                                                  &acMelodies_GanonAppears,
-                                                                  &acMelodies_EventClear,
-                                                                  &acMelodies_HorseGoal,
-                                                                  &acMelodies_Appearance,
-                                                                  &acMelodies_MasterSword,
-                                                                  &acMelodies_DoorTimeOpened,
-                                                                  &acMelodies_RainbowBridge,
-                                                              });
+static MusicCategoryNode mcMelodies_ItemJingles("Item Jingles", {
+                                                                    &mcMelodies_ItemGet,
+                                                                    &mcMelodies_HeartContainerGet,
+                                                                    &mcMelodies_TreasureChestOpening,
+                                                                    &mcMelodies_SpiritualStoneGet,
+                                                                    &mcMelodies_SmallItemGet,
+                                                                    &mcMelodies_SongLearned,
+                                                                    &mcMelodies_MedallionGet,
+                                                                });
+static MusicCategoryNode mcMelodies_MiscFanfares("Misc Fanfares", {
+                                                                      &mcMelodies_GameOver,
+                                                                      &mcMelodies_BossClear,
+                                                                      &mcMelodies_GanonAppears,
+                                                                      &mcMelodies_EventClear,
+                                                                      &mcMelodies_HorseGoal,
+                                                                      &mcMelodies_Appearance,
+                                                                      &mcMelodies_MasterSword,
+                                                                      &mcMelodies_DoorTimeOpened,
+                                                                      &mcMelodies_RainbowBridge,
+                                                                  });
 // Melodies: Child Songs
-static AudioCategoryLeaf acMelodies_SariasSong("Saria's Song", 53);
-static AudioCategoryLeaf acMelodies_EponasSong("Epona's Song", 54);
-static AudioCategoryLeaf acMelodies_ZeldasLullaby("Zelda's Lullaby", 55);
-// static AudioCategoryLeaf acMelodies_SunsSong("Sun's Song", 56); // Still unshuffled because of bugs
-static AudioCategoryLeaf acMelodies_SongTime("Song of Time", 57);
-static AudioCategoryLeaf acMelodies_SongStorms("Song of Storms", 58);
+static MusicCategoryLeaf mcMelodies_SariasSong("Saria's Song", 53);
+static MusicCategoryLeaf mcMelodies_EponasSong("Epona's Song", 54);
+static MusicCategoryLeaf mcMelodies_ZeldasLullaby("Zelda's Lullaby", 55);
+// static MusicCategoryLeaf mcMelodies_SunsSong("Sun's Song", 56); // Still unshuffled because of bugs
+static MusicCategoryLeaf mcMelodies_SongTime("Song of Time", 57);
+static MusicCategoryLeaf mcMelodies_SongStorms("Song of Storms", 58);
 // Melodies: Warp Songs
-static AudioCategoryLeaf acMelodies_PreludeLight("Prelude of Light", 23);
-static AudioCategoryLeaf acMelodies_BoleroFire("Bolero of Fire", 36);
-static AudioCategoryLeaf acMelodies_MinuetForest("Minuet of Forest", 37);
-static AudioCategoryLeaf acMelodies_SerenadeWater("Serenade of Water", 38);
-static AudioCategoryLeaf acMelodies_RequiemSpirit("Requiem of Spirit", 39);
-static AudioCategoryLeaf acMelodies_NoctureShadow("Nocture of Shadow", 40);
+static MusicCategoryLeaf mcMelodies_PreludeLight("Prelude of Light", 23);
+static MusicCategoryLeaf mcMelodies_BoleroFire("Bolero of Fire", 36);
+static MusicCategoryLeaf mcMelodies_MinuetForest("Minuet of Forest", 37);
+static MusicCategoryLeaf mcMelodies_SerenadeWater("Serenade of Water", 38);
+static MusicCategoryLeaf mcMelodies_RequiemSpirit("Requiem of Spirit", 39);
+static MusicCategoryLeaf mcMelodies_NoctureShadow("Nocture of Shadow", 40);
 // Melodies: Ocarina Songs
-static AudioCategory acMelodies_ChildSongs("Child Songs", {
-                                                              &acMelodies_SariasSong,
-                                                              &acMelodies_EponasSong,
-                                                              &acMelodies_ZeldasLullaby,
-                                                              //&acMelodies_SunsSong,
-                                                              &acMelodies_SongTime,
-                                                              &acMelodies_SongStorms,
-                                                          });
-static AudioCategory acMelodies_WarpSongs("Warp Songs", {
-                                                            &acMelodies_PreludeLight,
-                                                            &acMelodies_BoleroFire,
-                                                            &acMelodies_MinuetForest,
-                                                            &acMelodies_SerenadeWater,
-                                                            &acMelodies_RequiemSpirit,
-                                                            &acMelodies_NoctureShadow,
-                                                        });
+static MusicCategoryNode mcMelodies_ChildSongs("Child Songs", {
+                                                                  &mcMelodies_SariasSong,
+                                                                  &mcMelodies_EponasSong,
+                                                                  &mcMelodies_ZeldasLullaby,
+                                                                  //&mcMelodies_SunsSong,
+                                                                  &mcMelodies_SongTime,
+                                                                  &mcMelodies_SongStorms,
+                                                              });
+static MusicCategoryNode mcMelodies_WarpSongs("Warp Songs", {
+                                                                &mcMelodies_PreludeLight,
+                                                                &mcMelodies_BoleroFire,
+                                                                &mcMelodies_MinuetForest,
+                                                                &mcMelodies_SerenadeWater,
+                                                                &mcMelodies_RequiemSpirit,
+                                                                &mcMelodies_NoctureShadow,
+                                                            });
 // Melodies: Root
-static AudioCategory acMelodies_Fanfares("Fanfares", { &acMelodies_ItemJingles, &acMelodies_MiscFanfares });
-static AudioCategory acMelodies_OcarinaSongs("Ocarina Songs", { &acMelodies_ChildSongs, &acMelodies_WarpSongs });
+static MusicCategoryNode mcMelodies_Fanfares("Fanfares", { &mcMelodies_ItemJingles, &mcMelodies_MiscFanfares });
+static MusicCategoryNode mcMelodies_OcarinaSongs("Ocarina Songs", { &mcMelodies_ChildSongs, &mcMelodies_WarpSongs });
 // Melodies
-static AudioCategory acMelodies_Root("Melodies", { &acMelodies_Fanfares, &acMelodies_OcarinaSongs });
+static MusicCategoryNode mcMelodies_Root("Melodies", { &mcMelodies_Fanfares, &mcMelodies_OcarinaSongs });
 
 bool archiveFound     = false;
 bool musicDirsCreated = false;
@@ -341,8 +345,8 @@ void CreateMusicDirectories() {
     // Create all dirs
     FSUSER_CreateDirectory(sdmcArchive, fsMakePath(PATH_ASCII, "/OoT3DR"), FS_ATTRIBUTE_DIRECTORY);
     FSUSER_CreateDirectory(sdmcArchive, fsMakePath(PATH_ASCII, CustomMusicRootPath.c_str()), FS_ATTRIBUTE_DIRECTORY);
-    acBgm_Root.CreateDirectories(sdmcArchive);
-    acMelodies_Root.CreateDirectories(sdmcArchive);
+    mcBgm_Root.CreateDirectories(sdmcArchive);
+    mcMelodies_Root.CreateDirectories(sdmcArchive);
 
     musicDirsCreated = true;
     FSUSER_CloseArchive(sdmcArchive);
@@ -384,13 +388,13 @@ int ShuffleMusic_Archive() {
     archiveFound = true;
 
     // Clear any previous sequence data
-    acBgm_Root.ClearSeqDatas();
-    acMelodies_Root.ClearSeqDatas();
+    mcBgm_Root.ClearSeqDatas();
+    mcMelodies_Root.ClearSeqDatas();
 
     // Find all leaves of the tree
-    static std::vector<AudioCategoryLeaf*> allAudioCatLeaves;
+    static std::vector<MusicCategoryLeaf*> allAudioCatLeaves;
     if (allAudioCatLeaves.empty()) {
-        for (auto* root : { &acBgm_Root, &acMelodies_Root }) {
+        for (auto* root : { &mcBgm_Root, &mcMelodies_Root }) {
             auto newLeaves = root->GetAllLeaves();
             allAudioCatLeaves.insert(allAudioCatLeaves.begin(), newLeaves.begin(), newLeaves.end());
         }
@@ -398,41 +402,41 @@ int ShuffleMusic_Archive() {
 
     // Add original sequences
     if (!Settings::CustomMusicOnly) {
-        const auto audioCatAddSeq = [&sar](AudioCategory& audioCat, u16 fileIdx) {
+        const auto musicNodeAddSeq = [&sar](MusicCategoryNode& audioCat, u16 fileIdx) {
             audioCat.AddNewSeqData(SequenceData(sar.GetRawFilePtr(fileIdx), sar.GetOriginalBank(fileIdx),
                                                 sar.GetOriginalChFlags(fileIdx)));
         };
-        const auto fillNodeWithOriginals = [&](AudioCategory& node) {
+        const auto fillNodeWithOriginals = [&](MusicCategoryNode& node) {
             for (auto leaf : allAudioCatLeaves) {
                 if (leaf->HasAncestor(&node)) {
-                    audioCatAddSeq(node, leaf->FileRep);
+                    musicNodeAddSeq(node, leaf->FileRep);
                 }
             }
         };
         // BGM
         if (Settings::ShuffleBGM.Is(SHUFFLEMUSIC_MIXED)) {
-            fillNodeWithOriginals(acBgm_Root);
+            fillNodeWithOriginals(mcBgm_Root);
         } else if (Settings::ShuffleBGM.Is(SHUFFLEMUSIC_GROUPED)) {
-            fillNodeWithOriginals(acBgm_AreaThemes);
-            fillNodeWithOriginals(acBgm_EventMusic);
-            fillNodeWithOriginals(acBgm_BattleThemes);
+            fillNodeWithOriginals(mcBgm_AreaThemes);
+            fillNodeWithOriginals(mcBgm_EventMusic);
+            fillNodeWithOriginals(mcBgm_BattleThemes);
         } else if (Settings::ShuffleBGM.Is(SHUFFLEMUSIC_OWN)) {
             for (auto leaf : allAudioCatLeaves) {
-                if (leaf->HasAncestor(&acBgm_Root)) {
-                    audioCatAddSeq(*leaf, leaf->FileRep);
+                if (leaf->HasAncestor(&mcBgm_Root)) {
+                    musicNodeAddSeq(*leaf, leaf->FileRep);
                 }
             }
         }
         // Melodies
         if (Settings::ShuffleMelodies.Is(SHUFFLEMUSIC_MIXED)) {
-            fillNodeWithOriginals(acMelodies_Root);
+            fillNodeWithOriginals(mcMelodies_Root);
         } else if (Settings::ShuffleMelodies.Is(SHUFFLEMUSIC_GROUPED)) {
-            fillNodeWithOriginals(acMelodies_Fanfares);
-            fillNodeWithOriginals(acMelodies_OcarinaSongs);
+            fillNodeWithOriginals(mcMelodies_Fanfares);
+            fillNodeWithOriginals(mcMelodies_OcarinaSongs);
         } else if (Settings::ShuffleBGM.Is(SHUFFLEMUSIC_OWN)) {
             for (auto leaf : allAudioCatLeaves) {
-                if (leaf->HasAncestor(&acMelodies_Root)) {
-                    audioCatAddSeq(*leaf, leaf->FileRep);
+                if (leaf->HasAncestor(&mcMelodies_Root)) {
+                    musicNodeAddSeq(*leaf, leaf->FileRep);
                 }
             }
         }
@@ -440,8 +444,8 @@ int ShuffleMusic_Archive() {
 
     // Add external sequences
     if (Settings::CustomMusic) {
-        acBgm_Root.AddExternalSeqDatas(sdmcArchive);
-        acMelodies_Root.AddExternalSeqDatas(sdmcArchive);
+        mcBgm_Root.AddExternalSeqDatas(sdmcArchive);
+        mcMelodies_Root.AddExternalSeqDatas(sdmcArchive);
     }
 
     // Shuffle

--- a/source/music.hpp
+++ b/source/music.hpp
@@ -6,6 +6,11 @@
 #include <3ds.h>
 
 namespace Music {
+
+// Index Variant
+// Shuffles and replaces sequence indexes with a patch
+// Does not support custom music, but does not require the original archive to be provided
+
 const u32 BGM_BASE  = 0x1000585;
 const int SEQ_COUNT = 85;
 
@@ -27,4 +32,21 @@ extern std::array<u32, SEQ_COUNT> seqOverridesMusic;
 
 void InitMusicRandomizer();
 void ShuffleSequences(int type);
+
+// Archive Variant
+// Shuffles and replaces files in the original sound archive
+// Requires the original archive to be provided, but avoids certain bugs and supports custom music
+
+typedef enum {
+    SARSHUFFLE_SUCCESS,
+    SARSHUFFLE_NO_DIRS,
+    SARSHUFFLE_SDMC_ARCHIVE_FAIL,
+    SARSHUFFLE_BCSAR_NOT_FOUND,
+} ArchiveShuffleResult;
+
+extern bool archiveFound;
+extern bool musicDirsCreated;
+void CreateMusicDirectories();
+int ShuffleMusic_Archive();
+
 } // namespace Music

--- a/source/patch.cpp
+++ b/source/patch.cpp
@@ -407,10 +407,14 @@ bool WriteAllPatches() {
     |         rBGMOverrides          |
     ---------------------------------*/
 
-    patchOffset = V_TO_P(patchSymbols.RBGMOVERRIDES_ADDR);
-    patchSize   = sizeof(Music::seqOverridesMusic);
-    if (!WritePatch(patchOffset, patchSize, (char*)Music::seqOverridesMusic.data(), code, bytesWritten, totalRW, buf)) {
-        return false;
+    // Only write patch if index variant of music shuffle is used
+    if (!Music::archiveFound) {
+        patchOffset = V_TO_P(patchSymbols.RBGMOVERRIDES_ADDR);
+        patchSize   = sizeof(Music::seqOverridesMusic);
+        if (!WritePatch(patchOffset, patchSize, (char*)Music::seqOverridesMusic.data(), code, bytesWritten, totalRW,
+                        buf)) {
+            return false;
+        }
     }
 
     /*---------------------------------

--- a/source/settings.hpp
+++ b/source/settings.hpp
@@ -758,8 +758,9 @@ extern Option MirrorWorld;
 
 extern Option ShuffleMusic;
 extern Option ShuffleBGM;
-extern Option ShuffleFanfares;
-extern Option ShuffleOcaMusic;
+extern Option ShuffleMelodies;
+extern Option CustomMusic;
+extern Option CustomMusicOnly;
 extern Option ShuffleSFX;
 extern Option ShuffleSFXFootsteps;
 extern Option ShuffleSFXLinkVoice;


### PR DESCRIPTION
Adds a new way of shuffling music by replacing music files and recreating the sound archive. For that to be possible, the QueenSound.bcsar file has to be placed in `/OoT3DR/Custom Music/` in the SD card. 
Shuffling music this way avoids several bugs, like the wrong music playing after minibosses/minigames, at GC to LW shortcut, and the replaced enemy theme playing wrong in certain locations. (The Sun's Song bug is still present.)
If the archive isn't found, the previous music shuffle implementation will be used.

On app start, two trees of folders will be created. One for BGM and one for melodies. (Fanfares and Ocarina Songs)
Each music file has a leaf that represents it. When music is shuffled, a leaf will pick a random sequence from it's node or it's ancestors to replace the original sequence, and then remove it for any other leaf to pick.
For example, if you want a sequence to only appear in Hyrule Field, you'd place it in the Hyrule Field folder at `Custom Music/Background Music/Area Themes/Overworld/Hyrule Field/`. If you want a sequence to appear anywhere in the overworld, you'd place it in the Overworld folder. If you don't care where it appears, you would place it in the root, which for BGM is `Custom Music/Background Music/`.

On top of placing the sequence file (.bcseq) file in the folder, a `.cmeta` file can be provided to set which bank should be used, and which channel flags to set. This should have the same name (without the .bcseq extension) as the sequence file. If none is found, the bank is set to Orchestra with all channel flags enabled.

I decide to use a new directory for this in the SD Card, from root being: `/OoT3DR/`. I think we should move presets and spoiler logs here too, so it's easier to find for users. Spaces and capitalization seem to be in line with what the 3DS already uses.

There have been some slight changes to the existing music shuffle settings. Now there are only two, one for BGM and one for melodies, where you can select them to be shuffled all mixed together, in groups, or own. When set to Own, they can only appear in their original location. This is meant to be used with Custom Music.

`-fno-rtti` was removed from the make file to allow the use of `dynamic_cast`. As far as I can tell this is fine, but I can make do without it if necessary.

Special thanks to Gota7 and his work on Citric Composer, making this possible! Code ported from that has had a comment added near the top of the file.
