### PR TITLE
Random GS Locations: Adjust pos of FoT first room emblem loc

### DIFF
--- a/source/gold_skulltulas/gs_forest_temple.cpp
+++ b/source/gold_skulltulas/gs_forest_temple.cpp
@@ -105,10 +105,13 @@ void GsTable_Init_ForestTemple() {
               GsTimeCondition{ GS_TIME_ALWAYS },
               SettingRequirements{ nullptr },
               PosRot{
-                  { 115, 858, 115 },
+                  { 115, 858, 140 },
                   { 16384, 0, 0 },
               },
-              { [] { return HookshotOrBoomerang || ((CanUseProjectile || CanUse(DINS_FIRE)) && CanUse(HOVER_BOOTS)); },
+              { [] {
+                   return CanJumpslash || HookshotOrBoomerang ||
+                          ((CanUseProjectile || CanUse(DINS_FIRE)) && CanUse(HOVER_BOOTS));
+               },
                 /*Glitched*/
                 [] {
                     return (Bombs && CanDoGlitch(GlitchType::ISG, GlitchDifficulty::INTERMEDIATE) &&


### PR DESCRIPTION
The wall this one is on is flat even though graphically there's an indent. Move it out so it can be hit easier. This also allows it to be killed, and the token collected with, a jump slash, so add that to logic.