### PR TITLE
Fix: Prevent walking off Ganon's Castle ledge when bridge is not spawned

### DIFF
--- a/code/src/entrance.c
+++ b/code/src/entrance.c
@@ -1027,6 +1027,12 @@ void Entrance_OverrideSpawnScene(void) {
             gGlobalContext->linkActorEntry->pos.y = 0x0623;
             gGlobalContext->linkActorEntry->pos.z = 0xFF22;
         }
+
+        // Modify Ganon's Castle exit spawn to set Link's speed to a stationary spawn to avoid
+        // Link walking off the ledge when the bridge is not spawned yet
+        if (gGlobalContext->sceneNum == 100 && gGlobalContext->curSpawn == 1) {
+            gGlobalContext->linkActorEntry->params = 0x0DFF; // Stationary spawn
+        }
     }
 
     // Repair the authentically bugged scene/spawn info for leaving Barinade's boss room -> JabuJabu's belly


### PR DESCRIPTION
This is a follow up to #632 in fixing the spawn position for exiting Ganon's Castle with dungeon entrance randomizer.

Previously I believed that 3ds didn't need to modify adult Link's position as the ledge outside is larger in 3ds compared to N64. While this is technically true (the position is fine), when Link transitions through the entrance he spawns with a walking speed, causing him to auto run off the ledge and take damage. This can put <1 heart playthroughs in a soft lock as they will die and respawn with the same speed.

This updates the scene spawn override to set links entry parameters to a stationary spawn when exiting Ganon's Castle with dungeon entrance randomizer.