### PR TITLE
More Hyper Actors, adjustments, and fixes

### DIFF
--- a/code/include/z3D/z3D.h
+++ b/code/include/z3D/z3D.h
@@ -684,4 +684,7 @@ typedef void (*Model_EnableMeshGroupByIndex_proc)(SkeletonAnimationModel* skel, 
 typedef void (*Model_DisableMeshGroupByIndex_proc)(SkeletonAnimationModel* skel, u32 index);
 #define Model_DisableMeshGroupByIndex ((Model_DisableMeshGroupByIndex_proc)0x36932C)
 
+typedef s32 (*Player_InBlockingCsMode_proc)(GlobalContext* globalCtx, Player* player);
+#define Player_InBlockingCsMode ((Player_InBlockingCsMode_proc)0x35DB20)
+
 #endif //_Z3D_H_

--- a/code/include/z3D/z3Dactor.h
+++ b/code/include/z3D/z3Dactor.h
@@ -209,7 +209,9 @@ typedef struct Actor {
     /* 0x115 */ u8 targetPriority;      // Lower values have higher priority. Resets to 0 when player stops targeting
     /* 0x116 */ u16 textId;             // Text ID to pass to link/display when interacting with the actor
     /* 0x118 */ u16 freezeTimer;        // Actor does not update when set. Timer decrements automatically
-    /* 0x120 */ char unk_118[0x7];
+    /* 0x11A */ s16 colorFilterTimer;
+    /* 0x11C */ u32 colorFilterParams;
+    /* 0x120 */ char unk_120;
     /* 0x121 */ u8 isDrawn;     // Set to true if the actor is currently being drawn. Always stays false for lens actors
     /* 0x122 */ u8 unk_122;     // Set within a routine that deals with collision
     /* 0x123 */ u8 naviEnemyId; // Sets what 0600 dialog to display when talking to navi. Default 0xFF

--- a/code/oot.ld
+++ b/code/oot.ld
@@ -904,6 +904,18 @@ SECTIONS
 		*(.patch_SetSFX)
 	}
 
+	.patch_CollisionCheck_SetAC_Once 0x376174 : {
+		*(.patch_CollisionCheck_SetAC_Once)
+	}
+
+	.patch_CollisionCheck_SetAT_Once 0x3761FC : {
+		*(.patch_CollisionCheck_SetAT_Once)
+	}
+
+	.patch_CollisionCheck_SetOC_Once 0x3762B0 : {
+		*(.patch_CollisionCheck_SetOC_Once)
+	}
+
 	.patch_GKSetDurability 0x376BDC : {
 		*(.patch_GKSetDurability)
 	}
@@ -1534,8 +1546,24 @@ SECTIONS
 		*(.patch_DampeSetCollectibleFlag)
 	}
 
+	.patch_KingDodongoID 0x514594 : {
+		*(.patch_KingDodongoID)
+	}
+
+	.patch_KingDodongoFireBreathID 0x520D38 : {
+		*(.patch_KingDodongoFireBreathID)
+	}
+
 	.patch_PhantomGanonLightningID 0x523698 : {
 		*(.patch_PhantomGanonLightningID)
+	}
+
+	.patch_GohmaLarvaID 0x525F24 : {
+		*(.patch_GohmaLarvaID)
+	}
+
+	.patch_VolvagiaRockID 0x52FDB4 : {
+		*(.patch_VolvagiaRockID)
 	}
 
 	.patch_BombchuCheapestPriceOne 0x525348 : {

--- a/code/oot_e.ld
+++ b/code/oot_e.ld
@@ -904,6 +904,18 @@ SECTIONS
 		*(.patch_SetSFX)
 	}
 
+	.patch_CollisionCheck_SetAC_Once 0x376174 : {
+		*(.patch_CollisionCheck_SetAC_Once)
+	}
+
+	.patch_CollisionCheck_SetAT_Once 0x3761FC : {
+		*(.patch_CollisionCheck_SetAT_Once)
+	}
+
+	.patch_CollisionCheck_SetOC_Once 0x3762B0 : {
+		*(.patch_CollisionCheck_SetOC_Once)
+	}
+
 	.patch_GKSetDurability 0x376BDC : {
 		*(.patch_GKSetDurability)
 	}
@@ -1534,8 +1546,24 @@ SECTIONS
 		*(.patch_DampeSetCollectibleFlag)
 	}
 
