### PR TITLE
Custom Music: Allow sequences to use 4 banks

### DIFF
--- a/source/custom_music/sequence_data.cpp
+++ b/source/custom_music/sequence_data.cpp
@@ -11,15 +11,16 @@ static const std::string cmetaExtension = ".cmeta";
 
 // Sequence Data
 
-SequenceData::SequenceData() : dataType(DataType_Raw), rawBytesPtr(nullptr), bankNum(0), chFlags(0), volume(0) {
+SequenceData::SequenceData()
+    : dataType(DataType_Raw), rawBytesPtr(nullptr), banks({ 0, 0, 0, 0 }), chFlags(0), volume(0) {
 }
 
-SequenceData::SequenceData(std::vector<u8>* rawBytesPtr_, u32 bankNum_, u16 chFlags_, u8 volume_)
-    : dataType(DataType_Raw), rawBytesPtr(rawBytesPtr_), bankNum(bankNum_), chFlags(chFlags_), volume(volume_) {
+SequenceData::SequenceData(std::vector<u8>* rawBytesPtr_, std::array<u32, 4> banks_, u16 chFlags_, u8 volume_)
+    : dataType(DataType_Raw), rawBytesPtr(rawBytesPtr_), banks(banks_), chFlags(chFlags_), volume(volume_) {
 }
 
-SequenceData::SequenceData(std::string filePath_, u32 bankNum_, u16 chFlags_, u8 volume_)
-    : dataType(DataType_Path), filePath(filePath_), bankNum(bankNum_), chFlags(chFlags_), volume(volume_) {
+SequenceData::SequenceData(std::string filePath_, std::array<u32, 4> banks_, u16 chFlags_, u8 volume_)
+    : dataType(DataType_Path), filePath(filePath_), banks(banks_), chFlags(chFlags_), volume(volume_) {
 }
 
 SequenceData::~SequenceData() = default;
@@ -40,8 +41,8 @@ std::vector<u8> SequenceData::GetData(FS_Archive archive_) {
     }
 }
 
-u32 SequenceData::GetBank() {
-    return bankNum;
+std::array<u32, 4> SequenceData::GetBanks() {
+    return banks;
 }
 
 u16 SequenceData::GetChFlags() {
@@ -108,9 +109,9 @@ void MusicCategoryNode::AddNewSeqData(SequenceData seqData) {
 void MusicCategoryNode::AddExternalSeqDatas(FS_Archive sdmcArchive) {
     for (const auto& bcseq : fs::directory_iterator(GetFullPath())) {
         if (bcseq.is_regular_file() && bcseq.path().extension().string() == bcseqExtension) {
-            u8 bank     = 7;   // Set bank to Orchestra by default
-            u16 chFlags = -1;  // Enable all channel flags by default
-            u8 volume   = 127; // 100% by default
+            std::array<u32, 4> banks = { 7, 7, 7, 7 }; // Set banks to Orchestra by default
+            u16 chFlags              = -1;             // Enable all channel flags by default
+            u8 volume                = 127;            // 100% by default
 
             // Check for cmeta file
             auto fileName = bcseq.path().stem().string();
@@ -120,26 +121,27 @@ void MusicCategoryNode::AddExternalSeqDatas(FS_Archive sdmcArchive) {
 
                     BinaryDataReader br(sdmcArchive, cmeta.path().string());
                     // Bank
-                    if (br.GetFileSize() >= 1) {
-                        bank = br.ReadByte();
-                        br.position += 3; // Only one bank can be set for now, jump over the extra bytes
-
-                        // Channel Flags
-                        if (br.GetFileSize() >= 6) {
-                            chFlags = br.ReadU16();
-
-                            // Volume
-                            if (br.GetFileSize() >= 7) {
-                                volume = br.ReadByte();
-                            }
+                    for (size_t bnkIdx = 0; bnkIdx < 4; bnkIdx++) {
+                        if (br.GetFileSize() >= bnkIdx + 1) {
+                            banks[bnkIdx] = br.ReadByte();
+                        } else {
+                            break;
                         }
+                    }
+                    // Channel Flags
+                    if (br.GetFileSize() >= 6) {
+                        chFlags = br.ReadU16();
+                    }
+                    // Volume
+                    if (br.GetFileSize() >= 7) {
+                        volume = br.ReadByte();
                     }
                     br.Close();
                     break;
                 }
             }
 
-            seqDatas.push_back(SequenceData(bcseq.path().string(), bank, chFlags, volume));
+            seqDatas.push_back(SequenceData(bcseq.path().string(), banks, chFlags, volume));
         }
     }
     for (auto child : children) {

--- a/source/custom_music/sequence_data.hpp
+++ b/source/custom_music/sequence_data.hpp
@@ -3,14 +3,15 @@
 #include <3ds.h>
 #include <vector>
 #include <string>
+#include <array>
 
 static const std::string CustomMusicRootPath = "/OoT3DR/Custom Music/";
 
 class SequenceData {
   public:
     SequenceData();
-    SequenceData(std::vector<u8>* rawBytesPtr_, u32 bankNum_, u16 chFlags_, u8 volume_);
-    SequenceData(std::string filePath_, u32 bankNum_, u16 chFlags_, u8 volume_);
+    SequenceData(std::vector<u8>* rawBytesPtr_, std::array<u32, 4> banks_, u16 chFlags_, u8 volume_);
+    SequenceData(std::string filePath_, std::array<u32, 4> banks_, u16 chFlags_, u8 volume_);
     ~SequenceData();
 
     /// Returns the raw bytes of the sequence.
@@ -20,7 +21,7 @@ class SequenceData {
     ///   Reads the file only the first time this is called.
     std::vector<u8> GetData(FS_Archive archive_);
     /// Returns the bank index.
-    u32 GetBank();
+    std::array<u32, 4> GetBanks();
     /// Returns the bits of the set flags.
     u16 GetChFlags();
     /// Returns the volume.
@@ -42,7 +43,7 @@ class SequenceData {
     /// PATH Type: The raw bytes of the external sequence
     std::vector<u8> rawBytes;
 
-    u32 bankNum;
+    std::array<u32, 4> banks;
     u16 chFlags;
     u8 volume;
 };

--- a/source/custom_music/sound_archive.hpp
+++ b/source/custom_music/sound_archive.hpp
@@ -3,6 +3,7 @@
 #include <3ds.h>
 #include <string>
 #include <vector>
+#include <array>
 
 #include "reference_structures.hpp"
 #include "sequence_data.hpp"
@@ -64,6 +65,6 @@ class SoundArchive {
 
     std::vector<u8> newVolumes;
     std::vector<u16> newChFlags;
-    std::vector<u32> newBanks;
+    std::vector<std::array<u32, 4>> newBanks;
     std::vector<std::vector<u8>> newFiles;
 };

--- a/source/music.cpp
+++ b/source/music.cpp
@@ -403,7 +403,8 @@ int ShuffleMusic_Archive() {
     // Add original sequences
     if (!Settings::CustomMusicOnly) {
         const auto musicNodeAddSeq = [&sar](MusicCategoryNode& audioCat, u16 fileIdx) {
-            audioCat.AddNewSeqData(SequenceData(sar.GetRawFilePtr(fileIdx), sar.GetOriginalBank(fileIdx),
+            u32 origBank = sar.GetOriginalBank(fileIdx);
+            audioCat.AddNewSeqData(SequenceData(sar.GetRawFilePtr(fileIdx), { origBank, origBank, origBank, origBank },
                                                 sar.GetOriginalChFlags(fileIdx), sar.GetOriginalVolume(fileIdx)));
         };
         const auto fillNodeWithOriginals = [&](MusicCategoryNode& node) {


### PR DESCRIPTION
This allows custom music to use up to four different instrument banks. The extra banks have to be set in the `cmeta` file, and then can be used with the `bank_select` command.

Some songs that are affected:
- `Majora's Mask - Stone Tower Temple` will now have the background ambience.
- `Majora's Mask - Music Box House` will now play the tuba.

---

While this solution is very hacky, it does seem to work flawlessly. If any more major changes need to be done, it may be better to rewrite the entire sound archive handling instead. For me though, this was the final missing functionality. So with this, I believe there won't be much need to touch this stuff in the future.
