### PR TITLE
Adjust boss clear logic

### DIFF
--- a/source/descriptions.cpp
+++ b/source/descriptions.cpp
@@ -1577,6 +1577,12 @@ string_view LogicShadowStatueDesc                     = "Difficulty: Novice\n"  
                                                         "By sending a Bombchu around the edge of the gorge,"
                                                         "you can knock down the statue without needing a\n"//
                                                         "Bow. Applies in both vanilla and MQ Shadow.";     //
+string_view LogicShadowBongoDesc                      = "Difficulty Expert\n"                              //
+                                                        "Using precise sword slashes, Bongo Bongo can be\n"//
+                                                        "defeated without using projectiles.\n"            //
+                                                        "This trick is much more difficult when done with\n"
+                                                        "Kokiri Sword vs Master Sword or Biggorron Sword.\n"
+                                                        "Useful for Boss Entrance Randomizer.";            //
 string_view LogicChildDeadhandDesc                    = "Difficulty: Novice\n"                             //
                                                         "Requires 10 stick slashes.";                      //
 string_view LogicGtgWithoutHookshotDesc               = "Difficulty: Expert\n"                             //

--- a/source/descriptions.hpp
+++ b/source/descriptions.hpp
@@ -463,6 +463,7 @@ extern string_view LogicShadowFireArrowEntryDesc;
 extern string_view LogicShadowUmbrellaDesc;
 extern string_view LogicShadowFreestandingKeyDesc;
 extern string_view LogicShadowStatueDesc;
+extern string_view LogicShadowBongoDesc;
 extern string_view LogicChildDeadhandDesc;
 extern string_view LogicGtgWithoutHookshotDesc;
 extern string_view LogicGtgFakeWallDesc;

