### PR TITLE
Remove Jabu Clear event from MQ Boss Area

### DIFF
--- a/source/location_access/locacc_jabujabus_belly.cpp
+++ b/source/location_access/locacc_jabujabus_belly.cpp
@@ -350,7 +350,6 @@ void AreaTable_Init_JabuJabusBelly() {
                  {
                      // Events
                      EventAccess(&FairyPot, { [] { return true; } }),
-                     EventAccess(&JabuJabusBellyClear, { [] { return true; } }),
                  },
                  {
                      // Locations


### PR DESCRIPTION
This made it possible for Barinade to be placed in a location inaccessible to child as MQ boss area is within the dungeon and not the boss room