### PR TITLE
Fix: Use blue potion refill for Granny Shop item when unshuffled

### DIFF
--- a/source/item_pool.cpp
+++ b/source/item_pool.cpp
@@ -578,7 +578,7 @@ void GenerateItemPool() {
             AddItemToMainPool(BOMBCHU_10);
         }
     } else {
-        PlaceItemInLocation(KAK_GRANNYS_SHOP, BOTTLE_WITH_BLUE_POTION, false, true);
+        PlaceItemInLocation(KAK_GRANNYS_SHOP, BLUE_POTION_REFILL, false, true);
         PlaceItemInLocation(GC_MEDIGORON, GIANTS_KNIFE, false, true);
         PlaceItemInLocation(WASTELAND_BOMBCHU_SALESMAN, BOMBCHU_10, false, true);
     }


### PR DESCRIPTION
When merchants are set to unshuffled, the Granny Shop location was having a `BOTTLE_WITH_BLUE_POTION` placed in it which is considered a real bottle in logic.

This was leading to logic sometimes expecting you to buy the blue potion from granny to get the first bottle, and in some rare cases it may consider this the "only" bottle you can get and causing a soft lock (bottle locking all other bottles).

This PR sets the placed item to be `BLUE_POTION_REFILL`, instead to follow what is already declared in `item_locations.cpp` and what the game actually does (granny sells refills, not bottles).

For testing, I made it so hidden items would be logged in the item locations section, and found a seed that had Granny shop location in the playthrough spheres.

[before.txt](https://github.com/gamestabled/OoT3D_Randomizer/files/11568352/before.txt)
[after.txt](https://github.com/gamestabled/OoT3D_Randomizer/files/11568353/after.txt)
