### PR TITLE
Improve appearance for some age-restricted items

### DIFF
--- a/code/include/z3D/z3Dactor.h
+++ b/code/include/z3D/z3Dactor.h
@@ -46,7 +46,8 @@ typedef struct SkeletonAnimationModel {
     /* 0x04 */ char unk_04[0x08];
     /* 0x0C */ SkeletonAnimationModel_unk_0C* unk_0C;
     /* 0x10 */ SkeletonAnimationModel_unk_10* unk_10;
-    /* 0x14 */ char unk_14[0x68];
+    /* 0x14 */ void* unk_draw_struct_14;
+    /* 0x18 */ char unk_18[0x64];
     /* 0x7C */ nn_math_MTX34 mtx;
     /* 0xAC */ s8 unk_AC;
     /* 0xAD */ char unk_AD[0x03];

--- a/code/oot.ld
+++ b/code/oot.ld
@@ -884,6 +884,10 @@ SECTIONS
 		*(.patch_IncomingGetItemID)
 	}
 
+	.patch_Model_EnableMeshGroupByIndex 0x372670 : {
+		*(.patch_Model_EnableMeshGroupByIndex)
+	}
+
 	.patch_MaskSalesmanCheckNoMaskOne 0x372B64 : {
 	    *(.patch_MaskSalesmanCheckNoMask)
 	}

--- a/code/oot.ld
+++ b/code/oot.ld
@@ -276,6 +276,10 @@ SECTIONS
 		*(.patch_PlayerEditAndRetrieveCMB)
 	}
 
+	.patch_AdultItemsCMABsAsChild 0x191BB0 : {
+		*(.patch_AdultItemsCMABsAsChild)
+	}
+
 	.patch_SetChildCustomTunic 0x191DB0 : {
 		*(.patch_SetChildCustomTunic)
 	}
@@ -682,10 +686,6 @@ SECTIONS
 
 	.patch_GetCustomMessageTextOne 0x2CD3EC : {
 		*(.patch_GetCustomMessageTextOne)
-	}
-
-	.patch_ChildHoverBoots 0x2D5DF8 : {
-		*(.patch_ChildHoverBoots)
 	}
 
 	.patch_InstantTextFirstLine 0x2E049C : {
@@ -1510,10 +1510,6 @@ SECTIONS
 
 	.patch_HookshotRotation 0x4C2524 : {
 		*(.patch_HookshotRotation)
-	}
-
-	.patch_HookshotDrawRedLaser 0x4C2620 : {
-		*(.patch_HookshotDrawRedLaser)
 	}
 
 	.patch_EditDrawGetItemAfterModelSpawn 0x4C61A4 : {

--- a/code/oot_e.ld
+++ b/code/oot_e.ld
@@ -884,6 +884,10 @@ SECTIONS
 		*(.patch_IncomingGetItemID)
 	}
 
+	.patch_Model_EnableMeshGroupByIndex 0x372670 : {
+		*(.patch_Model_EnableMeshGroupByIndex)
+	}
+
 	.patch_MaskSalesmanCheckNoMaskOne 0x372B64 : {
 	    *(.patch_MaskSalesmanCheckNoMask)
 	}

--- a/code/oot_e.ld
+++ b/code/oot_e.ld
@@ -276,6 +276,10 @@ SECTIONS
 		*(.patch_PlayerEditAndRetrieveCMB)
 	}
 
+	.patch_AdultItemsCMABsAsChild 0x191BB0 : {
+		*(.patch_AdultItemsCMABsAsChild)
+	}
+
 	.patch_SetChildCustomTunic 0x191DB0 : {
 		*(.patch_SetChildCustomTunic)
 	}
