### PR TITLE
Remove playOption from gSettingsContext, auto detect on game start instead

### DIFF
--- a/code/src/common.c
+++ b/code/src/common.c
@@ -3,6 +3,8 @@
 #include "3ds/svc.h"
 #include "lib/printf.h"
 
+u8 playingOnCitra = 0;
+
 s8 BitCompare(u32 value1, u32 value2, u8 bit) {
     if ((value1 & (1 << bit)) > (value2 & (1 << bit))) {
         return 1;

--- a/code/src/common.h
+++ b/code/src/common.h
@@ -11,6 +11,7 @@
 #define TICKS_PER_SEC 268123480
 #define SEQ_AUDIO_BLANK 0x1000142
 
+extern u8 playingOnCitra;
 extern u32 rGameplayFrames; // globalCtx->gameplayFrames is not accurate, it doesn't increment on file 3
 
 /// Returns 1 if the bit is set in value1 but not in value2, -1 if vice versa, and 0 if they're the same

--- a/code/src/gfx.c
+++ b/code/src/gfx.c
@@ -823,7 +823,7 @@ static void Gfx_ShowMenu(void) {
     pressed = 0;
 
     Draw_ClearFramebuffer();
-    if (gSettingsContext.playOption == PLAY_ON_CONSOLE) {
+    if (!playingOnCitra) {
         Draw_FlushFramebuffer();
     }
 
@@ -968,7 +968,7 @@ static void Gfx_ShowMenu(void) {
                 showingLegend = false;
                 Draw_ClearBackbuffer();
                 Draw_CopyBackBuffer();
-                if (gSettingsContext.playOption == PLAY_ON_CONSOLE) {
+                if (!playingOnCitra) {
                     Draw_FlushFramebuffer();
                 }
                 break;
@@ -1005,7 +1005,7 @@ static void Gfx_ShowMenu(void) {
         Gfx_DrawButtonPrompts();
         Gfx_DrawHeader();
         Draw_CopyBackBuffer();
-        if (gSettingsContext.playOption == PLAY_ON_CONSOLE) {
+        if (!playingOnCitra) {
             Draw_FlushFramebuffer();
         }
 
@@ -1016,7 +1016,7 @@ static void Gfx_ShowMenu(void) {
 
 static void Gfx_ShowMultiplayerSyncMenu(void) {
     Draw_ClearFramebuffer();
-    if (gSettingsContext.playOption == PLAY_ON_CONSOLE) {
+    if (!playingOnCitra) {
         Draw_FlushFramebuffer();
     }
 
@@ -1059,7 +1059,7 @@ static void Gfx_ShowMultiplayerSyncMenu(void) {
 
                 Draw_ClearBackbuffer();
                 Draw_CopyBackBuffer();
-                if (gSettingsContext.playOption == PLAY_ON_CONSOLE) {
+                if (!playingOnCitra) {
                     Draw_FlushFramebuffer();
                 }
                 mp_isSyncing     = false;
@@ -1080,7 +1080,7 @@ static void Gfx_ShowMultiplayerSyncMenu(void) {
 
                 Draw_ClearBackbuffer();
                 Draw_CopyBackBuffer();
-                if (gSettingsContext.playOption == PLAY_ON_CONSOLE) {
+                if (!playingOnCitra) {
                     Draw_FlushFramebuffer();
                 }
                 mp_isSyncing = false;
@@ -1090,7 +1090,7 @@ static void Gfx_ShowMultiplayerSyncMenu(void) {
         }
 
         Draw_CopyBackBuffer();
-        if (gSettingsContext.playOption == PLAY_ON_CONSOLE) {
+        if (!playingOnCitra) {
             Draw_FlushFramebuffer();
         }
 

--- a/code/src/main.c
+++ b/code/src/main.c
@@ -16,6 +16,7 @@
 #include "z3D/z3D.h"
 #include "3ds/extdata.h"
 #include "3ds/services/irrst.h"
+#include "3ds/svc.h"
 
 GlobalContext* gGlobalContext = NULL;
 static u8 rRandomizerInit     = 0;
@@ -39,6 +40,10 @@ void before_GlobalContext_Update(GlobalContext* globalCtx) {
         Randomizer_Init();
         set_GlobalContext(globalCtx);
         rRandomizerInit = 1;
+
+        s64 output = 0;
+        svcGetSystemInfo(&output, 0x20000, 0);
+        playingOnCitra = (output != 0);
     }
     rGameplayFrames++;
     ItemOverride_Update();

--- a/code/src/multiplayer.c
+++ b/code/src/multiplayer.c
@@ -345,7 +345,7 @@ void Multiplayer_Run(void) {
             break;
         case 1:
             // Connect or host: Scan for a bit before creating a network
-            if (netScanChecks < (gSettingsContext.playOption == PLAY_ON_CONSOLE ? 3 : 30)) {
+            if (netScanChecks < (playingOnCitra ? 30 : 3)) {
                 netScanChecks++;
 
                 size_t total_networks        = 0;
@@ -380,7 +380,7 @@ void Multiplayer_Run(void) {
             } else {
                 u8 max_players = UDS_MAXNODES;
                 // Citra crashes when allowing too many nodes
-                if (gSettingsContext.playOption == PLAY_ON_CITRA) {
+                if (playingOnCitra) {
                     max_players /= 2;
                 }
                 udsNetworkStruct networkstruct;

--- a/code/src/settings.h
+++ b/code/src/settings.h
@@ -443,18 +443,12 @@ typedef enum {
 } MirrorWorld;
 
 typedef enum {
-    PLAY_ON_CONSOLE,
-    PLAY_ON_CITRA,
-} PlayOption;
-
-typedef enum {
     REGION_NA,
     REGION_EUR
 } REGION;
 
 typedef struct {
     u8 hashIndexes[5];
-    u8 playOption;
     u8 region;
 
     u8 logic;

--- a/source/main.cpp
+++ b/source/main.cpp
@@ -47,9 +47,10 @@ int main() {
 
         // launch oot3d directly by holding L and R (cartridge only)
         if (kHeld & KEY_L && kHeld & KEY_R) {
-            s64 output = 0;
-            svcGetSystemInfo(&output, 0x20000, 0); // This checks if the app is running on Citra
-            if (!output) {
+            s64 playingOnCitra = 0;
+            // Type 0x20000 only exists on Citra, where parameter 0 returns 1
+            svcGetSystemInfo(&playingOnCitra, 0x20000, 0);
+            if (!playingOnCitra) {
                 if (Settings::Region == REGION_NA) {
                     aptSetChainloader(0x0004000000033500, 2);
                 } else if (Settings::Region == REGION_EUR) {

--- a/source/settings.cpp
+++ b/source/settings.cpp
@@ -1367,7 +1367,6 @@ SettingsContext FillContext() {
     ctx.hashIndexes[2]  = hashIconIndexes[2];
     ctx.hashIndexes[3]  = hashIconIndexes[3];
     ctx.hashIndexes[4]  = hashIconIndexes[4];
-    ctx.playOption      = PlayOption;
     ctx.region          = Region;
 
     ctx.logic                = Logic.Value<u8>();


### PR DESCRIPTION
Allows safer sharing of seeds between console and emulator.

For example, using a `code.bin` on Citra that was originally generated on console, _and_ had multiplayer enabled, would crash because of the issue where Citra can't do local play with 16 nodes.