### PR TITLE
Custom Music QoL Update

### DIFF
--- a/source/custom_music/cmeta_interpreter.cpp
+++ b/source/custom_music/cmeta_interpreter.cpp
@@ -1,0 +1,116 @@
+#include <iostream>
+#include <fstream>
+#include <string>
+#include <sstream>
+#include <algorithm>
+#include <cctype>
+
+#include "cmeta_interpreter.hpp"
+
+static const std::string CMETAKEY_BANKS    = "banks";
+static const std::string CMETAKEY_CHFLAGS  = "chFlags";
+static const std::string CMETAKEY_VOLUME   = "volume";
+static const std::string CMETAKEY_CATEGORY = "category";
+
+CMetaInterpreter::CMetaInterpreter(std::string path) : banks{ 7, 7, 7, 7 }, channelFlags(-1), volume(0x7F) {
+    // Set banks to Orchestra by default
+    // Enable all channel flags by default
+    // 100% volume (assumed, as it's unsigned) by default
+
+    std::fstream f(path);
+    std::string f_out;
+    while (std::getline(f, f_out)) {
+        std::stringstream ss(f_out);
+        std::string key;
+        std::string value;
+        std::getline(ss, key, '=');
+        std::getline(ss, value, '=');
+
+        // Removes leading and trailing spaces, tabs, and newline characters
+        const auto sanitizeInput = [](std::string& str) {
+            std::replace(str.begin(), str.end(), '\t', ' ');
+            str.erase(0, str.find_first_not_of(' '));
+            str.erase(str.find_last_not_of(' ') + 1);
+            while (str.back() == '\n' || str.back() == '\r') {
+                str.pop_back();
+            }
+        };
+
+        sanitizeInput(key);
+        sanitizeInput(value);
+
+        const auto getIntFromValue = [](std::string value) {
+            if (value.length() > 2) {
+                // Hexadecimal
+                if (value[0] == '0' && value[1] == 'x') {
+                    return std::stoi(value, nullptr, 16);
+                }
+                // Binary
+                else if (value[0] == '0' && value[1] == 'b') {
+                    value.erase(0, 2);
+                    return std::stoi(value, nullptr, 2);
+                }
+            }
+            // Percentage, decimal (Should only be used for volume)
+            if (value.back() == '%') {
+                value.pop_back();
+                return std::min(0xFF, (int)(0xFF * (std::stoi(value) / 200.0f)));
+            }
+            // Decimal
+            return std::stoi(value);
+        };
+
+        if (key == CMETAKEY_BANKS) {
+            // Effectively treat all non-alphanumerical symbols as separators
+            for (size_t i = 0; i < value.length(); i++) {
+                if (!isalnum(value.at(i))) {
+                    value.at(i) = ' ';
+                }
+            }
+            std::stringstream bs(value);
+            u8 i = 0;
+            std::string bs_out;
+            while (std::getline(bs, bs_out, ' ')) {
+                // Two spaces in a row gives an empty token; skip them
+                if (bs_out.empty()) {
+                    continue;
+                }
+                // At most four banks can be set
+                if (i >= 4) {
+                    break;
+                }
+                banks.at(i) = getIntFromValue(bs_out);
+                i++;
+            }
+        } else if (key == CMETAKEY_CHFLAGS) {
+            channelFlags = getIntFromValue(value);
+        } else if (key == CMETAKEY_VOLUME) {
+            volume = getIntFromValue(value);
+        } else if (key == CMETAKEY_CATEGORY) {
+            category = value;
+            if (category.front() == '!') {
+                category.erase(0, category.find_first_not_of('!'));
+            }
+        }
+    }
+
+    f.close();
+}
+
+CMetaInterpreter::~CMetaInterpreter() = default;
+
+const std::array<u32, 4>& CMetaInterpreter::GetBanks() {
+    return banks;
+}
+
+u16 CMetaInterpreter::GetChannelFlags() {
+    return channelFlags;
+}
+
+u8 CMetaInterpreter::GetVolume() {
+    return volume;
+}
+
+const std::string& CMetaInterpreter::GetCategory() {
+    return category;
+}

--- a/source/custom_music/cmeta_interpreter.hpp
+++ b/source/custom_music/cmeta_interpreter.hpp
@@ -1,0 +1,22 @@
+#pragma once
+
+#include <3ds.h>
+#include <string>
+#include <array>
+
+class CMetaInterpreter {
+  public:
+    CMetaInterpreter(std::string path);
+    ~CMetaInterpreter();
+
+    const std::array<u32, 4>& GetBanks();
+    u16 GetChannelFlags();
+    u8 GetVolume();
+    const std::string& GetCategory();
+
+  private:
+    std::array<u32, 4> banks;
+    u16 channelFlags;
+    u8 volume;
+    std::string category;
+};

