### PR TITLE
Fix child having incorrect access to Fire Temple Boss Door

### DIFF
--- a/source/location_access/locacc_fire_temple.cpp
+++ b/source/location_access/locacc_fire_temple.cpp
@@ -62,8 +62,9 @@ void AreaTable_Init_FireTemple() {
                      Entrance(FIRE_TEMPLE_BOSS_ENTRYWAY,
                               { [] {
                                    return BossKeyFireTemple &&
-                                          ((IsAdult && (LogicFireBossDoorJump || 
-                                             Here(FIRE_TEMPLE_FIRE_MAZE_UPPER, [] { return CanUse(MEGATON_HAMMER); }))) || 
+                                          ((IsAdult &&
+                                            (LogicFireBossDoorJump || Here(FIRE_TEMPLE_FIRE_MAZE_UPPER,
+                                                                           [] { return CanUse(MEGATON_HAMMER); }))) ||
                                            CanUse(HOVER_BOOTS));
                                },
                                 /*Glitched*/

--- a/source/location_access/locacc_fire_temple.cpp
+++ b/source/location_access/locacc_fire_temple.cpp
@@ -62,8 +62,9 @@ void AreaTable_Init_FireTemple() {
                      Entrance(FIRE_TEMPLE_BOSS_ENTRYWAY,
                               { [] {
                                    return BossKeyFireTemple &&
-                                          ((IsAdult && LogicFireBossDoorJump) || CanUse(HOVER_BOOTS) ||
-                                           Here(FIRE_TEMPLE_FIRE_MAZE_UPPER, [] { return CanUse(MEGATON_HAMMER); }));
+                                          ((IsAdult && (LogicFireBossDoorJump || 
+                                             Here(FIRE_TEMPLE_FIRE_MAZE_UPPER, [] { return CanUse(MEGATON_HAMMER); }))) || 
+                                           CanUse(HOVER_BOOTS));
                                },
                                 /*Glitched*/
                                 [] {


### PR DESCRIPTION
Logically, child could access the Fire Temple boss door in glitchless logic, but this is a bug as even with the platform hammered down, child can't jump far enough to make it across the gap. Fixes #693 