### PR TITLE
Fix random key rings always having all enabled

### DIFF
--- a/source/settings.cpp
+++ b/source/settings.cpp
@@ -2935,8 +2935,12 @@ void UpdateSettings() {
             auto keyRings = keyRingOptions;
             Shuffle(keyRings);
             auto amount = Random(0, keyRings.size() + 1);
-            for (size_t i = 0; i < amount; i++) {
-                keyRings[i]->SetSelectedIndex(ON);
+            for (size_t i = 0; i < keyRings.size(); i++) {
+                if (i < amount) {
+                    keyRings[i]->SetSelectedIndex(ON);
+                } else {
+                    keyRings[i]->SetSelectedIndex(OFF);
+                }
             }
         }
         if (RingWell) {


### PR DESCRIPTION
The problem was I forgot to unset them during randomization.