@@ -682,10 +686,6 @@ SECTIONS
 
 	.patch_GetCustomMessageTextOne 0x2CD3EC : {
 		*(.patch_GetCustomMessageTextOne)
-	}
-
-	.patch_ChildHoverBoots 0x2D5DF8 : {
-		*(.patch_ChildHoverBoots)
 	}
 
 	.patch_InstantTextFirstLine 0x2E049C : {
@@ -1510,10 +1510,6 @@ SECTIONS
 
 	.patch_HookshotRotation 0x4C2524 : {
 		*(.patch_HookshotRotation)
-	}
-
-	.patch_HookshotDrawRedLaser 0x4C2620 : {
-		*(.patch_HookshotDrawRedLaser)
 	}
 
 	.patch_EditDrawGetItemAfterModelSpawn 0x4C61A4 : {

--- a/code/src/actors/hookshot.c
+++ b/code/src/actors/hookshot.c
@@ -1,6 +1,6 @@
 #include "z3D/z3D.h"
 #include "hookshot.h"
-#include "player.h"
+#include "settings.h"
 
 #define ArmsHook_Init_addr 0x1EBF84
 #define ArmsHook_Init ((ActorFunc)ArmsHook_Init_addr)
@@ -9,7 +9,7 @@
 
 void ArmsHook_rInit(Actor* thisx, GlobalContext* globalCtx) {
     ArmsHook_Init(thisx, globalCtx);
-    if (!Player_ShouldDrawHookshotParts()) {
+    if (gSaveContext.linkAge == AGE_CHILD) {
         thisx->scale.x /= 5;
         thisx->scale.y /= 5;
         thisx->scale.z /= 5;
@@ -17,5 +17,5 @@ void ArmsHook_rInit(Actor* thisx, GlobalContext* globalCtx) {
 }
 
 f32 Hookshot_GetZRotation(void) {
-    return gSaveContext.linkAge == 0 ? *HookshotRotation : -1.4; // TODO find position and lower that
+    return gSaveContext.linkAge == AGE_ADULT ? *HookshotRotation : -1.4; // TODO find position and lower that
 }

--- a/code/src/actors/player.c
+++ b/code/src/actors/player.c
@@ -166,8 +166,12 @@ f32 Player_GetSpeedMultiplier(void) {
     return speedMultiplier;
 }
 
-s32 Player_ShouldDrawHoverBootsEffect() {
-    return gSaveContext.linkAge == 0 || !gSettingsContext.hoverbootsAsChild;
+s32 Player_IsAdult() {
+    return gSaveContext.linkAge == AGE_ADULT;
+}
+
+s32 Player_ShouldApplyAdultItemsCMABs() {
+    return gSaveContext.linkAge == AGE_ADULT || gSettingsContext.hoverbootsAsChild || gSettingsContext.hookshotAsChild;
 }
 
 s32 Player_ShouldUseSlingshot() {
@@ -177,10 +181,6 @@ s32 Player_ShouldUseSlingshot() {
     } else {
         return gSaveContext.linkAge == 1 && !gSettingsContext.bowAsChild;
     }
-}
-
-s32 Player_ShouldDrawHookshotParts() {
-    return gSaveContext.linkAge == 0 || !gSettingsContext.hookshotAsChild;
 }
 
 s32 Player_CanPickUpThisActor(Actor* interactedActor) {

--- a/code/src/actors/player.c
+++ b/code/src/actors/player.c
@@ -30,17 +30,22 @@
 u16 healthDecrement = 0;
 u8 storedMask       = 0;
 
-void* Player_EditAndRetrieveCMB(ZARInfo* zarInfo, u32 objModelIdx) {
-    void* cmbMan = ZAR_GetCMBByIndex(zarInfo, objModelIdx);
+void** Player_EditAndRetrieveCMB(ZARInfo* zarInfo, u32 objModelIdx) {
+    void** cmbMan = ZAR_GetCMBByIndex(zarInfo, objModelIdx);
+    void* cmb     = *cmbMan;
 
     if (gSettingsContext.customTunicColors == ON) {
-        if (gSaveContext.linkAge == 0) {
-            void* cmb = (void*)(((char*)zarInfo->buf) + 0xDAE8);
+        if (gSaveContext.linkAge == AGE_ADULT) {
             CustomModel_EditLinkToCustomTunic(cmb);
         } else {
-            void* cmb = (void*)(((char*)zarInfo->buf) + 0xDACC);
             CustomModel_EditChildLinkToCustomTunic(cmb);
         }
+    }
+
+    if (gSettingsContext.stickAsAdult) {
+        // The unused deku stick will use the same materialIndex as the bow, to make it appear brown.
+        // This also avoids issues with its combiners being repurposed by the custom tunic patches.
+        ((char*)cmb)[0x4C52] = 5;
     }
 
     return cmbMan;

--- a/code/src/actors/player.h
+++ b/code/src/actors/player.h
@@ -9,6 +9,5 @@ void PlayerActor_rInit(Actor* thisx, GlobalContext* globalCtx);
 void PlayerActor_rUpdate(Actor* thisx, GlobalContext* globalCtx);
 void PlayerActor_rDestroy(Actor* thisx, GlobalContext* globalCtx);
 void PlayerActor_rDraw(Actor* thisx, GlobalContext* globalCtx);
-s32 Player_ShouldDrawHookshotParts(void);
 
 #endif //_PLAYER_H_

--- a/code/src/hooks.s
+++ b/code/src/hooks.s
@@ -1343,6 +1343,14 @@ hook_ChildHoverBoots:
     beq 0x2D5F04
     b 0x2D5DFC
 
+.global hook_Model_EnableMeshGroupByIndex
+hook_Model_EnableMeshGroupByIndex:
+    push {r0,r2-r12,lr}
+    bl Model_OverrideMesh
+    cpy r1,r0
+    pop {r0,r2-r12,lr}
+    b 0x4C8B8C
+
 .global hook_ArrowsOrSeeds
 hook_ArrowsOrSeeds:
     push {r0-r12, lr}

--- a/code/src/hooks.s
+++ b/code/src/hooks.s
@@ -1333,15 +1333,13 @@ hook_SavewarpSetRespawnFlag:
     mov r0,#0xFF
     bx lr
 
-.global hook_ChildHoverBoots
-hook_ChildHoverBoots:
-    beq 0x2D5F04
+.global hook_AdultItemsCMABsAsChild
+hook_AdultItemsCMABsAsChild:
     push {r0-r12, lr}
-    bl Player_ShouldDrawHoverBootsEffect
-    cmp r0,#0x0
+    bl Player_ShouldApplyAdultItemsCMABs
+    cmp r0,#0x1
     pop {r0-r12, lr}
-    beq 0x2D5F04
-    b 0x2D5DFC
+    bx lr
 
 .global hook_Model_EnableMeshGroupByIndex
 hook_Model_EnableMeshGroupByIndex:
@@ -1359,19 +1357,10 @@ hook_ArrowsOrSeeds:
     pop {r0-r12, lr}
     bx lr
 
-.global hook_HookshotDrawRedLaser
-hook_HookshotDrawRedLaser:
-    push {r0-r12, lr}
-    bl Player_ShouldDrawHookshotParts
-    cmp r0,#0x0
-    pop {r0-r12, lr}
-    bxeq lr
-    b 0x4C55C0
-
 .global hook_HookshotDrawChain
 hook_HookshotDrawChain:
     push {r0-r12, lr}
-    bl Player_ShouldDrawHookshotParts
+    bl Player_IsAdult
     cmp r0,#0x0
     pop {r0-r12, lr}
     beq 0x2202BC
@@ -1389,7 +1378,7 @@ hook_HookshotRotation:
 .global hook_LinkReflection
 hook_LinkReflection:
     push {r0-r12, lr}
-    bl Player_ShouldDrawHookshotParts
+    bl Player_IsAdult
     cmp r0,#0x1
     pop {r0-r12, lr}
     streq r1,[r0,#0x714]

--- a/code/src/models.c
+++ b/code/src/models.c
@@ -4,6 +4,8 @@
 #include "item_table.h"
 #include "objects.h"
 #include "custom_models.h"
+#include "settings.h"
+#include "common.h"
 #include <stddef.h>
 
 typedef void (*SkeletonAnimationModel_MatrixCopy_proc)(SkeletonAnimationModel* glModel, nn_math_MTX34* mtx);
@@ -326,4 +328,17 @@ s32 Model_DrawByActor(Actor* actor) {
         }
     }
     return actorDrawn;
+}
+
+u32 Model_OverrideMesh(void* unk, u32 meshGroupIndex) {
+    // When adult Link holds a deku stick, draw unused deku stick instead of shield.
+    if (IsInGameOrBossChallenge() && gSaveContext.linkAge == AGE_ADULT && gSettingsContext.stickAsAdult &&
+        PLAYER->heldItemActionParam == 6 && // holding a deku stick
+        meshGroupIndex == 23 &&             // meshGroupIndex for deku stick in child object and shield in adult object
+        unk == PLAYER->skelAnime.unk_28->unk_draw_struct_14 // check that this is for the player model
+    ) {
+        return 44; // meshGroupIndex for unused deku stick in adult object
+    }
+
+    return meshGroupIndex;
 }

--- a/code/src/patches.s
+++ b/code/src/patches.s
@@ -1718,6 +1718,11 @@ SavewarpSetRespawnFlag_patch:
 ChildHoverBoots_patch:
     b hook_ChildHoverBoots
 
+.section .patch_Model_EnableMeshGroupByIndex
+.global Model_EnableMeshGroupByIndex_patch
+Model_EnableMeshGroupByIndex_patch:
+    b hook_Model_EnableMeshGroupByIndex
+
 .section .patch_NockArrow
 .global NockArrow_patch
 NockArrow_patch:

--- a/code/src/patches.s
+++ b/code/src/patches.s
@@ -1713,10 +1713,10 @@ LHOwlEntranceOverride_patch:
 SavewarpSetRespawnFlag_patch:
     bl hook_SavewarpSetRespawnFlag
 
-.section .patch_ChildHoverBoots
-.global ChildHoverBoots_patch
-ChildHoverBoots_patch:
-    b hook_ChildHoverBoots
+.section .patch_AdultItemsCMABsAsChild
+.global AdultItemsCMABsAsChild_patch
+AdultItemsCMABsAsChild_patch:
+    bl hook_AdultItemsCMABsAsChild
 
 .section .patch_Model_EnableMeshGroupByIndex
 .global Model_EnableMeshGroupByIndex_patch
@@ -1732,11 +1732,6 @@ NockArrow_patch:
 .global DecreaseArrowCount_patch
 DecreaseArrowCount_patch:
     bl hook_ArrowsOrSeeds
-
-.section .patch_HookshotDrawRedLaser
-.global HookshotDrawRedLaser_patch
-HookshotDrawRedLaser_patch:
-    bl hook_HookshotDrawRedLaser
 
 .section .patch_HookshotDrawChain
 .global HookshotDrawChain_patch

--- a/source/descriptions.cpp
+++ b/source/descriptions.cpp
@@ -980,9 +980,9 @@ string_view ageItemsInLogicDesc       = "Using items as the wrong age may be req
 /*------------------------------                                                           //
 |    ENABLE ADULT DEKU STICK   |                                                           //
 ------------------------------*/                                                           //
-string_view adultStickDesc            = "Adult Link can wield a deku stick. In game Adult\n"
-                                        "Link will look like he's holding a Hylian Shield,\n"
-                                        "but rest assured it is a deku stick.";            //
+string_view adultStickDesc            = "Adult Link can wield a Deku Stick.\n"             //
+                                        "It will look like the N64 Deku Stick, but with a\n"
+                                        "simpler texture.";                                //
                                                                                            //
 /*------------------------------                                                           //
 |    ENABLE ADULT BOOMERANG    |                                                           //
@@ -993,6 +993,7 @@ string_view adultBoomerangDesc        = "Adult Link can throw the boomerang.";  
 |     ENABLE CHILD HAMMER      |                                                           //
 ------------------------------*/                                                           //
 string_view childHammerDesc           = "Child Link can swing the Megaton Hammer.";        //
+                                                                                           //
 /*------------------------------                                                           //
 |    ENABLE ADULT SLINGSHOT    |                                                           //
 ------------------------------*/                                                           //
@@ -1009,9 +1010,7 @@ string_view childBowDesc              = "Child Link can use the Bow. It will loo
 |    ENABLE CHILD HOOKSHOT     |                                                           //
 ------------------------------*/                                                           //
 string_view childHookshotDesc         = "Child Link can use the Hookshot/Longshot.\n"      //
-                                        "It will be difficult to aim, the red dot and\n"   //
-                                        "laser won't appear and the hook will look like\n" //
-                                        "a small bomb.";                                   //
+                                        "The hook will look like a small bomb.";           //
 /*------------------------------                                                           //
 |   ENABLE CHILD IRON BOOTS    |                                                           //
 ------------------------------*/                                                           //
@@ -1020,8 +1019,7 @@ string_view childIronBootsDesc        = "Child Link can equip the Iron Boots."; 
 /*------------------------------                                                           //
 |   ENABLE CHILD HOVER BOOTS   |                                                           //
 ------------------------------*/                                                           //
-string_view childHoverBootsDesc       = "Child Link can equip the Hover Boots. The yellow\n"
-                                        "circle beneath Link's feet won't appear.";        //
+string_view childHoverBootsDesc       = "Child Link can equip the Hover Boots.";           //
                                                                                            //
 /*------------------------------                                                           //
 |     ENABLE ADULT MASKS       |                                                           //


### PR DESCRIPTION
- Deku Sticks will appear as actual sticks even when used as adult.
Normally the game draws the Hylian Shield mesh because its ID in the adult model is the same value used for the Deku Stick mesh in the child model. But in the adult model there is also an unused mesh for an untextured N64-style Deku Stick, and once enabled with a simple patch it behaves correctly. To solve the texture issue, another hack changes its `materialIndex` to be the same as the bow mesh, so it looks wooden.

https://user-images.githubusercontent.com/82058772/219941197-bc6f0a0a-63b3-4a8a-83a4-06814461f325.mp4

<br>

- The Hookshot red laser and the Hover Boots yellow circle will appear correctly even for child Link.
When I first added the patches to enable those items as child, I looked at the draw functions to skip over the code that was causing crashes. But as it turns out, the real issue was in the init function instead: the textures for the laser and circle are CMAB files stored in the global `zelda_keep` object, so they're always loaded regardless of age; Grezzo added a (seemingly useless) age check to only apply those CMAB textures if Link is adult. So a simple patch to skip the age check is enough to make the textures draw correctly.

https://user-images.githubusercontent.com/82058772/219941391-9da7b740-41fa-44b4-9e4b-ac122d751c78.mp4

<br>

I made some attempts to improve other models too, like the hookshot tip as child, but that requires fetching data from both Link objects, which I haven't had any success with yet. So for now I thought I would PR the two things above, then we'll see if something can be figured out for the rest.