### PR TITLE
Fix incorrect voice count for SFX shuffle

### DIFF
--- a/code/src/sfx.c
+++ b/code/src/sfx.c
@@ -43,9 +43,9 @@ u32 SetSFX(u32 original) {
 
     if (gSettingsContext.shuffleSFXCategorically) {
         if (gSettingsContext.shuffleSFX == SHUFFLESFX_SCENESPECIFIC) {
-            return rSfxData.rSFXOverrides_Types[type][(sfxID + gGlobalContext->sceneNum) % rSfxData.rSeqMaxes[type]];
+            return rSfxData.rSFXOverrides_Types[type][(sfxID + gGlobalContext->sceneNum) % rSfxData.rSeqCounts[type]];
         } else if (gSettingsContext.shuffleSFX == SHUFFLESFX_CHAOS) {
-            return rSfxData.rSFXOverrides_Types[type][(sfxID + gRandInt) % rSfxData.rSeqMaxes[type]];
+            return rSfxData.rSFXOverrides_Types[type][(sfxID + gRandInt) % rSfxData.rSeqCounts[type]];
         }
     } else {
         if (gSettingsContext.shuffleSFX == SHUFFLESFX_SCENESPECIFIC) {

--- a/code/src/sfx.h
+++ b/code/src/sfx.h
@@ -46,7 +46,7 @@ typedef enum {
 
 typedef struct {
     /// Contains the amount of sound effects in each group, excluding SEQ_NOCAT and SEQ_NOSHUFFLE.
-    u16 rSeqMaxes[SEQTYPE_COUNT];
+    u16 rSeqCounts[SEQTYPE_COUNT];
 
     /// Contains the original list of SeqTypes.
     /// Can be used to check which type a sound effect is.


### PR DESCRIPTION
When excluding Link's voice, it'd still count them for the amount of available voice lines.