### PR TITLE
Fix trade item model bug

### DIFF
--- a/code/oot.ld
+++ b/code/oot.ld
@@ -816,10 +816,6 @@ SECTIONS
 		*(.patch_FWGetSet)
 	}
 
-	.patch_OverrideGraphicID_351B94 0x351B94 : {
-		*(.patch_OverrideGraphicID_351B94)
-	}
-
 	.patch_ApplyDamageMultiplier 0x352DC0 : {
 		*(.patch_ApplyDamageMultiplier)
 	}

--- a/code/oot_e.ld
+++ b/code/oot_e.ld
@@ -816,10 +816,6 @@ SECTIONS
 		*(.patch_FWGetSet)
 	}
 
-	.patch_OverrideGraphicID_351B94 0x351B94 : {
-		*(.patch_OverrideGraphicID_351B94)
-	}
-
 	.patch_ApplyDamageMultiplier 0x352DC0 : {
 		*(.patch_ApplyDamageMultiplier)
 	}

--- a/code/src/actor.c
+++ b/code/src/actor.c
@@ -247,7 +247,7 @@ void Actor_Init() {
     strncpy(gObjectTable[OBJECT_CUSTOM_SMALL_KEY_GTG].filename, gObjectTable[OBJECT_GI_KEY].filename, 0x40);
     strncpy(gObjectTable[OBJECT_CUSTOM_SMALL_KEY_GANON].filename, gObjectTable[OBJECT_GI_KEY].filename, 0x40);
 
-    // Define object 128 to be by default the same as object
+    // Define object 128 to be by default the same as object 185
     strncpy(gObjectTable[OBJECT_CUSTOM_BOSS_KEYS].filename, gObjectTable[OBJECT_GI_BOSSKEY].filename, 0x40);
 
     // Define draw item 3 (corresponding to gid 4) to be double defense custom model

--- a/code/src/patches.s
+++ b/code/src/patches.s
@@ -41,11 +41,6 @@ OverrideTextID_patch:
 OverrideItemID_patch:
     b hook_OverrideItemID
 
-.section .patch_OverrideGraphicID_351B94
-.global OverrideGraphicID_patch_351B94
-OverrideGraphicID_patch_351B94:
-    bl hook_OverrideGraphicID_351B94
-
 .section .patch_OverrideGraphicID_35495C
 .global OverrideGraphicID_patch_35495C
 OverrideGraphicID_patch_35495C:

--- a/source/hint_list.cpp
+++ b/source/hint_list.cpp
@@ -1967,7 +1967,7 @@ void HintTable_Init() {
                      Text{"And the #evil one#'s key will be&provided by Zelda once #%d |Dungeon#&is|Dungeons#&are| conquered.",
                 /*french*/"Aussi, Zelda crééra la clé du&#Malin# une fois #%d |donjon conquéri|donjons conquéris|#.",
                /*spanish*/"Y Zelda entregará la llave&del #señor del mal# tras completar&#%d |mazmorra|mazmorras|#.",
-               /*italian*/"E la chiave del #re del male# sarà&ricevuta da Zelda dopo aver completato&#%d dungeon#.",
+               /*italian*/"E la chiave del #re del male# sarà&ricevuta da Zelda dopo aver&completato #%d dungeon#.",
                 /*german*/"Und der #Schlüssel des Bösen# wird&von Zelda verliehen, sobald #%d&|Labyrinth# abgeschlossen wurde|Labyrinthe# abgeschlossen wurden|."},
     });
 


### PR DESCRIPTION
I think one of the OverrideGraphicID patches was added by mistake, as it seems to only affect the model for the trade item Link holds up, which doesn't need to be overridden.
I played through a seed without it and I didn't notice any ill effects, so I think it's safe to remove.