### PR TITLE
Fix: shop items check for custom assets object

### DIFF
--- a/code/src/actors/shops.c
+++ b/code/src/actors/shops.c
@@ -299,6 +299,7 @@ void ShopsanityItem_Init(Actor* itemx, GlobalContext* globalCtx) {
     if (Object_GetIndex(&globalCtx->objectCtx, 0x148) < 0) {
         Object_Spawn(&globalCtx->objectCtx, 0x148);
     }
+    CustomModel_Update();
 
     item->shopItemPosition = numShopItemsLoaded;
     numShopItemsLoaded++;


### PR DESCRIPTION
Shop items were not checking if the custom object was loaded before trying to use it. This usually worked anyway because the player actor initializes before shop items, and loads the object. But that doesn't happen if custom tunic colors are disabled, so now `ShopsanityItem_Init` will also check for and load the object.