+	.patch_KingDodongoID 0x514594 : {
+		*(.patch_KingDodongoID)
+	}
+
+	.patch_KingDodongoFireBreathID 0x520D38 : {
+		*(.patch_KingDodongoFireBreathID)
+	}
+
 	.patch_PhantomGanonLightningID 0x523698 : {
 		*(.patch_PhantomGanonLightningID)
+	}
+
+	.patch_GohmaLarvaID 0x525F24 : {
+		*(.patch_GohmaLarvaID)
+	}
+
+	.patch_VolvagiaRockID 0x52FDB4 : {
+		*(.patch_VolvagiaRockID)
 	}
 
 	.patch_BombchuCheapestPriceOne 0x525348 : {

--- a/code/src/actor.c
+++ b/code/src/actor.c
@@ -1,4 +1,5 @@
 #include "z3D/z3D.h"
+#include "common.h"
 #include "owl.h"
 #include "item00.h"
 #include "heart_container.h"
@@ -282,19 +283,34 @@ void TitleCard_rUpdate(GlobalContext* globalCtx, TitleCardContext* titleCtx) {
     TitleCard_Update(globalCtx, titleCtx);
 }
 
-void HyperActors(Actor* thisx, GlobalContext* globalCtx) {
+static s32 hyperActors_ExtraUpdate = 0;
+
+s32 HyperActors_GetExtraUpdate(void) {
+    return hyperActors_ExtraUpdate;
+}
+
+void HyperActors_UpdateAgain(Actor* thisx) {
+    if (thisx->colorFilterTimer > 0) {
+        thisx->colorFilterTimer--;
+    }
+    hyperActors_ExtraUpdate = 1;
+    thisx->update(thisx, gGlobalContext);
+    hyperActors_ExtraUpdate = 0;
+}
+
+void HyperActors_Main(Actor* thisx, GlobalContext* globalCtx) {
     thisx->update(thisx, globalCtx);
 
-    if (globalCtx->csCtx.state != 0 || thisx->update == NULL) {
+    if (!IsInGame() || thisx->update == NULL || (PLAYER != NULL && Player_InBlockingCsMode(globalCtx, PLAYER))) {
         return;
     }
 
     if (gSettingsContext.hyperBosses == ON) {
         if ((thisx->id == 0x28) ||                                           // Gohma
-            (thisx->id == 0x12) ||                                           // King Dodongo
+            (thisx->id == 0x27 || thisx->id == 0x30) ||                      // King Dodongo + Fire Breath
             (thisx->id == 0xBA && thisx->params == -1) ||                    // Barinade
             (thisx->id == 0x52 || thisx->id == 0x67 || thisx->id == 0x6D) || // Phantom Ganon + Horse + Lightning
-            (thisx->id == 0x96 || thisx->id == 0xA2) ||                      // Volvagia (Flying + Grounded)
+            (thisx->id == 0x96 || thisx->id == 0xA2 || thisx->id == 0xAD) || // Volvagia + Rock Attack
             (thisx->id == 0xC4) ||                                           // Morpha
             (thisx->id == 0xE9 && thisx->params == -1) ||                    // Bongo Bongo
             (thisx->id == 0xDC) ||                                           // Twinrova
@@ -308,11 +324,81 @@ void HyperActors(Actor* thisx, GlobalContext* globalCtx) {
                     if (actor == thisx || actor->update == NULL) {
                         continue;
                     }
-                    actor->update(actor, globalCtx);
+                    HyperActors_UpdateAgain(actor);
                 }
             }
+            HyperActors_UpdateAgain(thisx);
+        }
+    }
 
-            thisx->update(thisx, globalCtx);
+    if (gSettingsContext.hyperMiddleBosses == ON) {
+        if ((thisx->id == 0x2) ||   // Stalfos
+            (thisx->id == 0x33) ||  // Dark Link
+            (thisx->id == 0x91) ||  // Poe Sisters
+            (thisx->id == 0x99) ||  // Flare Dancer
+            (thisx->id == 0xA3) ||  // Flare Dancer's Fireball
+            (thisx->id == 0xA4) ||  // Dead Hand
+            (thisx->id == 0xA5) ||  // Dead Hand's Hands
+            (thisx->id == 0xAB) ||  // Flare Dancer Core
+            (thisx->id == 0xC6) ||  // Big Octo
+            (thisx->id == 0x113) || // Iron Knuckle
+            (thisx->id == 0x197)) { // Gerudo Fighter
+
+            HyperActors_UpdateAgain(thisx);
+        }
+    }
+
+    if (gSettingsContext.hyperEnemies == ON) {
+        if ((thisx->id == 0xD) ||                            // Poe & Composer Brothers
+            (thisx->id == 0xE) ||                            // Octorok
+            (thisx->id == 0x11) ||                           // Wallmaster
+            (thisx->id == 0x12) ||                           // Dodongo
+            (thisx->id == 0x13) ||                           // Keese
+            (thisx->id == 0x1B) ||                           // Tektite
+            (thisx->id == 0x1C) ||                           // Leever
+            (thisx->id == 0x1D) ||                           // Peahat
+            (thisx->id == 0x25) ||                           // Lizalfos & Dinalfos
+            (thisx->id == 0x2B) ||                           // Gohma Larva
+            (thisx->id == 0x2D) ||                           // Shabom
+            (thisx->id == 0x2F) ||                           // Baby Dodongo
+            (thisx->id == 0x34) ||                           // Biri
+            (thisx->id == 0x35) ||                           // Tailpasaran
+            (thisx->id == 0x37) ||                           // Skulltula
+            (thisx->id == 0x38) ||                           // Torch Slug
+            (thisx->id == 0x3A) ||                           // Stinger (Land)
+            (thisx->id == 0x4B) ||                           // Moblin
+            (thisx->id == 0x54 && thisx->params != 0) ||     // Armos (Enemy)
+            (thisx->id == 0x55) ||                           // Deku Baba
+            (thisx->id == 0x60) ||                           // Mad Scrub
+            (thisx->id == 0x63) ||                           // Bari
+            (thisx->id == 0x69) ||                           // Bubble
+            (thisx->id == 0x6B) ||                           // Flying Floor Tile
+            (thisx->id == 0x8A) ||                           // Beamos
+            (thisx->id == 0x8E) ||                           // Floormaster
+            (thisx->id == 0x90) ||                           // Redead & Gibdo
+            (thisx->id == 0x95) ||                           // Skullwalltula
+            (thisx->id == 0xC5) ||                           // Shell Blade
+            (thisx->id == 0xC7) ||                           // Wilted Deku Baba
+            (thisx->id == 0xDD) ||                           // Like Like
+            (thisx->id == 0xDE) ||                           // Parasitic Tentacle
+            (thisx->id == 0xE0) ||                           // Anubis
+            (thisx->id == 0xE1) ||                           // Anubis Fire
+            (thisx->id == 0xEC) ||                           // Spike Trap
+            (thisx->id == 0x115 && thisx->params == 0x3F) || // Skull Kid (Hostile)
+            (thisx->id == 0x116) ||                          // Skull Kid's Needle
+            (thisx->id == 0x11D) ||                          // Flying Pot
+            (thisx->id == 0x121) ||                          // Freezard
+            (thisx->id == 0x175) ||                          // Big Poe
+            (thisx->id == 0x18C) ||                          // Stinger (Water)
+            (thisx->id == 0x192) ||                          // Deku Scrub (Deku Tree)
+            (thisx->id == 0x193) ||                          // Deku Scrub Projectile
+            (thisx->id == 0x195) ||                          // Business Scrub (Hostile)
+            (thisx->id == 0x1AF) ||                          // Wolfos
+            (thisx->id == 0x1B0) ||                          // Stalchild
+            (thisx->id == 0x1C0) ||                          // Guay
+            (thisx->id == 0x1C1)) {                          // Door Mimic
+
+            HyperActors_UpdateAgain(thisx);
         }
     }
 }

--- a/code/src/hooks.s
+++ b/code/src/hooks.s
@@ -336,7 +336,7 @@ hook_ApplyDamageMultiplier:
 .global hook_HyperActors
 hook_HyperActors:
     push {r0-r12, lr}
-    bl HyperActors
+    bl HyperActors_Main
     pop {r0-r12, lr}
     bx lr
 
@@ -1744,6 +1744,16 @@ hook_CollisionATvsAC:
     cpy r1,r12 @ AC collider
     bl RedIce_CheckIceArrow
     pop {r0-r12,lr}
+    bx lr
+
+.global hook_CollisionCheck_SetAll_Once
+hook_CollisionCheck_SetAll_Once:
+    cpy r5,r2
+    push {r0-r12,lr}
+    bl HyperActors_GetExtraUpdate
+    cmp r0,#0x1
+    pop {r0-r12,lr}
+    addeq lr,#0x8
     bx lr
 
 .global hook_GanonDrawMasterSword

--- a/code/src/patches.s
+++ b/code/src/patches.s
@@ -923,8 +923,20 @@ SwapFaroresWind_patch:
 BombchuShopAlwaysOpen_patch:
     nop
 
+.section .patch_KingDodongoID
+    .short 0x27
+
+.section .patch_KingDodongoFireBreathID
+    .short 0x30
+
 .section .patch_PhantomGanonLightningID
     .short 0x6D
+
+.section .patch_GohmaLarvaID
+    .short 0x2B
+
+.section .patch_VolvagiaRockID
+    .short 0xAD
 
 .section .patch_BombchuCheapestPriceOne
     .word 0x0063FFFF
@@ -2040,6 +2052,21 @@ InitSceneEntranceOverride_patch:
 .global CollisionATvsAC_patch
 CollisionATvsAC_patch:
     bl hook_CollisionATvsAC
+
+.section .patch_CollisionCheck_SetAC_Once
+.global CollisionCheck_SetAC_Once_patch
+CollisionCheck_SetAC_Once_patch:
+    bl hook_CollisionCheck_SetAll_Once
+
+.section .patch_CollisionCheck_SetAT_Once
+.global CollisionCheck_SetAT_Once_patch
+CollisionCheck_SetAT_Once_patch:
+    bl hook_CollisionCheck_SetAll_Once
+
+.section .patch_CollisionCheck_SetOC_Once
+.global CollisionCheck_SetOC_Once_patch
+CollisionCheck_SetOC_Once_patch:
+    bl hook_CollisionCheck_SetAll_Once
 
 .section .patch_GanonDrawMasterSword
 .global GanonDrawMasterSword_patch

--- a/code/src/settings.h
+++ b/code/src/settings.h
@@ -325,6 +325,12 @@ typedef enum {
 } RandomTrapDamageSetting;
 
 typedef enum {
+    HYPERACTORS_OFF,
+    HYPERACTORS_ON,
+    HYPERACTORS_CHOOSE,
+} HyperActorsSetting;
+
+typedef enum {
     ITEMPOOL_MINIMAL,
     ITEMPOOL_SCARCE,
     ITEMPOOL_BALANCED,
@@ -551,6 +557,8 @@ typedef struct {
     u8 curseTraps;
     u8 extraArrowEffects;
     u8 hyperBosses;
+    u8 hyperMiddleBosses;
+    u8 hyperEnemies;
 
     u8 faroresWindAnywhere;
     u8 stickAsAdult;

--- a/source/descriptions.cpp
+++ b/source/descriptions.cpp
@@ -1219,10 +1219,19 @@ string_view extraArrowEffectsDesc     = "Ice Arrows will act like blue fire, mel
                                         "Majora's Mask.";                                  //
                                                                                            //
 /*------------------------------                                                           //
-|         HYPER BOSSES         |                                                           //
+|         HYPER ACTORS         |                                                           //
 ------------------------------*/                                                           //
-string_view hyperBossesDesc           = "Powers up all the bosses, including Ganon,\n"     //
-                                        "allowing them to act twice as fast!";             //
+string_view hyperActorsDesc           = "Powers up the selected actors, allowing them to\n"//
+                                        "move and act twice as fast!";                     //
+                                                                                           //
+string_view hyperBossesDesc           = "Affects all of the main bosses, including both\n" //
+                                        "Ganon phases.";                                   //
+                                                                                           //
+string_view hyperMiddleBossesDesc     = "Affects all middle bosses, like Dark Link and\n"  //
+                                        "Dead Hand. This also includes Iron Knuckles and\n"//
+                                        "Stalfos.";                                        //
+                                                                                           //
+string_view hyperEnemiesDesc          = "Affects all regular enemies.";                    //
                                                                                            //
                                                                                            //--------------//
 /*------------------------------                                                                           //

--- a/source/descriptions.hpp
+++ b/source/descriptions.hpp
@@ -380,7 +380,10 @@ extern string_view fireTrapDesc;
 extern string_view antiFairyTrapDesc;
 extern string_view curseTrapsDesc;
 extern string_view extraArrowEffectsDesc;
+extern string_view hyperActorsDesc;
 extern string_view hyperBossesDesc;
+extern string_view hyperMiddleBossesDesc;
+extern string_view hyperEnemiesDesc;
 
 extern string_view ToggleAllTricksDesc;
 

--- a/source/preset.cpp
+++ b/source/preset.cpp
@@ -497,7 +497,7 @@ PremadePreset presetFullChaos = { "Full Chaos",
                                       { &Settings::FireTrap, ON },
                                       { &Settings::AntiFairyTrap, ON },
                                       { &Settings::CurseTraps, ON },
-                                      { &Settings::HyperBosses, ON },
+                                      { &Settings::HyperActors, HYPERACTORS_ON },
                                       // Item Pool Settings
                                       { &Settings::IceTrapValue, ICETRAPS_ONSLAUGHT },
                                       { &Settings::RemoveDoubleDefense, OFF },

--- a/source/settings.cpp
+++ b/source/settings.cpp
@@ -336,7 +336,10 @@ Option FireTrap            = Option::Bool(2, "Fire Trap",           {"Off", "On"
 Option AntiFairyTrap       = Option::Bool(2, "Anti-Fairy Trap",     {"Off", "On"},                                                          {antiFairyTrapDesc},                                                                                              OptionCategory::Setting,    ON);
 Option CurseTraps          = Option::Bool(2, "Curse Traps",         {"Off", "On"},                                                          {curseTrapsDesc},                                                                                                 OptionCategory::Setting);
 Option ExtraArrowEffects   = Option::Bool("Extra Arrow Effects",    {"Off", "On"},                                                          {extraArrowEffectsDesc});
-Option HyperBosses         = Option::Bool("Hyper Bosses",           {"Off", "On"},                                                          {hyperBossesDesc});
+Option HyperActors         = Option::U8  ("Hyper Actors",           {"All Off", "All On", "Choose"},                                        {hyperActorsDesc});
+Option HyperBosses         = Option::Bool(2, "Hyper Bosses",        {"Off", "On"},                                                          {hyperBossesDesc});
+Option HyperMiddleBosses   = Option::Bool(2, "Hyper Middle Bosses", {"Off", "On"},                                                          {hyperMiddleBossesDesc});
+Option HyperEnemies        = Option::Bool(2, "Hyper Enemies",       {"Off", "On"},                                                          {hyperEnemiesDesc});
 bool HasNightStart         = false;
 std::vector<Option *> miscOptions = {
     &Racing,
@@ -361,7 +364,10 @@ std::vector<Option *> miscOptions = {
     &AntiFairyTrap,
     &CurseTraps,
     &ExtraArrowEffects,
+    &HyperActors,
     &HyperBosses,
+    &HyperMiddleBosses,
+    &HyperEnemies,
 };
 
 // Item Usability Settings
@@ -1444,6 +1450,8 @@ SettingsContext FillContext() {
     ctx.curseTraps          = (CurseTraps) ? 1 : 0;
     ctx.extraArrowEffects   = (ExtraArrowEffects) ? 1 : 0;
     ctx.hyperBosses         = (HyperBosses) ? 1 : 0;
+    ctx.hyperMiddleBosses   = (HyperMiddleBosses) ? 1 : 0;
+    ctx.hyperEnemies        = (HyperEnemies) ? 1 : 0;
 
     ctx.faroresWindAnywhere  = (FaroresWindAnywhere) ? 1 : 0;
     ctx.stickAsAdult         = (StickAsAdult) ? 1 : 0;
@@ -2193,6 +2201,27 @@ void ForceChange(u32 kDown, Option* currentSetting) {
         FireTrap.Hide();
         AntiFairyTrap.Hide();
         CurseTraps.Hide();
+    }
+
+    static const std::vector<Option*> hyperActorOptions = {
+        &HyperBosses,
+        &HyperMiddleBosses,
+        &HyperEnemies,
+    };
+    if (HyperActors.Is(HYPERACTORS_OFF)) {
+        for (auto op : hyperActorOptions) {
+            op->SetSelectedIndex(OFF);
+            op->Hide();
+        }
+    } else if (HyperActors.Is(HYPERACTORS_ON)) {
+        for (auto op : hyperActorOptions) {
+            op->SetSelectedIndex(ON);
+            op->Hide();
+        }
+    } else {
+        for (auto op : hyperActorOptions) {
+            op->Unhide();
+        }
     }
 
     // Manage toggle for item usability options

--- a/source/settings.hpp
+++ b/source/settings.hpp
@@ -459,7 +459,10 @@ extern Option FireTrap;
 extern Option AntiFairyTrap;
 extern Option CurseTraps;
 extern Option ExtraArrowEffects;
+extern Option HyperActors;
 extern Option HyperBosses;
+extern Option HyperMiddleBosses;
+extern Option HyperEnemies;
 extern bool HasNightStart;
 
 extern Option FaroresWindAnywhere;


### PR DESCRIPTION
Adds `Hyper Middle Bosses` and `Hyper Enemies` options, and places them together with `Hyper Bosses` under the new `Hyper Actors` option that can toggle all off, all on, or choose.

Include some more boss attack actors in `Hyper Bosses`.

Fixes the issue where some hyper actors would take double damage.

Patches some actor's ids to match their index in the actor overlay table. 
King Dodongo had the same id as regular Dodongos. Gohma Larva had the same as Queen Gohma. The others were just zero. Based on my testing, changing these had no negative effect.
