### PR TITLE
Fix hint region of Colossus Megalith area

### DIFF
--- a/source/location_access/locacc_gerudo_valley.cpp
+++ b/source/location_access/locacc_gerudo_valley.cpp
@@ -410,7 +410,7 @@ void AreaTable_Init_GerudoValley() {
                  Entrance(COLOSSUS_GROTTO, { [] { return CanUse(SILVER_GAUNTLETS); } }),
              });
 
-    areaTable[COLOSSUS_MEGALITH] = Area("Colossus Megalith", "Desert Colossus", NONE, DAY_NIGHT_CYCLE, {},
+    areaTable[COLOSSUS_MEGALITH] = Area("Colossus Megalith", "Desert Colossus", DESERT_COLOSSUS, DAY_NIGHT_CYCLE, {},
                                         {
                                             // Locations
                                             LocationAccess(COLOSSUS_FREESTANDING_POH, { [] { return true; } }),


### PR DESCRIPTION
Apparently it would inherit the hint region of the nearby dungeon, which would allow that dungeon's items to appear there.