### PR TITLE
Miscellaneous Bug Fixes

### DIFF
--- a/code/src/actors/player.c
+++ b/code/src/actors/player.c
@@ -106,6 +106,11 @@ void PlayerActor_rUpdate(Actor* thisx, GlobalContext* globalCtx) {
     Player* this = (Player*)thisx;
     PlayerActor_Update(thisx, globalCtx);
 
+    // Restore Randomizer draw function in case something (like Farore's Wind) overwrote it
+    if (thisx->draw == PlayerActor_Draw) {
+        thisx->draw = PlayerActor_rDraw;
+    }
+
     Arrow_HandleSwap(this, globalCtx);
 
     if (this->naviActor != 0) {

--- a/code/src/actors/player.c
+++ b/code/src/actors/player.c
@@ -27,12 +27,20 @@
 #define PlayerDListGroup_EmptySheathAdult ((void*)0x53C4D8)
 #define PlayerDListGroup_EmptySheathChildWithHylianShield ((void*)0x53C4DC)
 
+#define OBJECT_LINK_OPENING 0x19F
+
 u16 healthDecrement = 0;
 u8 storedMask       = 0;
 
 void** Player_EditAndRetrieveCMB(ZARInfo* zarInfo, u32 objModelIdx) {
     void** cmbMan = ZAR_GetCMBByIndex(zarInfo, objModelIdx);
     void* cmb     = *cmbMan;
+
+    if (gActorOverlayTable[0].initInfo->objectId == OBJECT_LINK_OPENING) {
+        // Title Screen Link uses a different object, so don't apply the custom tunic patches
+        // to avoid displaying a broken tunic.
+        return cmbMan;
+    }
 
     if (gSettingsContext.customTunicColors == ON) {
         if (gSaveContext.linkAge == AGE_ADULT) {
@@ -52,7 +60,7 @@ void** Player_EditAndRetrieveCMB(ZARInfo* zarInfo, u32 objModelIdx) {
 }
 
 void* Player_GetCustomTunicCMAB(ZARInfo* originalZarInfo, u32 originalIndex) {
-    if (gSettingsContext.customTunicColors == OFF) {
+    if (gSettingsContext.customTunicColors == OFF || gActorOverlayTable[0].initInfo->objectId == OBJECT_LINK_OPENING) {
         return ZAR_GetCMABByIndex(originalZarInfo, originalIndex);
     }
     s16 exObjectBankIdx = Object_GetIndex(&rExtendedObjectCtx, OBJECT_CUSTOM_GENERAL_ASSETS);

--- a/code/src/item_override.c
+++ b/code/src/item_override.c
@@ -341,7 +341,6 @@ static u32 ItemOverride_PlayerIsReadyInWater(void) {
         (PLAYER->stateFlags2 & 0x000C0000) == 0 && PLAYER->actor.draw != NULL &&
         gGlobalContext->actorCtx.titleCtx.delayTimer == 0 && gGlobalContext->actorCtx.titleCtx.durationTimer == 0 &&
         gGlobalContext->actorCtx.titleCtx.alpha == 0 && (PLAYER->stateFlags1 & 0x08000000) != 0 && // Player is Swimming
-        (PLAYER->stateFlags2 & 0x400) != 0 &&           // Player is underwater
         (PLAYER->stateFlags1 & 0x400) == 0 &&           // Player is not already receiving an item when surfacing
         gGlobalContext->sceneLoadFlag == 0 &&           // Another scene isn't about to be loaded
         rPendingOverrideQueue[0].key.type == OVR_TEMPLE // Must be an item received for completing a dungeon
@@ -403,6 +402,9 @@ void ItemOverride_Update(void) {
         } else {
             ItemOverride_TryPendingItem();
             if (readyStatus == READY_IN_WATER) {
+                // Force underwater player flag in order to play the correct get-item
+                // animation even if Link is at the water's surface.
+                PLAYER->stateFlags2 |= 0x400;
                 SetupItemInWater(PLAYER, gGlobalContext);
                 rDummyActor->parent = NULL;
                 ItemOverride_PopPendingOverride();

--- a/code/src/item_override.c
+++ b/code/src/item_override.c
@@ -394,7 +394,10 @@ void ItemOverride_Update(void) {
     CustomModel_Update();
     u8 readyStatus = ItemOverride_PlayerIsReady();
     if (readyStatus) {
-        ItemOverride_PopIceTrap();
+        if (readyStatus == READY_ON_LAND) { // Ice traps effects only work on land
+            ItemOverride_PopIceTrap();
+        }
+
         if (IceTrap_IsPending()) {
             IceTrap_Give();
         } else {

--- a/code/src/menus.c
+++ b/code/src/menus.c
@@ -4,6 +4,7 @@
 #include "savefile.h"
 #include "settings.h"
 #include "dungeon_rewards.h"
+#include "item_override.h"
 
 #define gItemsMenuSpritesManager (*(MenuSpriteManager**)0x506734)
 #define gBowMenuSpritesManager (*(MenuSpriteManager**)0x506738)
@@ -147,6 +148,7 @@ u16 GearMenu_GetRewardHint(void) {
 }
 
 u16 SaveMenu_IgnoreOpen(void) {
-    return (gSettingsContext.menuOpeningButton == 0 && rInputCtx.cur.sel) ||
+    return ItemOverride_IsAPendingOverride() || // safety check to avoid missing pending overrides by save-warping
+           (gSettingsContext.menuOpeningButton == 0 && rInputCtx.cur.sel) ||
            (gSettingsContext.menuOpeningButton == 1 && rInputCtx.cur.strt);
 }

--- a/code/src/savefile.c
+++ b/code/src/savefile.c
@@ -532,6 +532,7 @@ void SaveFile_SetStartingInventory(void) {
     // Set Epona as freed if Skip Epona Race is enabled and Epona's Song is in the starting inventory
     if (gSettingsContext.skipEponaRace == SKIP && (gSaveContext.questItems >> 13) & 0x1) {
         EventSet(0x18);
+        gSaveContext.horseData.pos.y = 0xF000; // place Epona OoB, so you can't reach her without playing the song
     }
 }
 

--- a/code/src/savefile.c
+++ b/code/src/savefile.c
@@ -60,7 +60,8 @@ void SaveFile_Init(u32 fileBaseIndex) {
     gSaveContext.eventChkInf[0x4] |= 0x8020; // Entered MS chamber, Pulled MS from pedestal
     gSaveContext.eventChkInf[0xC] |= 0x0020; // Sheik Spawned at MS pedestal as Adult
 
-    gSaveContext.sceneFlags[5].swch |= 0x00010000; // remove Ruto cutscene in Water Temple
+    gSaveContext.sceneFlags[0x05].swch |= 0x00010000; // Met Ruto in Water Temple
+    gSaveContext.sceneFlags[0x5C].swch |= 0x80000000; // Spoke to owl in Desert Colossus (required for music to play)
 
     gSaveContext.otherNewEventFlags |= 0x01; // Club Moblin cutscene
 


### PR DESCRIPTION
This PR fixes the following issues:

- Warping with Farore's Wind would make the Master Sword appear in its scabbard even if Link is swordless, because the spawn animation overwrites the player's draw function. Now the randomizer's `PlayerActor_rDraw` will be restored if something overwrites it.
- Quitting to the title screen could show Link with a glitched tunic, because he uses a different object and model compared to regular gameplay. I have added some checks to avoid applying the custom tunic to this model, so Link will appear with the normal green tunic.
- The fix to put Epona out of bounds so that she could not be reached without the Ocarina was not applied when starting with Epona's Song. I've added the same fix to `SaveFile_SetStartingInventory`.
- Ice Traps on dungeon rewards would not trigger if Link spawned in the water after entering the blue warp, because the damage effects don't work in water. This made it look like there was no reward at all. Now they will instead act like traps from NPCs, showing the "FOOL" text and queuing a trap effect for the next time Link is on land.
- When completing Jabu Jabu as child with no ER, Link spawns at the water's surface, which wasn't enough to be considered "ready in water" because that required being underwater. This means the pending override wouldn't trigger until either diving or reaching land, so it could be permanently missed if the player save-warped. I have removed the underwater check and instead forced the relevant flag to be on before calling `SetupItemInWater` (this is required to play the correct Get Item animation). As additional safety, I also added a check to disable the start and select buttons if there is a pending override, to prevent save-warping.
- The long-standing bug with Desert Colossus music should be fixed now. In OoT, when exiting Spirit Temple to the silver gauntlets hand, the music plays for a split second before being overridden by the owl theme. Grezzo probably wanted to avoid this, and made it so that if you've exited Spirit Temple from the hands and you haven't yet talked to the owl, the music won't play in Desert Colossus. In the randomizer that owl never spawns, so the music never returns. The fix is simply to set the owl flag on file creation.