### PR TITLE
Properly revalidate world after shuffling all entrances

### DIFF
--- a/source/entrance.cpp
+++ b/source/entrance.cpp
@@ -1313,6 +1313,11 @@ int ShuffleAllEntrances() {
         }
     }
 
+    // Verify one more time that everything is okay
+    if (!ValidateWorld(nullptr)) {
+        return ENTRANCE_SHUFFLE_FAILURE;
+    }
+
     return ENTRANCE_SHUFFLE_SUCCESS;
 }
 


### PR DESCRIPTION
The world will now be properly validated for completion after shuffling all entrances. Previously it was only validated after setting certain kinds of entrances, but this allowed an edge case to slip through.