### PR TITLE
Directories: Info screen + Migrate to /OoT3DR/

### DIFF
--- a/source/custom_music/sequence_data.cpp
+++ b/source/custom_music/sequence_data.cpp
@@ -64,13 +64,6 @@ MusicCategoryNode::MusicCategoryNode(std::string Name_, std::vector<MusicCategor
 
 MusicCategoryNode::~MusicCategoryNode() = default;
 
-void MusicCategoryNode::CreateDirectories(FS_Archive sdmcArchive) {
-    FSUSER_CreateDirectory(sdmcArchive, fsMakePath(PATH_ASCII, GetFullPath().c_str()), FS_ATTRIBUTE_DIRECTORY);
-    for (auto& child : children) {
-        child->CreateDirectories(sdmcArchive);
-    }
-}
-
 std::string MusicCategoryNode::GetFullPath() {
     if (fullPath.empty()) {
         std::string finalPath = Name + '/';
@@ -82,6 +75,16 @@ std::string MusicCategoryNode::GetFullPath() {
         fullPath = finalPath;
     }
     return fullPath;
+}
+
+std::vector<std::string> MusicCategoryNode::GetDirectories() {
+    std::vector<std::string> dirs;
+    dirs.push_back(GetFullPath());
+    for (auto child : children) {
+        auto childDirs = child->GetDirectories();
+        dirs.insert(dirs.end(), childDirs.begin(), childDirs.end());
+    }
+    return dirs;
 }
 
 void MusicCategoryNode::SetParent(MusicCategoryNode* parent_) {

--- a/source/custom_music/sequence_data.hpp
+++ b/source/custom_music/sequence_data.hpp
@@ -56,10 +56,10 @@ class MusicCategoryNode {
     MusicCategoryNode(std::string Name_, std::vector<MusicCategoryNode*> children_);
     ~MusicCategoryNode();
 
-    /// Creates it's folder in it's parent's, and then calls each child to do the same.
-    void CreateDirectories(FS_Archive sdmcArchive);
     /// Returns the full path of this node.
     std::string GetFullPath();
+    /// Returns a vector of this node's and it's children's directories.
+    std::vector<std::string> GetDirectories();
     /// Sets this node's parent node.
     void SetParent(MusicCategoryNode* parent_);
     /// Returns true if this node has the given node as an ancestor.

--- a/source/main.cpp
+++ b/source/main.cpp
@@ -15,7 +15,6 @@ int main() {
     ItemTable_Init();
     LocationTable_Init();
     MenuInit();
-    Music::CreateMusicDirectories();
 
     u64 initialHoldTime = svcGetSystemTick();
     u64 intervalTime    = initialHoldTime;

--- a/source/menu.cpp
+++ b/source/menu.cpp
@@ -58,9 +58,28 @@ void MenuInit() {
 
     consoleSelect(&topScreen);
 
-    if (!CreatePresetDirectories()) {
-        printf("\x1b[20;5Failed to create preset directories.");
-        printf("\x1b[21;5Loading presets might crash.");
+    // Create directories
+    FS_Archive sdmcArchive;
+    if (R_SUCCEEDED(FSUSER_OpenArchive(&sdmcArchive, ARCHIVE_SDMC, fsMakePath(PATH_EMPTY, "")))) {
+        CreateLogDirectories(sdmcArchive);
+        CreatePresetDirectories(sdmcArchive);
+        Music::CreateMusicDirectories(sdmcArchive);
+
+        FSUSER_CloseArchive(sdmcArchive);
+    } else {
+        consoleClear();
+        printf("\x1b[10;10HFailed to create directories.");
+        printf("\x1b[11;10H- Spoiler logs won't be written.");
+        printf("\x1b[12;10H- Loading presets might crash.");
+        printf("\x1b[13;10H- Custom music will fail.");
+        printf("\x1b[15;10HPress B to continue.");
+
+        while (aptMainLoop()) {
+            hidScanInput();
+            if (hidKeysHeld() & KEY_B) {
+                break;
+            }
+        }
     }
 
     // If cached presets exist, load them

--- a/source/music.cpp
+++ b/source/music.cpp
@@ -334,22 +334,33 @@ static MusicCategoryNode mcMelodies_Root("Melodies", { &mcMelodies_Fanfares, &mc
 bool archiveFound     = false;
 bool musicDirsCreated = false;
 
-void CreateMusicDirectories() {
-    FS_Archive sdmcArchive;
+void CreateMusicDirectories(FS_Archive sdmcArchive) {
+    std::vector<std::string> dirs;
 
-    // Open SD archive
-    if (!R_SUCCEEDED(FSUSER_OpenArchive(&sdmcArchive, ARCHIVE_SDMC, fsMakePath(PATH_EMPTY, "")))) {
-        return;
+    dirs.push_back("/OoT3DR/");
+    dirs.push_back(CustomMusicRootPath);
+
+    auto bgmDirs = mcBgm_Root.GetDirectories();
+    dirs.insert(dirs.end(), bgmDirs.begin(), bgmDirs.end());
+
+    auto melodyDirs = mcMelodies_Root.GetDirectories();
+    dirs.insert(dirs.end(), melodyDirs.begin(), melodyDirs.end());
+
+    const auto printInfo = [&](int progress) {
+        consoleClear();
+        printf("\x1b[10;10HCreating Music Directories");
+        printf("\x1b[11;10HProgress: %d/%d", progress, dirs.size());
+        printf("\x1b[13;10HIf this is slow, don't worry.");
+        printf("\x1b[14;10HThis only has to be done once.");
+    };
+
+    printInfo(0);
+    for (size_t i = 0; i < dirs.size(); i++) {
+        FSUSER_CreateDirectory(sdmcArchive, fsMakePath(PATH_ASCII, dirs[i].c_str()), FS_ATTRIBUTE_DIRECTORY);
+        printInfo(i + 1);
     }
 
-    // Create all dirs
-    FSUSER_CreateDirectory(sdmcArchive, fsMakePath(PATH_ASCII, "/OoT3DR"), FS_ATTRIBUTE_DIRECTORY);
-    FSUSER_CreateDirectory(sdmcArchive, fsMakePath(PATH_ASCII, CustomMusicRootPath.c_str()), FS_ATTRIBUTE_DIRECTORY);
-    mcBgm_Root.CreateDirectories(sdmcArchive);
-    mcMelodies_Root.CreateDirectories(sdmcArchive);
-
     musicDirsCreated = true;
-    FSUSER_CloseArchive(sdmcArchive);
 }
 
 int ShuffleMusic_Archive() {
@@ -434,7 +445,7 @@ int ShuffleMusic_Archive() {
         } else if (Settings::ShuffleMelodies.Is(SHUFFLEMUSIC_GROUPED)) {
             fillNodeWithOriginals(mcMelodies_Fanfares);
             fillNodeWithOriginals(mcMelodies_OcarinaSongs);
-        } else if (Settings::ShuffleBGM.Is(SHUFFLEMUSIC_OWN)) {
+        } else if (Settings::ShuffleMelodies.Is(SHUFFLEMUSIC_OWN)) {
             for (auto leaf : allAudioCatLeaves) {
                 if (leaf->HasAncestor(&mcMelodies_Root)) {
                     musicNodeAddSeq(*leaf, leaf->FileRep);

--- a/source/music.hpp
+++ b/source/music.hpp
@@ -46,7 +46,7 @@ typedef enum {
 
 extern bool archiveFound;
 extern bool musicDirsCreated;
-void CreateMusicDirectories();
+void CreateMusicDirectories(FS_Archive sdmcArchive);
 int ShuffleMusic_Archive();
 
 } // namespace Music

--- a/source/preset.hpp
+++ b/source/preset.hpp
@@ -8,7 +8,7 @@
 
 enum class OptionCategory;
 
-bool CreatePresetDirectories();
+void CreatePresetDirectories(FS_Archive sdmcArchive);
 std::vector<std::string> GetSettingsPresets();
 bool SavePreset(std::string_view presetName, OptionCategory category);
 bool LoadPreset(std::string_view presetName, OptionCategory category);

--- a/source/spoiler_log.cpp
+++ b/source/spoiler_log.cpp
@@ -20,6 +20,9 @@
 #include <string>
 #include <unordered_map>
 #include <vector>
+#include <filesystem>
+
+namespace fs = std::filesystem;
 
 namespace {
 std::string placementtxt;
@@ -37,6 +40,25 @@ constexpr std::array<std::string_view, 32> hashIcons = {
 static RandomizerHash randomizerHash;
 static SpoilerData spoilerData;
 static std::array<SpoilerDataLocs, SPOILER_LOCDATS> spoilerDataLocs;
+
+void CreateLogDirectories(FS_Archive sdmcArchive) {
+    std::vector<std::string> dirs = {
+        "/OoT3DR/",
+        "/OoT3DR/Logs/",
+    };
+
+    const auto printInfo = [&](int progress) {
+        consoleClear();
+        printf("\x1b[10;10HCreating Log Directories");
+        printf("\x1b[11;10HProgress: %d/%d", progress, dirs.size());
+    };
+
+    printInfo(0);
+    for (size_t i = 0; i < dirs.size(); i++) {
+        FSUSER_CreateDirectory(sdmcArchive, fsMakePath(PATH_ASCII, dirs[i].c_str()), FS_ATTRIBUTE_DIRECTORY);
+        printInfo(i + 1);
+    }
+}
 
 void GenerateHash() {
     for (size_t i = 0; i < randomizerHash.size(); i++) {
@@ -73,7 +95,7 @@ const SpoilerDataLocs* GetSpoilerDataLocs(size_t index) {
 }
 
 static auto GetGeneralPath() {
-    return "/3ds/" + Settings::seed + " (" + GetRandomizerHashAsString() + ")";
+    return "/OoT3DR/Logs/" + Settings::seed + " (" + GetRandomizerHashAsString() + ")";
 }
 
 static auto GetSpoilerLogPath() {

--- a/source/spoiler_log.hpp
+++ b/source/spoiler_log.hpp
@@ -1,11 +1,15 @@
 #pragma once
 
+#include <3ds.h>
+
 #include <array>
 #include <string>
 #include <string_view>
 #include "../code/src/spoiler_data.h"
 
 using RandomizerHash = std::array<std::string, 5>;
+
+void CreateLogDirectories(FS_Archive sdmcArchive);
 
 void GenerateHash();
 const RandomizerHash& GetRandomizerHash();

--- a/source/utils.cpp
+++ b/source/utils.cpp
@@ -1,8 +1,15 @@
+#include <algorithm>
+
 #include "utils.hpp"
 
 std::string SanitizedString(std::string s) {
-    // Remove line breaks
-    s.erase(std::remove(s.begin(), s.end(), '\n'), s.end());
+    // Remove leading spaces
+    while (s.size() > 0 && s[0] == ' ') {
+        s.erase(0, 1);
+    }
+
+    // Replace line breaks with spaces
+    std::replace(s.begin(), s.end(), '\n', ' ');
 
     // Remove consecutive spaces
     while (s.find("  ") != std::string::npos) {

--- a/source/utils.hpp
+++ b/source/utils.hpp
@@ -1,7 +1,9 @@
 #pragma once
 
-#include <algorithm>
 #include <string>
 
-// Returns a new string with line breaks and consecutive spaces removed
+/// Returns a new string with:
+/// - Leading spaces removed.
+/// - Line breaks replaced with spaces.
+/// - Consecutive spaces removed.
 std::string SanitizedString(std::string s);


### PR DESCRIPTION
* Add directory creation info screen. 
Example in the following video has thread sleep added:

https://user-images.githubusercontent.com/5352197/233390263-e103bc0f-b83b-4088-a503-efb433853104.mp4

* Change preset and log folders to `/OoT3DR/Presets/` and `/OoT3DR/Logs/` respectively.
Presets in the old folders will be moved on app start.
* Plus some other small fixes:
  * Fix copy-paste error in `music.cpp` where it shouldv'e been `Settings::ShuffleMelodies`.
  * Adjust `SanitizedString` function to account for cases like this: `"  Option\nText"`