### PR TITLE
Small updates: Less folder creation messages + clarified description

### DIFF
--- a/source/custom_music/sequence_data.cpp
+++ b/source/custom_music/sequence_data.cpp
@@ -110,11 +110,14 @@ void MusicCategoryNode::AddNewSeqData(SequenceData seqData) {
 }
 
 void MusicCategoryNode::AddExternalSeqDatas(FS_Archive sdmcArchive) {
+    // Make sure directory exists to avoid issues
+    FSUSER_CreateDirectory(sdmcArchive, fsMakePath(PATH_ASCII, GetFullPath().c_str()), FS_ATTRIBUTE_DIRECTORY);
+
     for (const auto& bcseq : fs::directory_iterator(GetFullPath())) {
         if (bcseq.is_regular_file() && bcseq.path().extension().string() == bcseqExtension) {
             std::array<u32, 4> banks = { 7, 7, 7, 7 }; // Set banks to Orchestra by default
             u16 chFlags              = -1;             // Enable all channel flags by default
-            u8 volume                = 127;            // 100% by default
+            u8 volume                = 127;            // 100% (assumed, as it's unsigned) by default
 
             // Check for cmeta file
             auto fileName = bcseq.path().stem().string();

--- a/source/descriptions.cpp
+++ b/source/descriptions.cpp
@@ -1290,7 +1290,10 @@ string_view randomGsLocationsDesc     = "Moves Gold Skulltulas to different loca
                                         "The logic is updated for any that are moved.";    //
                                                                                            //
 string_view gsLocGuaranteeNewDesc     = "Excludes the original location from the Gold\n"   //
-                                        "Skulltula's available locations pool.";           //
+                                        "Skulltula's available locations pool.\n"          //
+                                        "\n"                                               //
+                                        "If no new locations are available, the original\n"//
+                                        "will be used regardless.";                        //
                                                                                            //
                                                                                            //--------------//
 /*------------------------------                                                                           //

--- a/source/gold_skulltulas/gs_castle_town.cpp
+++ b/source/gold_skulltulas/gs_castle_town.cpp
@@ -141,23 +141,25 @@ void GsTable_Init_CastleTown() {
               { [] {
                   return IsChild && CanGetNightTimeGS && (CanJumpslash || CanUseProjectile || CanUse(DINS_FIRE));
               } } },
+            // Can become inaccessible if the guards start blocking during day time.
+            // TODO: Decide if the garden should always be open or if this should be removed.
             // https://noclip.website/#oot3d/nakaniwa;ShareData=AE$m_9vfZdTi+]mTbqHC+)/!KRcb;wUiU+_9L_kFVFpi?8o,BO9JmZv97ju?+5
-            { HC_GARDEN,
-              "Under the stone bridge where Zelda stands.",
-              GsScene{ 0x4A },
-              Room{ 0 },
-              GsTimeCondition{ GS_TIME_ALWAYS },
-              SettingRequirements{ nullptr },
-              PosRot{
-                  { -430, 64, -10 },
-                  { -32768, 0, 0 },
-              },
-              { [] { return IsChild && (CanJumpslash || CanUseProjectile); },
-                /*Glitched*/
-                [] {
-                    return IsChild && CanDoGlitch(GlitchType::RestrictedItems, GlitchDifficulty::NOVICE) &&
-                           (HasBottle || (FaroresWind && FaroresWindAnywhere)) && CanUse(DINS_FIRE);
-                } } },
+            //{ HC_GARDEN,
+            //  "Under the stone bridge where Zelda stands.",
+            //  GsScene{ 0x4A },
+            //  Room{ 0 },
+            //  GsTimeCondition{ GS_TIME_ALWAYS },
+            //  SettingRequirements{ nullptr },
+            //  PosRot{
+            //      { -430, 64, -10 },
+            //      { -32768, 0, 0 },
+            //  },
+            //  { [] { return IsChild && (CanJumpslash || CanUseProjectile); },
+            //    /*Glitched*/
+            //    [] {
+            //        return IsChild && CanDoGlitch(GlitchType::RestrictedItems, GlitchDifficulty::NOVICE) &&
+            //               (HasBottle || (FaroresWind && FaroresWindAnywhere)) && CanUse(DINS_FIRE);
+            //    } } },
         });
 
     gsTable[MARKET_GS_GUARD_HOUSE] = new GoldSkulltulaData( //

--- a/source/music.cpp
+++ b/source/music.cpp
@@ -335,31 +335,32 @@ bool archiveFound     = false;
 bool musicDirsCreated = false;
 
 void CreateMusicDirectories(FS_Archive sdmcArchive) {
-    std::vector<std::string> dirs;
+    if (R_FAILED(FSUSER_OpenDirectory(nullptr, sdmcArchive, fsMakePath(PATH_ASCII, CustomMusicRootPath.c_str())))) {
+        std::vector<std::string> dirs;
 
-    dirs.push_back("/OoT3DR/");
-    dirs.push_back(CustomMusicRootPath);
+        dirs.push_back("/OoT3DR/");
+        dirs.push_back(CustomMusicRootPath);
 
-    auto bgmDirs = mcBgm_Root.GetDirectories();
-    dirs.insert(dirs.end(), bgmDirs.begin(), bgmDirs.end());
+        auto bgmDirs = mcBgm_Root.GetDirectories();
+        dirs.insert(dirs.end(), bgmDirs.begin(), bgmDirs.end());
 
-    auto melodyDirs = mcMelodies_Root.GetDirectories();
-    dirs.insert(dirs.end(), melodyDirs.begin(), melodyDirs.end());
+        auto melodyDirs = mcMelodies_Root.GetDirectories();
+        dirs.insert(dirs.end(), melodyDirs.begin(), melodyDirs.end());
 
-    const auto printInfo = [&](int progress) {
-        consoleClear();
-        printf("\x1b[10;10HCreating Music Directories");
-        printf("\x1b[11;10HProgress: %d/%d", progress, dirs.size());
-        printf("\x1b[13;10HIf this is slow, don't worry.");
-        printf("\x1b[14;10HThis only has to be done once.");
-    };
+        const auto printInfo = [&](int progress) {
+            consoleClear();
+            printf("\x1b[10;10HCreating Music Directories");
+            printf("\x1b[11;10HProgress: %d/%d", progress, dirs.size());
 
-    printInfo(0);
-    for (size_t i = 0; i < dirs.size(); i++) {
-        FSUSER_CreateDirectory(sdmcArchive, fsMakePath(PATH_ASCII, dirs[i].c_str()), FS_ATTRIBUTE_DIRECTORY);
-        printInfo(i + 1);
+            printf("\x1b[13;10HOnly needs to be done once.");
+        };
+
+        printInfo(0);
+        for (size_t i = 0; i < dirs.size(); i++) {
+            FSUSER_CreateDirectory(sdmcArchive, fsMakePath(PATH_ASCII, dirs[i].c_str()), FS_ATTRIBUTE_DIRECTORY);
+            printInfo(i + 1);
+        }
     }
-
     musicDirsCreated = true;
 }
 


### PR DESCRIPTION
- When creating custom music folders, skip if top dir exists. Will speed up app start, but _if_ folder structure is changed it'll have to be manually removed. Add a safety check to create the node's folder if it doesn't exist during seed gen.
- Clarify in the `Guarantee New` description for `Random GS Locations` that the original location will be used if no new exist or could be chosen.
- Temporarily remove new GS loc in Zelda's Garden, as it can become inaccessible depending on story flags.