### PR TITLE
Improve starting bunny hood

### DIFF
--- a/code/src/item_effect.c
+++ b/code/src/item_effect.c
@@ -271,6 +271,7 @@ void ItemEffect_FillWalletUpgrade(SaveContext* saveCtx, s16 arg1, s16 arg2) {
 
 void ItemEffect_OpenMaskShop(SaveContext* saveCtx, s16 arg1, s16 arg2) {
     gSaveContext.sceneFlags[0x60].unk |= 0x1 << 0x11;
+    gSaveContext.itemGetInf[2] &= 0xFFF7; // Replace starting bunny hood with letter
 
     if (gSettingsContext.openKakariko == OPENKAKARIKO_OPEN) {
         gSaveContext.infTable[7] |= 0x40; // "Spoke to Gate Guard About Mask Shop"

--- a/code/src/savefile.c
+++ b/code/src/savefile.c
@@ -473,6 +473,8 @@ void SaveFile_SetStartingInventory(void) {
 
     if (gSettingsContext.startingChildTrade) {
         gSaveContext.items[SLOT_TRADE_CHILD] = ITEM_MASK_BUNNY;
+        SaveFile_BorrowMask(0x21);
+        gSaveContext.sceneFlags[0x60].unk |= 0x1 << 0x11;
     }
 
     if (gSettingsContext.startingOcarina > 0) {

--- a/code/src/savefile.h
+++ b/code/src/savefile.h
@@ -21,6 +21,7 @@ u8 SaveFile_ChildTradeSlots(void);
 u8 SaveFile_WeirdEggHatched(void);
 u8 SaveFile_CurrentMask(void);
 u32 SaveFile_MaskSlotValue(void);
+void SaveFile_BorrowMask(s16 SI_ItemId);
 void SaveFile_SetOwnedTradeItemEquipped(void);
 void SaveFile_ResetItemSlotsIfMatchesID(u8 itemSlot);
 u8 SaveFile_InventoryMenuHasSlot(u8 adult, u8 itemSlot);


### PR DESCRIPTION
Allows the player to switch back to bunny hood after receiving the weird egg without needing to find Zelda's letter and reborrow it. Obtaining Zelda's letter does still overwrite it until it is reborrowed.