### PR TITLE
Merchants use custom message even without hints

### DIFF
--- a/code/src/actors/granny.c
+++ b/code/src/actors/granny.c
@@ -4,7 +4,7 @@
 #define GRANNY_FLAG (gSaveContext.eventChkInf[3] & 0x04)
 
 s32 EnDs_GetTextID(void) {
-    if ((gSettingsContext.shuffleMerchants == SHUFFLEMERCHANTS_HINTS) && !GRANNY_FLAG) {
+    if ((gSettingsContext.shuffleMerchants != SHUFFLEMERCHANTS_OFF) && !GRANNY_FLAG) {
         return 0x9121; // custom text
     }
     return 0x500C; // vanilla text

--- a/code/src/actors/medigoron.c
+++ b/code/src/actors/medigoron.c
@@ -18,7 +18,7 @@ void EnGm_SetRewardFlag(void) {
 }
 
 s32 EnGm_UseCustomText(void) {
-    return (gSettingsContext.shuffleMerchants == SHUFFLEMERCHANTS_HINTS && (gSaveContext.eventChkInf[3] & 0x20) == 0);
+    return (gSettingsContext.shuffleMerchants != SHUFFLEMERCHANTS_OFF && (gSaveContext.eventChkInf[3] & 0x20) == 0);
 }
 
 s32 EnGm_ItemOverride(void) {

--- a/source/fill.cpp
+++ b/source/fill.cpp
@@ -1117,9 +1117,6 @@ int Fill() {
                 CreateGossipStoneHints();
                 printf("Done");
             }
-            if (ShuffleMerchants.Is(SHUFFLEMERCHANTS_HINTS)) {
-                CreateMerchantsHints();
-            }
             return 1;
         }
         // Unsuccessful placement

--- a/source/hint_list/hint_list_item.cpp
+++ b/source/hint_list/hint_list_item.cpp
@@ -1945,12 +1945,15 @@ void HintTable_Init_Item() {
                        Text{"Epona", /*french*/"Epona", /*spanish*/"a Epona", /*italian*/"Epona", /*german*/"Epona"}
     );
 
-    // [HINT_ERROR] = HintText::Item({
-    //                      // obscure text
-    //                      Text{"something mysterious", /*french*/"un sacré mystère",  /*spanish*/"algo misterioso",       /*italian*/"qualcosa di misterioso", /*german*/"etwas Unvorhergesehenes"},
-    //                      Text{"an unknown treasure",  /*french*/"un trésor inconnu", /*spanish*/"un desconocido tesoro", /*italian*/"un tesoro incognito",    /*german*/"ein unbekannter Schatz"},
-    //                    },
-    //                      // clear text
+    hintTable[HINT_MYSTERIOUS] = HintText::Item({
+                         // only obscure text, used for merchants without hints
+                         Text{"something mysterious", /*french*/"un sacré mystère",  /*spanish*/"algo misterioso",       /*italian*/"qualcosa di misterioso", /*german*/"etwas Unvorhergesehenes"},
+                         Text{"an unknown treasure",  /*french*/"un trésor inconnu", /*spanish*/"un desconocido tesoro", /*italian*/"un tesoro incognito",    /*german*/"ein unbekannter Schatz"},
+                       }
+    );
+
+    // hintTable[HINT_ERROR] = HintText::Item({
     //                      Text{"An Error (Please Report This)", /*french*/"une erreur (signaler S.V.P.)", /*spanish*/"un error (repórtelo si es posible)", /*italian*/"un errore (segnalalo per favore)", /*german*/"ein Fehler (Bitte melden)"}
+    //                    }
     // );
 }

--- a/source/hints.cpp
+++ b/source/hints.cpp
@@ -738,13 +738,22 @@ void CreateMiscHints() {
         CreateAltarText(rewardHints);
     }
     CreateCompassAndGearMenuHints(rewardHints);
+
+    if (ShuffleMerchants.IsNot(SHUFFLEMERCHANTS_OFF)) {
+        CreateMerchantsHints();
+    }
 }
 
 void CreateMerchantsHints() {
+    Text medigoronItemText, grannyItemText, carpetSalesmanItemText;
 
-    Text medigoronItemText           = Location(GC_MEDIGORON)->GetPlacedItem().GetHint().GetText();
-    Text grannyItemText              = Location(KAK_GRANNYS_SHOP)->GetPlacedItem().GetHint().GetText();
-    Text carpetSalesmanItemText      = Location(WASTELAND_BOMBCHU_SALESMAN)->GetPlacedItem().GetHint().GetText();
+    if (ShuffleMerchants.Is(SHUFFLEMERCHANTS_HINTS)) {
+        medigoronItemText      = Location(GC_MEDIGORON)->GetPlacedItem().GetHint().GetTextCopy();
+        grannyItemText         = Location(KAK_GRANNYS_SHOP)->GetPlacedItem().GetHint().GetTextCopy();
+        carpetSalesmanItemText = Location(WASTELAND_BOMBCHU_SALESMAN)->GetPlacedItem().GetHint().GetTextCopy();
+    } else {
+        medigoronItemText = grannyItemText = carpetSalesmanItemText = hintTable[HINT_MYSTERIOUS].GetTextCopy();
+    }
     Text carpetSalesmanItemClearText = Location(WASTELAND_BOMBCHU_SALESMAN)->GetPlacedItem().GetHint().GetClear();
 
     for (Text* itemText :

--- a/source/keys.hpp
+++ b/source/keys.hpp
@@ -207,6 +207,7 @@ typedef enum {
     TRIFORCE_PIECE,
     EPONA,
     HINT,
+    HINT_MYSTERIOUS,
 
     // SHOP ITEMS
     BUY_DEKU_NUT_5,


### PR DESCRIPTION
Currently merchants use the same dialog when they're not shuffled and when they're shuffled without hints. With randomized shuffle settings, it's impossible to know if their items are randomized without buying them.

This PR makes merchants use the custom dialog even with hints disabled, in which case the item name will be "something mysterious". This name is taken from the unused HINT_ERROR, so it's already been fully translated.