--- a/source/location_access/locacc_jabujabus_belly.cpp
+++ b/source/location_access/locacc_jabujabus_belly.cpp
@@ -381,7 +381,8 @@ void AreaTable_Init_JabuJabusBelly() {
         Area("Jabu Jabus Belly Boss Room", "Jabu Jabus Belly", NONE, NO_DAY_NIGHT_CYCLE,
              {
                  // Events
-                 EventAccess(&JabuJabusBellyClear, { [] { return JabuJabusBellyClear || CanUse(BOOMERANG); } }),
+                 EventAccess(&JabuJabusBellyClear,
+                             { [] { return JabuJabusBellyClear || (CanUse(BOOMERANG) && CanJumpslash); } }),
              },
              {
                  // Locations

--- a/source/location_access/locacc_shadow_temple.cpp
+++ b/source/location_access/locacc_shadow_temple.cpp
@@ -327,7 +327,8 @@ void AreaTable_Init_ShadowTemple() {
                      return ShadowTempleClear ||
                             ((CanUse(LENS_OF_TRUTH) || ((Dungeon::ShadowTemple.IsVanilla() && LogicLensShadowBack) ||
                                                         (Dungeon::ShadowTemple.IsMQ() && LogicLensShadowMQBack))) &&
-                             (CanUse(KOKIRI_SWORD) || CanUse(MASTER_SWORD) || CanUse(BIGGORON_SWORD)));
+                             (CanUse(KOKIRI_SWORD) || CanUse(MASTER_SWORD) || CanUse(BIGGORON_SWORD)) &&
+                             (CanUse(HOOKSHOT) || CanUse(BOW) || CanUse(SLINGSHOT)));
                  } }),
              },
              {

--- a/source/location_access/locacc_shadow_temple.cpp
+++ b/source/location_access/locacc_shadow_temple.cpp
@@ -328,7 +328,7 @@ void AreaTable_Init_ShadowTemple() {
                             ((CanUse(LENS_OF_TRUTH) || ((Dungeon::ShadowTemple.IsVanilla() && LogicLensShadowBack) ||
                                                         (Dungeon::ShadowTemple.IsMQ() && LogicLensShadowMQBack))) &&
                              (CanUse(KOKIRI_SWORD) || CanUse(MASTER_SWORD) || CanUse(BIGGORON_SWORD)) &&
-                             (CanUse(HOOKSHOT) || CanUse(BOW) || CanUse(SLINGSHOT)));
+                             (CanUse(HOOKSHOT) || CanUse(BOW) || CanUse(SLINGSHOT) || LogicShadowBongo));
                  } }),
              },
              {

--- a/source/settings.cpp
+++ b/source/settings.cpp
@@ -743,6 +743,7 @@ Option LogicShadowFireArrowEntry        = LogicTrick("ShT Entry\n  w/ Fire Arrow
 Option LogicShadowUmbrella              = LogicTrick("ShT Stone Umbrella\n  w/ Hover Boots",      LogicShadowUmbrellaDesc);
 Option LogicShadowFreestandingKey       = LogicTrick("ShT Skull Vase Key\n  w/ Bombchu",          LogicShadowFreestandingKeyDesc);
 Option LogicShadowStatue                = LogicTrick("ShT River Statue\n  w/ Bombchu",            LogicShadowStatueDesc);
+Option LogicShadowBongo                 = LogicTrick("ShT Bongo\n  w/o Projectiles",              LogicShadowBongoDesc);
 Option LogicChildDeadhand               = LogicTrick("BotW Deadhand\n  w/o Sword",                LogicChildDeadhandDesc);
 Option LogicGtgWithoutHookshot          = LogicTrick("GTG West Silver Rupee\n  w/o Hookshot",     LogicGtgWithoutHookshotDesc);
 Option LogicGtgFakeWall                 = LogicTrick("GTG Invisible Wall\n  w/ Hover Boots",      LogicGtgFakeWallDesc);
@@ -834,6 +835,7 @@ std::vector<Option *> trickOptions = {
     &LogicShadowUmbrella,
     &LogicShadowFreestandingKey,
     &LogicShadowStatue,
+    &LogicShadowBongo,
     &LogicChildDeadhand,
     &LogicGtgWithoutHookshot,
     &LogicGtgFakeWall,
@@ -2359,6 +2361,7 @@ void ForceChange(u32 kDown, Option* currentSetting) {
                 LogicSpiritSunChest.SetSelectedIndex(1);
                 // LogicShadowFireArrowEntry.SetSelectedIndex(1);
                 LogicShadowUmbrella.SetSelectedIndex(1);
+                LogicShadowBongo.SetSelectedIndex(1);
                 LogicGtgWithoutHookshot.SetSelectedIndex(1);
             }
         }

--- a/source/settings.hpp
+++ b/source/settings.hpp
@@ -638,6 +638,7 @@ extern Option LogicShadowFireArrowEntry;
 extern Option LogicShadowUmbrella;
 extern Option LogicShadowFreestandingKey;
 extern Option LogicShadowStatue;
+extern Option LogicShadowBongo;
 extern Option LogicChildDeadhand;
 extern Option LogicGtgWithoutHookshot;
 extern Option LogicGtgFakeWall;


### PR DESCRIPTION
Looking at the logic for boss clears, Barinade was missing a sword/stick check, and Bongo was missing a projectile weapon check. I looked over the rest of the bosses and they seemed fine (ignoring that adult bosses did not have a stick check, but I think that is fine given how much health adult bosses have).

These probably were never a problem in that past for glitchless settings, but with Boss room shuffle, its possible that a previous exit check did not require something needed for the bosses.

The Bongo check in N64 rando has an accompanying logic option to bypass the need for projectiles (using precise sword slashes). ~~I'm not sure if that is something we want to add to replicate that behavior.~~

Based on Discord feedback, I have gone through and implemented a logic trick for fighting Bongo without projectiles (similar to N64). The trick is marked as expert based on discussion of how difficult the trick is to accomplish, especially as child.