### PR TITLE
Fix free cam bug on lon lon crates (and possibly other dynamic collision)

### DIFF
--- a/code/include/z3D/z3D.h
+++ b/code/include/z3D/z3D.h
@@ -344,6 +344,19 @@ typedef struct {
 } StaticCollisionContext; // size = 0x50
 
 typedef struct {
+    /* 0x00 */ Actor* actor;
+    /* 0x04 */ CollisionHeader* colHeader;
+    /* 0x08 */ char unk_04[0x0C];
+    /* 0x14 */ Vec3f scale1;
+    /* 0x20 */ Vec3s rot1;
+    /* 0x28 */ Vec3f pos1;
+    /* 0x34 */ Vec3f scale2;
+    /* 0x40 */ Vec3s rot2;
+    /* 0x48 */ Vec3f pos2;
+    /* 0x54 */ char unk_54[0x18];
+} ActorMesh; // size = 0x6C
+
+typedef struct {
     /* 0x0000 */ char unk_00[0x04];
     /* 0x0004 */ ActorMesh actorMeshArr[50];
     /* 0x151C */ u16 flags[50];
@@ -812,6 +825,9 @@ typedef s32 (*Player_InBlockingCsMode_proc)(GlobalContext* globalCtx, Player* pl
 
 typedef s32 (*Camera_CheckWater_proc)(Camera* camera);
 #define Camera_CheckWater ((Camera_CheckWater_proc)0x2D06A0)
+
+typedef f32 (*BgCheck_EntityRaycastFloor5_proc)(GlobalContext* globalCtx, CollisionContext* colCtx, CollisionPoly** floorPoly, s16* bgId, Player* player, Vec3f* playerPos);
+#define BgCheck_EntityRaycastFloor5 ((BgCheck_EntityRaycastFloor5_proc)0x316C18)
 
 typedef void (*Camera_UpdateInterface_proc)(u32 flags);
 #define Camera_UpdateInterface ((Camera_UpdateInterface_proc)0x330D84)

--- a/code/include/z3D/z3D.h
+++ b/code/include/z3D/z3D.h
@@ -826,7 +826,8 @@ typedef s32 (*Player_InBlockingCsMode_proc)(GlobalContext* globalCtx, Player* pl
 typedef s32 (*Camera_CheckWater_proc)(Camera* camera);
 #define Camera_CheckWater ((Camera_CheckWater_proc)0x2D06A0)
 
-typedef f32 (*BgCheck_EntityRaycastFloor5_proc)(GlobalContext* globalCtx, CollisionContext* colCtx, CollisionPoly** floorPoly, s16* bgId, Player* player, Vec3f* playerPos);
+typedef f32 (*BgCheck_EntityRaycastFloor5_proc)(GlobalContext* globalCtx, CollisionContext* colCtx,
+                                                CollisionPoly** floorPoly, s16* bgId, Player* player, Vec3f* playerPos);
 #define BgCheck_EntityRaycastFloor5 ((BgCheck_EntityRaycastFloor5_proc)0x316C18)
 
 typedef void (*Camera_UpdateInterface_proc)(u32 flags);

--- a/code/include/z3D/z3Dactor.h
+++ b/code/include/z3D/z3Dactor.h
@@ -249,18 +249,6 @@ typedef struct DynaPolyActor {
 } DynaPolyActor; // size = 0x1BC
 
 typedef struct {
-    /* 0x00 */ Actor* actor;
-    /* 0x04 */ char unk_04[0x10];
-    /* 0x14 */ Vec3f scale1;
-    /* 0x20 */ Vec3s rot1;
-    /* 0x28 */ Vec3f pos1;
-    /* 0x34 */ Vec3f scale2;
-    /* 0x40 */ Vec3s rot2;
-    /* 0x48 */ Vec3f pos2;
-    /* 0x54 */ char unk_54[0x18];
-} ActorMesh; // size = 0x6C
-
-typedef struct {
     /* 0x0000 */ Actor actor;
     /* 0x01A4 */ char unk_148[0x0005];
     /* 0x01A9 */ s8 heldItemActionParam;

--- a/code/src/camera.c
+++ b/code/src/camera.c
@@ -240,9 +240,21 @@ void Camera_FreeCamUpdate(Vec3s* out, Camera* camera) {
         out->y = camera->inputDir.y = camera->camDir.y = yaw;
         out->z = camera->inputDir.z = camera->camDir.z = 0;
 
-        // Pretty much entirely to let the alcoves in SpT reclaim control of the camera
-        s16 newCamDataIdx = Camera_GetCamDataId(&camera->globalCtx->colCtx, camera->player->actor.floorPoly, 0x32);
-        s16 newSetting    = camera->globalCtx->colCtx.stat.colHeader->camDataList[newCamDataIdx].setting;
+        // Update camera setting
+        CollisionPoly* floorPoly;
+        s16 newSetting;
+        Vec3f headPos;
+        headPos.x = camera->player->actor.world.pos.x;
+        headPos.y = camera->player->actor.world.pos.y + (gSaveContext.linkAge ? 44 : 68);
+        headPos.z = camera->player->actor.world.pos.z;
+
+        camera->playerGroundY = BgCheck_EntityRaycastFloor5(camera->globalCtx, &camera->globalCtx->colCtx, &floorPoly, &camera->bgCheckId, camera->player, &headPos);
+        s16 newCamDataIdx = Camera_GetCamDataId(&camera->globalCtx->colCtx, floorPoly, camera->bgCheckId);
+        if (camera->bgCheckId == 0x32)
+            newSetting = camera->globalCtx->colCtx.stat.colHeader->camDataList[newCamDataIdx].setting;
+        else
+            newSetting = camera->globalCtx->colCtx.dyna.actorMeshArr[camera->bgCheckId].colHeader->camDataList[newCamDataIdx].setting;
+
         if (newCamDataIdx != -1 && newSetting && (newSetting != 0x35 || gSaveContext.linkAge)) {
             camera->camDataIdx = newCamDataIdx;
             if (newSetting != camera->setting) {

--- a/code/src/camera.c
+++ b/code/src/camera.c
@@ -248,12 +248,15 @@ void Camera_FreeCamUpdate(Vec3s* out, Camera* camera) {
         headPos.y = camera->player->actor.world.pos.y + (gSaveContext.linkAge ? 44 : 68);
         headPos.z = camera->player->actor.world.pos.z;
 
-        camera->playerGroundY = BgCheck_EntityRaycastFloor5(camera->globalCtx, &camera->globalCtx->colCtx, &floorPoly, &camera->bgCheckId, camera->player, &headPos);
-        s16 newCamDataIdx = Camera_GetCamDataId(&camera->globalCtx->colCtx, floorPoly, camera->bgCheckId);
+        camera->playerGroundY = BgCheck_EntityRaycastFloor5(camera->globalCtx, &camera->globalCtx->colCtx, &floorPoly,
+                                                            &camera->bgCheckId, camera->player, &headPos);
+        s16 newCamDataIdx     = Camera_GetCamDataId(&camera->globalCtx->colCtx, floorPoly, camera->bgCheckId);
         if (camera->bgCheckId == 0x32)
             newSetting = camera->globalCtx->colCtx.stat.colHeader->camDataList[newCamDataIdx].setting;
         else
-            newSetting = camera->globalCtx->colCtx.dyna.actorMeshArr[camera->bgCheckId].colHeader->camDataList[newCamDataIdx].setting;
+            newSetting = camera->globalCtx->colCtx.dyna.actorMeshArr[camera->bgCheckId]
+                             .colHeader->camDataList[newCamDataIdx]
+                             .setting;
 
         if (newCamDataIdx != -1 && newSetting && (newSetting != 0x35 || gSaveContext.linkAge)) {
             camera->camDataIdx = newCamDataIdx;


### PR DESCRIPTION
Previously the free cam was only checking static collision to update the camera setting which caused issues when standing on top of the crates in the lon lon tower as the camera setting it found was the one for the PoH area which disabled free cam and locked the camera in place. This has been changed to properly check dynamic collision when appropriate.