### PR TITLE
Fix: Barinade bluewarp to use correct entrance index

### DIFF
--- a/code/src/cutscenes.c
+++ b/code/src/cutscenes.c
@@ -247,7 +247,7 @@ void Cutscene_OverrideJabuJabusBelly(void) {
         // Skipped if wrong warping
         gSaveContext.dayTime = 0x8000;
     }
-    gGlobalContext->nextEntranceIndex = Entrance_OverrideNextIndex(0x221);
+    gGlobalContext->nextEntranceIndex = Entrance_OverrideNextIndex(0x10E);
     gGlobalContext->sceneLoadFlag     = 0x14;
     gGlobalContext->fadeOutTransition = 0xA;
     gSaveContext.nextCutsceneIndex    = 0x0;


### PR DESCRIPTION
The entrance override for Barinade's bluewarp was using the entrance index for exiting Jabu-Jabu, rather than the actual blue warp index.

This appeared to have been fine for dungeon entrance rando, but with the addition of boss entrance rando, the player would not spawn outside the dungeon that contained Barinades boss room.

This PR just swaps the value to be the blue warp index instead. I'm not sure why the Barinade override was using the Jabu-Jabu exit originally.