--- a/source/custom_music/sequence_data.hpp
+++ b/source/custom_music/sequence_data.hpp
@@ -5,13 +5,18 @@
 #include <string>
 #include <array>
 
+#include "cmeta_interpreter.hpp"
+
 static const std::string CustomMusicRootPath = "/OoT3DR/Custom Music/";
+static const std::string bcseqExtension      = ".bcseq";
+static const std::string cmetaExtension      = ".cmeta";
 
 class SequenceData {
   public:
     SequenceData();
     SequenceData(std::vector<u8>* rawBytesPtr_, std::array<u32, 4> banks_, u16 chFlags_, u8 volume_);
-    SequenceData(std::string filePath_, std::array<u32, 4> banks_, u16 chFlags_, u8 volume_);
+    SequenceData(std::string bcseqPath_, CMetaInterpreter& ci);
+    SequenceData(std::string bcseqPath_, std::string cmetaPath_);
     ~SequenceData();
 
     /// Returns the raw bytes of the sequence.
@@ -19,13 +24,17 @@ class SequenceData {
     ///   If this Sequence Data is empty, returns an empty byte vector.
     /// - PATH Type: Returns the raw bytes of the external sequence.
     ///   Reads the file only the first time this is called.
-    std::vector<u8> GetData(FS_Archive archive_);
+    std::vector<u8>& GetData(FS_Archive archive_);
+
     /// Returns the bank index.
     std::array<u32, 4> GetBanks();
     /// Returns the bits of the set flags.
     u16 GetChFlags();
     /// Returns the volume.
     u8 GetVolume();
+
+    /// Keeps track of if the meta data has been set
+    bool valuesSet = false;
 
   private:
     enum DataType {
@@ -39,7 +48,9 @@ class SequenceData {
     std::vector<u8>* rawBytesPtr;
 
     /// PATH Type: The full path to the external sequence
-    std::string filePath;
+    std::string bcseqPath;
+    /// PATH Type: The full path to the cmeta file
+    std::string cmetaPath;
     /// PATH Type: The raw bytes of the external sequence
     std::vector<u8> rawBytes;
 
@@ -81,6 +92,9 @@ class MusicCategoryNode {
 
     /// Returns all leaves in this node's children.
     std::vector<MusicCategoryLeaf*> GetAllLeaves();
+    /// Returns the first (and hopefully only) node in this family tree with the same name.
+    /// If no match was found, returns nullptr.
+    MusicCategoryNode* GetNodeByName(const std::string name);
 
     const std::string Name;
 

--- a/source/custom_music/sound_archive.cpp
+++ b/source/custom_music/sound_archive.cpp
@@ -1,9 +1,10 @@
+#include <cstring>
+
 #include "sound_archive.hpp"
 #include "ctr_binary_data.hpp"
 #include "reference_structures.hpp"
 #include "file_reader.hpp"
 #include "common_structures.hpp"
-#include <cstring>
 
 SoundArchive::SoundArchive(FS_Archive archive_, const std::string& filePath_) {
     BinaryDataReader br(archive_, filePath_);

--- a/source/music.cpp
+++ b/source/music.cpp
@@ -1,10 +1,14 @@
-#include "music.hpp"
-#include "random.hpp"
 #include <3ds.h>
 #include <cstdlib>
+#include <filesystem>
+#include <functional>
+
+#include "music.hpp"
+#include "random.hpp"
 #include "settings.hpp"
 #include "sound_archive.hpp"
 #include "sequence_data.hpp"
+#include "cmeta_interpreter.hpp"
 
 namespace Music {
 // clang-format off
@@ -148,7 +152,6 @@ static MusicCategoryLeaf mcBgm_TempleTime("Temple of Time", 43);
 static MusicCategoryLeaf mcBgm_Windmill("Windmill", 61);
 static MusicCategoryLeaf mcBgm_ShopTheme("Shop Theme", 70);
 static MusicCategoryLeaf mcBgm_Drugstore("Drugstore", 80);
-static MusicCategoryLeaf mcBgm_Underground("Underground", 83);
 // BGM: Dungeons
 static MusicCategoryLeaf mcBgm_MiscDungeon("Misc Dungeon", 10);
 static MusicCategoryLeaf mcBgm_InsideDekuTree("Deku Tree", 14);
@@ -160,6 +163,7 @@ static MusicCategoryLeaf mcBgm_SpiritTemple("Spirit Temple", 48);
 static MusicCategoryLeaf mcBgm_IceCavern("Ice Cavern", 73);
 static MusicCategoryLeaf mcBgm_ShadowTemple("Shadow Temple", 76);
 static MusicCategoryLeaf mcBgm_WaterTemple("Water Temple", 77);
+static MusicCategoryLeaf mcBgm_GanonsCastle("Ganon's Castle", 83);
 // BGM: Area Themes
 static MusicCategoryNode mcBgm_Overworld("Overworld", {
                                                           &mcBgm_HyruleField,
@@ -180,7 +184,6 @@ static MusicCategoryNode mcBgm_Interiors("Interiors", {
                                                           &mcBgm_Windmill,
                                                           &mcBgm_ShopTheme,
                                                           &mcBgm_Drugstore,
-                                                          &mcBgm_Underground,
                                                       });
 static MusicCategoryNode mcBgm_Dungeons("Dungeons", {
                                                         &mcBgm_MiscDungeon,
@@ -193,6 +196,7 @@ static MusicCategoryNode mcBgm_Dungeons("Dungeons", {
                                                         &mcBgm_IceCavern,
                                                         &mcBgm_ShadowTemple,
                                                         &mcBgm_WaterTemple,
+                                                        &mcBgm_GanonsCastle,
                                                     });
 // BGM: Event Music
 static MusicCategoryLeaf mcBgm_TitleScreen("Title Screen", 16);
@@ -457,8 +461,55 @@ int ShuffleMusic_Archive() {
 
     // Add external sequences
     if (Settings::CustomMusic) {
+        // This adds the categorized sequences, inside the node folders
         mcBgm_Root.AddExternalSeqDatas(sdmcArchive);
         mcMelodies_Root.AddExternalSeqDatas(sdmcArchive);
+
+        // This adds the sequences uncategorized in the Custom Music folder, but not in any node
+        std::function<void(std::string)> addUncategorizedSeqDatas = [&](std::string folderPath) {
+            namespace fs = std::filesystem;
+            for (const auto& bcseq : fs::directory_iterator(folderPath)) {
+                if (bcseq.is_directory()) {
+                    // Exclamation mark indicates a tree node
+                    if (bcseq.path().stem().string().front() == '!') {
+                        continue;
+                    } else {
+                        addUncategorizedSeqDatas(bcseq.path().string());
+                    }
+                } else if (bcseq.is_regular_file() && bcseq.path().extension().string() == bcseqExtension) {
+                    for (const auto& cmeta : fs::directory_iterator(folderPath)) {
+                        if (cmeta.is_regular_file() && cmeta.path().stem().string() == bcseq.path().stem().string() &&
+                            cmeta.path().extension().string() == cmetaExtension) {
+
+                            CMetaInterpreter ci(cmeta.path().string());
+
+                            MusicCategoryNode* n = nullptr;
+
+                            n = mcBgm_Root.GetNodeByName(ci.GetCategory());
+                            if (n != nullptr) {
+                                if (Settings::ShuffleBGM.Is(SHUFFLEMUSIC_MIXED)) {
+                                    mcBgm_Root.AddNewSeqData(SequenceData(bcseq.path().string(), ci));
+                                } else {
+                                    n->AddNewSeqData(SequenceData(bcseq.path().string(), ci));
+                                }
+                                break;
+                            }
+                            n = mcMelodies_Root.GetNodeByName(ci.GetCategory());
+                            if (n != nullptr) {
+                                if (Settings::ShuffleMelodies.Is(SHUFFLEMUSIC_MIXED)) {
+                                    mcMelodies_Root.AddNewSeqData(SequenceData(bcseq.path().string(), ci));
+                                } else {
+                                    n->AddNewSeqData(SequenceData(bcseq.path().string(), ci));
+                                }
+                                break;
+                            }
+                            break;
+                        }
+                    }
+                }
+            }
+        };
+        addUncategorizedSeqDatas(CustomMusicRootPath);
     }
 
     // Shuffle


### PR DESCRIPTION
- Change cmeta to be text files
- Sequences can be put in folders: 
  - If a node has a non-node folder, it looks through it and all it's children for sequences. 
  - If there are sequences, whether directly or in folders, in the Custom Music folder, they're considered too. The cmeta is read and the sequence is added to the node of the category, or if music shuffle is mixed, to the root node.
- Change Underground node to Ganon's Castle