### PR TITLE
Multiplayer: Show up to 3 other players as Link

### DIFF
--- a/code/include/z3D/z3D.h
+++ b/code/include/z3D/z3D.h
@@ -780,8 +780,8 @@ typedef void (*PlaySound_proc)(u32);
 #define PlaySound ((PlaySound_proc)PlaySound_addr)
 
 typedef Actor* (*Actor_Spawn_proc)(ActorContext* actorCtx, GlobalContext* globalCtx, s16 actorId, float posX,
-                                   float posY, float posZ, s16 rotX, s16 rotY, s16 rotZ, s16 params)
-    __attribute__((pcs("aapcs-vfp")));
+                                   float posY, float posZ, s16 rotX, s16 rotY, s16 rotZ, s16 params,
+                                   s32 initImmediately) __attribute__((pcs("aapcs-vfp")));
 #define Actor_Spawn_addr 0x3738D0
 #define Actor_Spawn ((Actor_Spawn_proc)Actor_Spawn_addr)
 

--- a/code/include/z3D/z3D.h
+++ b/code/include/z3D/z3D.h
@@ -846,6 +846,12 @@ typedef s32 (*Audio_PlayActorSfx2_proc)(Actor* actor, s32 sfxID);
 #define Audio_PlayActorSfx2_addr 0x375BCC
 #define Audio_PlayActorSfx2 ((Audio_PlayActorSfx2_proc)Audio_PlayActorSfx2_addr)
 
+typedef s32 (*Model_GetMeshGroupCount_proc)(SkeletonAnimationModel* skelAnimeModel);
+#define Model_GetMeshGroupCount ((Model_GetMeshGroupCount_proc)0x2BB71C)
+
+typedef s32 (*Model_IsMeshGroupUsed_proc)(SkeletonAnimationModel* skelAnimeModel, s32 param);
+#define Model_IsMeshGroupUsed ((Model_IsMeshGroupUsed_proc)0x4C6880)
+
 typedef void (*Model_EnableMeshGroupByIndex_proc)(SkeletonAnimationModel* skel, u32 index);
 #define Model_EnableMeshGroupByIndex ((Model_EnableMeshGroupByIndex_proc)0x37266C)
 

--- a/code/include/z3D/z3D.h
+++ b/code/include/z3D/z3D.h
@@ -453,7 +453,7 @@ typedef struct OcLine OcLine; // TODO
 #define COLLISION_CHECK_OC_MAX 50
 #define COLLISION_CHECK_OC_LINE_MAX 3
 
-typedef struct {
+typedef struct CollisionCheckContext {
     /* 0x000 */ s16 colAtCount;
     /* 0x002 */ u16 sacFlags;
     /* 0x004 */ Collider* colAt[COLLISION_CHECK_AT_MAX];

--- a/code/include/z3D/z3Dactor.h
+++ b/code/include/z3D/z3Dactor.h
@@ -250,7 +250,11 @@ typedef struct DynaPolyActor {
 
 typedef struct {
     /* 0x0000 */ Actor actor;
-    /* 0x01A4 */ char unk_148[0x0005];
+    /* 0x01A4 */ s8 currentTunic;
+    /* 0x01A5 */ s8 currentSword;
+    /* 0x01A6 */ s8 currentShield;
+    /* 0x01A7 */ s8 currentBoots;
+    /* 0x01A8 */ s8 heldItemButton;
     /* 0x01A9 */ s8 heldItemActionParam;
     /* 0x01AA */ u8 heldItemId;
     /* 0x01AB */ char unk_1AB[0x1];

--- a/code/include/z3D/z3Dactor.h
+++ b/code/include/z3D/z3Dactor.h
@@ -305,7 +305,10 @@ typedef struct {
     /* 0x2250 */ char unk_2250[0x0238];
     /* 0x2488 */ s8 invincibilityTimer; // prevents damage when nonzero
                                         // (positive = visible, counts towards zero each frame)
-    /* 0x2489 */ char unk_2489[0x27B];
+    /* 0x2489 */ char unk_2489[0x0053];
+    /* 0x24DC */ void* cmbMan;
+    /* 0x24E0 */ void* zarInfo;
+    /* 0x24E4 */ char unk_24E4[0x0220];
     /* 0x2704 */ struct SkeletonAnimationModel_unk_0C* bodyTexAnim;
 } Player; // total size (from init vars): 2A4C
 

--- a/code/include/z3D/z3Dactor.h
+++ b/code/include/z3D/z3Dactor.h
@@ -29,7 +29,11 @@ typedef struct {
 } SkeletonAnimationModel_VTable;
 
 typedef struct SkeletonAnimationModel_unk_10 {
-    /* 0x00 */ char unk_00[0x14];
+    /* 0x00 */ void* unk_00;
+    /* 0x04 */ void* unk_04;
+    /* 0x08 */ s32 unk_08;
+    /* 0x0C */ s32 unk_0C;
+    /* 0x10 */ s32 unk_10;
 } SkeletonAnimationModel_unk_10; // size = 0x14
 
 typedef struct SkeletonAnimationModel_unk_0C {
@@ -279,7 +283,9 @@ typedef struct {
     /* 0x024C */ void* giDrawSpace;
     /* 0x0250 */ char unk_250[0x0004];
     /* 0x0254 */ struct SkelAnime skelAnime;
-    /* 0x02D8 */ char unk_2D8[0x0F4C];
+    /* 0x02D8 */ char jointTable[0x514];
+    /* 0x07EC */ char morphTable[0x514];
+    /* 0x0D00 */ char unk_2D8[0x0524];
     /* 0x1224 */ Actor* heldActor;
     /* 0x1228 */ char unk_1228[0x84];
     /* 0x12AC */ u8 getItemId;

--- a/code/include/z3D/z3Dcollision_check.h
+++ b/code/include/z3D/z3Dcollision_check.h
@@ -1,0 +1,119 @@
+#ifndef _Z3DCOLLISION_CHECK_H_
+#define _Z3DCOLLISION_CHECK_H_
+
+#include "z3Dvec.h"
+
+struct GlobalContext;
+struct CollisionCheckContext;
+
+typedef struct {
+    /* 0x00 */ struct Actor* actor; // Attached actor
+    /* 0x04 */ struct Actor* at;    // Actor attached to what it collided with as an AT collider.
+    /* 0x08 */ struct Actor* ac;    // Actor attached to what it collided with as an AC collider.
+    /* 0x0C */ struct Actor* oc;    // Actor attached to what it collided with as an OC collider.
+    /* 0x10 */ u8 atFlags;          // Information flags for AT collisions.
+    /* 0x11 */ u8 acFlags;          // Information flags for AC collisions.
+    /* 0x12 */ u8 ocFlags1;         // Information flags for OC collisions.
+    /* 0x13 */ u8 ocFlags2;         // Flags related to which colliders it can OC collide with.
+    /* 0x14 */ u8 colType;          // Determines hitmarks and sound effects during AC collisions.
+    /* 0x15 */ u8 shape;            // JntSph, Cylinder, Tris, or Quad
+} Collider;                         // size = 0x18
+_Static_assert(sizeof(Collider) == 0x18, "Collider size");
+
+typedef struct {
+    /* 0x00 */ u32 damageFlags;
+    /* 0x04 */ u8 effect;
+    /* 0x05 */ u8 damage;
+} ColliderTouch; // size = 0x8
+_Static_assert(sizeof(ColliderTouch) == 0x8, "ColliderTouch size");
+
+typedef struct {
+    /* 0x00 */ u32 damageFlags;
+    /* 0x04 */ u8 effect;
+    /* 0x05 */ u8 defense;
+    /* 0x06 */ Vec3s hitPos;
+} ColliderBump; // size = 0xC
+_Static_assert(sizeof(ColliderBump) == 0xC, "ColliderBump size");
+
+typedef struct {
+    /* 0x00 */ ColliderTouch toucher;
+    /* 0x08 */ ColliderBump bumper;
+    /* 0x14 */ u8 elementType;
+    /* 0x15 */ u8 toucherFlags;
+    /* 0x16 */ u8 bumperFlags;
+    /* 0x17 */ u8 ocElementFlags;
+    /* 0x18 */ Collider* at_hit;
+    /* 0x1C */ Collider* ac_hit;
+    /* 0x20 */ Collider* at_hit_info;
+    /* 0x24 */ Collider* ac_hit_info;
+} ColliderInfo; // size = 0x28
+_Static_assert(sizeof(ColliderInfo) == 0x28, "ColliderInfo size");
+
+typedef struct {
+    /* 0x00 */ f32 radius;
+    /* 0x04 */ f32 height;
+    /* 0x08 */ f32 yShift;
+    /* 0x0C */ Vec3f position;
+} Cylinderf; // size = 0x18
+_Static_assert(sizeof(Cylinderf) == 0x18, "Cylinderf size");
+
+typedef struct {
+    /* 0x00 */ Collider base;
+    /* 0x18 */ ColliderInfo info;
+    /* 0x40 */ Cylinderf dim;
+} ColliderCylinder; // size = 0x58
+_Static_assert(sizeof(ColliderCylinder) == 0x58, "ColliderCylinder size");
+
+typedef struct {
+    /* 0x00 */ u8 type;
+    /* 0x01 */ u8 atFlags;
+    /* 0x02 */ u8 acFlags;
+    /* 0x03 */ u8 maskA;
+    /* 0x04 */ u8 maskB;
+    /* 0x05 */ u8 shape;
+} ColliderInit; // size = 0x6
+_Static_assert(sizeof(ColliderInit) == 0x6, "ColliderInit size");
+
+typedef struct {
+    /* 0x00 */ u32 damageFlags;
+    /* 0x04 */ u8 effect;
+    /* 0x05 */ u8 defense;
+} ColliderBumpInit; // size = 0x8
+_Static_assert(sizeof(ColliderBumpInit) == 0x8, "ColliderBumpInit size");
+
+typedef struct {
+    /* 0x00 */ u8 elementType;
+    /* 0x04 */ ColliderTouch toucher;
+    /* 0x0C */ ColliderBumpInit bumper;
+    /* 0x14 */ u8 toucherFlags;
+    /* 0x15 */ u8 bumperFlags;
+    /* 0x16 */ u8 ocElementFlags;
+} ColliderInfoInit; // size = 0x18
+_Static_assert(sizeof(ColliderInfoInit) == 0x18, "ColliderInfoInit size");
+
+typedef struct {
+    /* 0x00 */ ColliderInit base;
+    /* 0x08 */ ColliderInfoInit info;
+    /* 0x20 */ Cylinderf dim;
+} ColliderCylinderInit; // size = 0x58
+_Static_assert(sizeof(ColliderCylinderInit) == 0x38, "ColliderCylinderInit size");
+
+typedef void (*Collider_InitCylinder_proc)(struct GlobalContext* globalCtx, ColliderCylinder* collider);
+#define Collider_InitCylinder ((Collider_InitCylinder_proc)0x353DD0)
+
+typedef void (*Collider_SetCylinder_proc)(struct GlobalContext* globalCtx, ColliderCylinder* collider,
+                                          struct Actor* actor, void* cylinderInitData);
+#define Collider_SetCylinder ((Collider_SetCylinder_proc)0x353D24)
+
+typedef void (*Collider_UpdateCylinder_proc)(struct Actor* actor, ColliderCylinder* collider);
+#define Collider_UpdateCylinder ((Collider_UpdateCylinder_proc)0x37632C)
+
+typedef void (*CollisionCheck_SetOC_proc)(struct GlobalContext* globalCtx, struct CollisionCheckContext* colChkCtx,
+                                          void* collider);
+#define CollisionCheck_SetOC ((CollisionCheck_SetOC_proc)0x3762A4)
+
+typedef void (*CollisionCheck_SetAC_proc)(struct GlobalContext* globalCtx, struct CollisionCheckContext* colChkCtx,
+                                          void* collider);
+#define CollisionCheck_SetAC ((CollisionCheck_SetAC_proc)0x376168)
+
+#endif //_Z3DCOLLISION_CHECK_H_

--- a/code/src/actor.c
+++ b/code/src/actor.c
@@ -61,6 +61,7 @@
 #include "red_ice.h"
 #include "shabom.h"
 #include "anubis.h"
+#include "link_puppet.h"
 
 #define OBJECT_GI_KEY 170
 #define OBJECT_GI_BOSSKEY 185
@@ -84,6 +85,8 @@ void Actor_Init() {
     gActorOverlayTable[0x0].initInfo->update  = PlayerActor_rUpdate;
     gActorOverlayTable[0x0].initInfo->destroy = PlayerActor_rDestroy;
     gActorOverlayTable[0x0].initInfo->draw    = PlayerActor_rDraw;
+
+    gActorOverlayTable[0x1].initInfo = &EnLinkPuppet_InitVars;
 
     gActorOverlayTable[0x4].initInfo->init         = ShopsanityItem_Init;
     gActorOverlayTable[0x4].initInfo->instanceSize = sizeof(ShopsanityItem);

--- a/code/src/actors/chest.c
+++ b/code/src/actors/chest.c
@@ -246,16 +246,16 @@ u8 Chest_OverrideIceSmoke(Actor* thisx) {
             case ICETRAP_BOMB_SIMPLE:
             case ICETRAP_BOMB_KNOCKDOWN:
                 sBomb = Actor_Spawn(&gGlobalContext->actorCtx, gGlobalContext, 0x10, thisx->world.pos.x,
-                                    thisx->world.pos.y, thisx->world.pos.z, 0, 0, 0, 0);
+                                    thisx->world.pos.y, thisx->world.pos.z, 0, 0, 0, 0, FALSE);
                 break;
             case ICETRAP_ANTIFAIRY:
                 sFairy = (EnElf*)Actor_Spawn(&gGlobalContext->actorCtx, gGlobalContext, 0x18, thisx->world.pos.x,
-                                             thisx->world.pos.y, thisx->world.pos.z, 0, 0, 0, 0x5);
+                                             thisx->world.pos.y, thisx->world.pos.z, 0, 0, 0, 0x5, FALSE);
                 PLAYER->actor.home.pos.y = -5000; // Make Link airborne for a frame to cancel the get item event
                 break;
             case ICETRAP_RUPPY:
                 Actor_Spawn(&gGlobalContext->actorCtx, gGlobalContext, 0x131, thisx->world.pos.x,
-                            thisx->world.pos.y + 30, thisx->world.pos.z, 0, 0, 0, 0x2);
+                            thisx->world.pos.y + 30, thisx->world.pos.z, 0, 0, 0, 0x2, FALSE);
                 PLAYER->actor.home.pos.y = -5000; // Make Link airborne for a frame to cancel the get item event
                 break;
             case ICETRAP_FIRE:

--- a/code/src/actors/gerudos.c
+++ b/code/src/actors/gerudos.c
@@ -18,7 +18,7 @@ void EnGe1_rInit(Actor* thisx, GlobalContext* globalCtx) {
     if ((self->actor.params & 0xFF) == GE1_TYPE_GATE_OPERATOR) {
         if (gSettingsContext.shuffleGerudoToken || gSettingsContext.shuffleOverworldEntrances
             /* || gSettingsContext.shuffleInteriorEntrances || gSettingsContexts.shuffleSpawnPositions*/) {
-            Actor_Spawn(&globalCtx->actorCtx, globalCtx, 0x138, -1358.0f, 88.0f, -3018.0f, 0, 0x95B0, 0, 0x0302);
+            Actor_Spawn(&globalCtx->actorCtx, globalCtx, 0x138, -1358.0f, 88.0f, -3018.0f, 0, 0x95B0, 0, 0x0302, FALSE);
         }
     } else if ((self->actor.params & 0xFF) == GE1_TYPE_EXTRA_GATE_OPERATOR) {
         self->actor.params &= ~0xFF;

--- a/code/src/actors/jabu.c
+++ b/code/src/actors/jabu.c
@@ -25,7 +25,7 @@ void BgBdanSwitch_rInit(Actor* thisx, GlobalContext* globalCtx) {
     if ((gSaveContext.infTable[0x14] & 0x20 || gSaveContext.eventChkInf[3] & 0x0080) &&
         gSettingsContext.jabuJabusBellyDungeonMode == DUNGEONMODE_MQ && globalCtx->sceneNum == 2 && thisx->room == 3 &&
         ((thisx->params & 0x000F) == 0)) {
-        Actor_Spawn(&globalCtx->actorCtx, globalCtx, 0x110, 222.0f, -1113.0f, -3270.0f, 0, 0, 0, 0);
+        Actor_Spawn(&globalCtx->actorCtx, globalCtx, 0x110, 222.0f, -1113.0f, -3270.0f, 0, 0, 0, 0, FALSE);
     }
     BgBdanSwitch_Init(thisx, globalCtx);
 }

--- a/code/src/actors/lake_hylia_objects.c
+++ b/code/src/actors/lake_hylia_objects.c
@@ -35,15 +35,15 @@ void BgSpot06Objects_rUpdate(Actor* thisx, GlobalContext* globalCtx) {
         }
 
         // Spawn a floor switch
-        floorSwitch =
-            Actor_Spawn(&globalCtx->actorCtx, globalCtx, 0x12A, -896.0f, -1243.0f, 6953.0f, 0, 0, 0, switchParams);
+        floorSwitch = Actor_Spawn(&globalCtx->actorCtx, globalCtx, 0x12A, -896.0f, -1243.0f, 6953.0f, 0, 0, 0,
+                                  switchParams, FALSE);
 
         // Spawn a sign
-        Actor_Spawn(&globalCtx->actorCtx, globalCtx, 0x141, -970.0f, -1242.0f, 6954.0f, 0, 0, 0, 0x0046);
+        Actor_Spawn(&globalCtx->actorCtx, globalCtx, 0x141, -970.0f, -1242.0f, 6954.0f, 0, 0, 0, 0x0046, FALSE);
 
         // Spawn a Navi check spot
         if (!(gSaveContext.eventChkInf[4] & 0x0400)) { // Water Temple blue warp not cleared
-            Actor_Spawn(&globalCtx->actorCtx, globalCtx, 0x173, -896.0f, -1243.0f, 6953.0f, 0, 0, 0, 0x3DB3);
+            Actor_Spawn(&globalCtx->actorCtx, globalCtx, 0x173, -896.0f, -1243.0f, 6953.0f, 0, 0, 0, 0x3DB3, FALSE);
         }
 
         actionCounter++;

--- a/code/src/actors/link_puppet.c
+++ b/code/src/actors/link_puppet.c
@@ -1,0 +1,141 @@
+#include <stddef.h>
+#include <string.h>
+
+#include "link_puppet.h"
+#include "common.h"
+
+// Draw at most three extra Links. More can cause graphical issues that persist until game restart.
+#define MAX_PUPPETS_AT_ONCE 3
+
+ActorInit EnLinkPuppet_InitVars = {
+    0x1,                  // ID
+    ACTORTYPE_NPC,        // Type
+    0xFF,                 // Room
+    0b110000,             // Flags
+    21,                   // Object ID (20: Adult, 21: Child)
+    sizeof(EnLinkPuppet), //
+    EnLinkPuppet_Init,    //
+    EnLinkPuppet_Destroy, //
+    EnLinkPuppet_Update,  //
+    EnLinkPuppet_Draw,    //
+};
+
+typedef void (*SkelAnime_InitLink_proc)(SkelAnime* skelAnime, ZARInfo* zarInfo, GlobalContext* globalCtx, void* cmbMan,
+                                        void* param_5, u32 animation, s32 limbBufCount, void* jointTable,
+                                        void* morphTable);
+#define SkelAnime_InitLink ((SkelAnime_InitLink_proc)0x3413EC)
+
+void EnLinkPuppet_Init(Actor* thisx, GlobalContext* globalCtx) {
+    EnLinkPuppet* this = (EnLinkPuppet*)thisx;
+
+    this->base.room = -1;
+
+    SkelAnime_InitLink(&this->skelAnime, PLAYER->zarInfo, globalCtx, PLAYER->cmbMan, thisx->unk_178, 0, 9, NULL, NULL);
+    for (size_t index = 0; index < BIT_COUNT(this->ghostPtr->ghostData.meshGroups1); index++) {
+        Model_DisableMeshGroupByIndex(this->skelAnime.unk_28, index);
+    }
+    for (size_t index = 0; index < BIT_COUNT(this->ghostPtr->ghostData.meshGroups2); index++) {
+        Model_DisableMeshGroupByIndex(this->skelAnime.unk_28, index + BIT_COUNT(u32));
+    }
+}
+
+typedef void (*SkelAnime_Free2_proc)(SkelAnime* anime);
+#define SkelAnime_Free2 ((SkelAnime_Free2_proc)0x350BE0)
+
+void EnLinkPuppet_Destroy(Actor* thisx, GlobalContext* globalCtx) {
+    EnLinkPuppet* this = (EnLinkPuppet*)thisx;
+
+    SkelAnime_Free2(&this->skelAnime);
+}
+
+void EnLinkPuppet_Update(Actor* thisx, GlobalContext* globalCtx) {
+    EnLinkPuppet* this = (EnLinkPuppet*)thisx;
+
+    if (this->ghostPtr == NULL) {
+        // Need to set the ghost data pointer first!
+        return;
+    }
+
+    if (!this->ghostPtr->inUse) {
+        Actor_Kill(thisx);
+        return;
+    }
+
+    if (this->ghostPtr->ghostData.currentScene != gGlobalContext->sceneNum) {
+        Actor_Kill(thisx);
+        return;
+    }
+
+    this->base.world.pos = this->ghostPtr->ghostData.position;
+    this->base.shape.rot = this->ghostPtr->ghostData.rotation;
+    for (size_t index = 0; index < BIT_COUNT(this->ghostPtr->ghostData.meshGroups1); index++) {
+        if (this->ghostPtr->ghostData.meshGroups1 & (0b1 << index)) {
+            Model_EnableMeshGroupByIndex(this->skelAnime.unk_28, index);
+        } else {
+            Model_DisableMeshGroupByIndex(this->skelAnime.unk_28, index);
+        }
+    }
+    for (size_t index = 0; index < BIT_COUNT(this->ghostPtr->ghostData.meshGroups2); index++) {
+        if (this->ghostPtr->ghostData.meshGroups2 & (0b1 << index)) {
+            Model_EnableMeshGroupByIndex(this->skelAnime.unk_28, index + BIT_COUNT(u32));
+        } else {
+            Model_DisableMeshGroupByIndex(this->skelAnime.unk_28, index + BIT_COUNT(u32));
+        }
+    }
+    memcpy(this->skelAnime.jointTable, this->ghostPtr->ghostData.jointTable, sizeof(Vec3s[LINK_JOINT_COUNT]));
+}
+
+typedef void (*SkelAnime_DrawOpa_proc)(SkelAnime* skelAnime, nn_math_MTX34* modelMtx, u32* overrideLimbDraw,
+                                       u32* postLimbDraw, Actor* param_5, u32 param_6);
+#define SkelAnime_DrawOpa ((SkelAnime_DrawOpa_proc)0x35E240)
+
+typedef void (*EffectSsDeadDb_Spawn_proc)(GlobalContext* globalCtx, Vec3f* position, Vec3f* velocity,
+                                          Vec3f* acceleration, s16 scale, s16 scale_step, s16 prim_r, s16 prim_g,
+                                          s16 prim_b, s16 prim_a, s16 env_r, s16 env_g, s16 env_b, s16 unused,
+                                          s32 frame_duration, s16 play_sound);
+#define EffectSsDeadDb_Spawn_addr 0x3642F4
+#define EffectSsDeadDb_Spawn ((EffectSsDeadDb_Spawn_proc)EffectSsDeadDb_Spawn_addr)
+
+void EnLinkPuppet_Draw(Actor* thisx, GlobalContext* globalCtx) {
+    EnLinkPuppet* this = (EnLinkPuppet*)thisx;
+
+    // Check how many Link puppets already exist before this one.
+    u8 linkPuppetCount = 0;
+    Actor* firstActor  = gGlobalContext->actorCtx.actorList[EnLinkPuppet_InitVars.type].first;
+    for (Actor* actor = firstActor; actor != NULL; actor = actor->next) {
+        if (actor == thisx) {
+            break;
+        }
+        if (actor->id == EnLinkPuppet_InitVars.id) {
+            linkPuppetCount++;
+        }
+    }
+
+    if (linkPuppetCount < MAX_PUPPETS_AT_ONCE && this->ghostPtr->ghostData.age == gSaveContext.linkAge) {
+        SkelAnime_DrawOpa(&this->skelAnime, &this->base.modelMtx, NULL, NULL, thisx, 0);
+        return;
+    }
+
+    // Only draw flames every 4th frame
+    if (rGameplayFrames % 4 == 0) {
+        static Vec3f vecEmpty;
+        static f32 colorR[] = { 1.0, 0.0, 0.0, 1.0, 1.0, 0.0, 1.0, 0.5 };
+        static f32 colorG[] = { 0.0, 1.0, 0.0, 1.0, 0.0, 1.0, 0.5, 0.0 };
+        static f32 colorB[] = { 0.0, 0.0, 1.0, 0.0, 1.0, 1.0, 0.0, 1.0 };
+
+        s16 envR = 100 * colorR[(this->base.params - 1) % ARRAY_SIZE(colorR)];
+        s16 envG = 100 * colorG[(this->base.params - 1) % ARRAY_SIZE(colorG)];
+        s16 envB = 100 * colorB[(this->base.params - 1) % ARRAY_SIZE(colorB)];
+
+        Vec3f spawnPos = this->base.world.pos;
+        spawnPos.y += (this->ghostPtr->ghostData.age == 0 ? 50 : 35);
+        EffectSsDeadDb_Spawn(gGlobalContext, &spawnPos, &vecEmpty, &vecEmpty,
+                             this->ghostPtr->ghostData.age == 0 ? 100 : 70, -1, 80, 80, 80, 0xFF, envR, envG, envB, 1,
+                             8, 0);
+    }
+}
+
+// Returns the ID of the puppet, starting at 0!
+u16 EnLinkPuppet_GetID(EnLinkPuppet* this) {
+    return this->base.params & 0xFF;
+}

--- a/code/src/actors/link_puppet.h
+++ b/code/src/actors/link_puppet.h
@@ -1,0 +1,20 @@
+#ifndef _LINK_PUPPET_H_
+#define _LINK_PUPPET_H_
+
+#include "z3D/z3D.h"
+#include "multiplayer_ghosts.h"
+
+typedef struct {
+    Actor base;
+    SkelAnime skelAnime;
+    LinkGhost* ghostPtr;
+} EnLinkPuppet;
+
+extern ActorInit EnLinkPuppet_InitVars;
+
+void EnLinkPuppet_Init(Actor* thisx, GlobalContext* globalCtx);
+void EnLinkPuppet_Destroy(Actor* thisx, GlobalContext* globalCtx);
+void EnLinkPuppet_Update(Actor* thisx, GlobalContext* globalCtx);
+void EnLinkPuppet_Draw(Actor* thisx, GlobalContext* globalCtx);
+
+#endif //_LINK_PUPPET_H_

--- a/code/src/actors/link_puppet.h
+++ b/code/src/actors/link_puppet.h
@@ -6,15 +6,16 @@
 
 typedef struct {
     Actor base;
-    SkelAnime skelAnime;
     LinkGhost* ghostPtr;
+    SkelAnime skelAnime;
+    ColliderCylinder collider;
 } EnLinkPuppet;
 
 extern ActorInit EnLinkPuppet_InitVars;
 
-void EnLinkPuppet_Init(Actor* thisx, GlobalContext* globalCtx);
-void EnLinkPuppet_Destroy(Actor* thisx, GlobalContext* globalCtx);
-void EnLinkPuppet_Update(Actor* thisx, GlobalContext* globalCtx);
-void EnLinkPuppet_Draw(Actor* thisx, GlobalContext* globalCtx);
+void EnLinkPuppet_Init(EnLinkPuppet* this, GlobalContext* globalCtx);
+void EnLinkPuppet_Destroy(EnLinkPuppet* this, GlobalContext* globalCtx);
+void EnLinkPuppet_Update(EnLinkPuppet* this, GlobalContext* globalCtx);
+void EnLinkPuppet_Draw(EnLinkPuppet* this, GlobalContext* globalCtx);
 
 #endif //_LINK_PUPPET_H_

--- a/code/src/actors/sheik.c
+++ b/code/src/actors/sheik.c
@@ -61,7 +61,7 @@ void Sheik_Spawn(void) {
         EnXc* sheik = (EnXc*)Actor_Spawn(&gGlobalContext->actorCtx, gGlobalContext, 0x48, //
                                          pos.x, pos.y, pos.z,                             //
                                          rot.x, rot.y, rot.z,                             //
-                                         100);
+                                         100, FALSE);
         if (sheik == (void*)0) {
             return;
         }

--- a/code/src/actors/skulltula.c
+++ b/code/src/actors/skulltula.c
@@ -62,7 +62,7 @@ void GsQueue_Update(void) {
 
             Actor_Spawn(&gGlobalContext->actorCtx, gGlobalContext, 0x95,      //
                         gs->posRot.pos.x, gs->posRot.pos.y, gs->posRot.pos.z, //
-                        gs->posRot.rot.x, gs->posRot.rot.y, gs->posRot.rot.z, params);
+                        gs->posRot.rot.x, gs->posRot.rot.y, gs->posRot.rot.z, params, FALSE);
 
             gsSpawnQueue[i] = NULL;
         }

--- a/code/src/icetrap.c
+++ b/code/src/icetrap.c
@@ -138,13 +138,13 @@ void IceTrap_Give(void) {
         } else if (trapType == ICETRAP_RUPPY) {
             // Spawn 4 explosive rupees around the player
             Actor_Spawn(&gGlobalContext->actorCtx, gGlobalContext, 0x131, PLAYER->actor.world.pos.x + 30,
-                        PLAYER->actor.world.pos.y + 30, PLAYER->actor.world.pos.z + 30, 0, 0, 0, 0x2);
+                        PLAYER->actor.world.pos.y + 30, PLAYER->actor.world.pos.z + 30, 0, 0, 0, 0x2, FALSE);
             Actor_Spawn(&gGlobalContext->actorCtx, gGlobalContext, 0x131, PLAYER->actor.world.pos.x + 30,
-                        PLAYER->actor.world.pos.y + 30, PLAYER->actor.world.pos.z - 30, 0, 0, 0, 0x2);
+                        PLAYER->actor.world.pos.y + 30, PLAYER->actor.world.pos.z - 30, 0, 0, 0, 0x2, FALSE);
             Actor_Spawn(&gGlobalContext->actorCtx, gGlobalContext, 0x131, PLAYER->actor.world.pos.x - 30,
-                        PLAYER->actor.world.pos.y + 30, PLAYER->actor.world.pos.z + 30, 0, 0, 0, 0x2);
+                        PLAYER->actor.world.pos.y + 30, PLAYER->actor.world.pos.z + 30, 0, 0, 0, 0x2, FALSE);
             Actor_Spawn(&gGlobalContext->actorCtx, gGlobalContext, 0x131, PLAYER->actor.world.pos.x - 30,
-                        PLAYER->actor.world.pos.y + 30, PLAYER->actor.world.pos.z - 30, 0, 0, 0, 0x2);
+                        PLAYER->actor.world.pos.y + 30, PLAYER->actor.world.pos.z - 30, 0, 0, 0, 0x2, FALSE);
         } else {
             // From testing 0-4 are all the unique damage types and 0 is boring (lava/spikes damage), so it's used for
             // the Fire Trap

--- a/code/src/main.c
+++ b/code/src/main.c
@@ -73,14 +73,5 @@ void after_GlobalContext_Update() {
         }
     }
 
-    // CitraPrint("PLAYER->actor.shape.unk_06: 0x%X\n", PLAYER->actor.shape.unk_06);
-    // CitraPrint("1 - draw_10: 0x%X", PLAYER->skelAnime.unk_28->unk_0C->unk_00);
-    // CitraPrint("2 - draw_10: 0x%X", PLAYER->skelAnime.unk_28->unk_10);
-    // CitraPrint("unk_00: 0x%X", PLAYER->skelAnime.unk_28->unk_10->unk_00);
-    // CitraPrint("unk_04: 0x%X", PLAYER->skelAnime.unk_28->unk_10->unk_04);
-    // CitraPrint("unk_08: 0x%X", PLAYER->skelAnime.unk_28->unk_10->unk_08);
-    // CitraPrint("unk_0C: 0x%X", PLAYER->skelAnime.unk_28->unk_10->unk_0C);
-    // CitraPrint("unk_10: 0x%X\n", PLAYER->skelAnime.unk_28->unk_10->unk_10);
-
     Multiplayer_Sync_Update();
 }

--- a/code/src/main.c
+++ b/code/src/main.c
@@ -73,5 +73,14 @@ void after_GlobalContext_Update() {
         }
     }
 
+    // CitraPrint("PLAYER->actor.shape.unk_06: 0x%X\n", PLAYER->actor.shape.unk_06);
+    // CitraPrint("1 - draw_10: 0x%X", PLAYER->skelAnime.unk_28->unk_0C->unk_00);
+    // CitraPrint("2 - draw_10: 0x%X", PLAYER->skelAnime.unk_28->unk_10);
+    // CitraPrint("unk_00: 0x%X", PLAYER->skelAnime.unk_28->unk_10->unk_00);
+    // CitraPrint("unk_04: 0x%X", PLAYER->skelAnime.unk_28->unk_10->unk_04);
+    // CitraPrint("unk_08: 0x%X", PLAYER->skelAnime.unk_28->unk_10->unk_08);
+    // CitraPrint("unk_0C: 0x%X", PLAYER->skelAnime.unk_28->unk_10->unk_0C);
+    // CitraPrint("unk_10: 0x%X\n", PLAYER->skelAnime.unk_28->unk_10->unk_10);
+
     Multiplayer_Sync_Update();
 }

--- a/code/src/multiplayer.c
+++ b/code/src/multiplayer.c
@@ -937,15 +937,17 @@ void Multiplayer_Send_GhostData(void) {
         ghostData.meshGroups1 |= 0x7000000;
     }
 
+    ghostData.currentTunic = PLAYER->currentTunic;
+
     if (playingOnCitra) {
-        memcpy(&ghostData.jointTable, PLAYER->skelAnime.jointTable, sizeof(Vec3s[LINK_JOINT_COUNT]));
+        memcpy(&ghostData.jointTable, PLAYER->skelAnime.jointTable, sizeof(ghostData.jointTable));
     }
 
     memcpy(&mBuffer[memSpacer], &ghostData, sizeof(GhostData));
     memSpacer += sizeof(GhostData) / 4;
 
     if (!playingOnCitra) {
-        memSpacer -= sizeof(Vec3s[LINK_JOINT_COUNT]) / 4;
+        memSpacer -= sizeof(ghostData.jointTable) / 4;
     }
 
     Multiplayer_SendPacket(memSpacer, UDS_BROADCAST_NETWORKNODEID);
@@ -955,7 +957,7 @@ void Multiplayer_Receive_GhostData(u16 senderID) {
     GhostData ghostData;
     u32 packetSize = sizeof(GhostData);
     if (!playingOnCitra) {
-        packetSize -= sizeof(Vec3s[LINK_JOINT_COUNT]);
+        packetSize -= sizeof(ghostData.jointTable);
     }
     memcpy(&ghostData, &mBuffer[1], packetSize);
 

--- a/code/src/multiplayer.c
+++ b/code/src/multiplayer.c
@@ -277,6 +277,7 @@ typedef enum {
     // Ghost Data
     PACKET_GHOSTPING,
     PACKET_GHOSTDATA,
+    PACKET_GHOSTDATA_JOINTTABLE,
     PACKET_LINKSFX,
     // Shared Progress
     PACKET_FULLSYNCREQUEST,
@@ -431,6 +432,9 @@ void Multiplayer_Update(u8 fromGlobalContextUpdate) {
     Multiplayer_Ghosts_Tick();
     if (fromGlobalContextUpdate) {
         Multiplayer_Send_GhostData();
+        if (playingOnCitra) {
+            Multiplayer_Send_GhostData_JointTable();
+        }
     } else {
         Multiplayer_Send_GhostPing();
     }
@@ -931,37 +935,47 @@ void Multiplayer_Send_GhostData(void) {
     }
 
     // Always have body enabled
-    if (gSaveContext.linkAge == 0) {
-        ghostData.meshGroups2 |= 0xE0000000;
-    } else {
-        ghostData.meshGroups1 |= 0x7000000;
+    if (gSaveContext.gameMode == 0) {
+        if (gSaveContext.linkAge == 0) {
+            ghostData.meshGroups2 |= 0x6000;
+        } else {
+            ghostData.meshGroups1 |= 0x7000000;
+        }
     }
 
     ghostData.currentTunic = PLAYER->currentTunic;
 
-    if (playingOnCitra) {
-        memcpy(&ghostData.jointTable, PLAYER->skelAnime.jointTable, sizeof(ghostData.jointTable));
-    }
-
-    memcpy(&mBuffer[memSpacer], &ghostData, sizeof(GhostData));
-    memSpacer += sizeof(GhostData) / 4;
-
-    if (!playingOnCitra) {
-        memSpacer -= sizeof(ghostData.jointTable) / 4;
-    }
+    u32 totalSize = sizeof(GhostData) - sizeof(ghostData.jointTable);
+    memcpy(&mBuffer[memSpacer], &ghostData, totalSize);
+    memSpacer += totalSize / 4;
 
     Multiplayer_SendPacket(memSpacer, UDS_BROADCAST_NETWORKNODEID);
 }
 
 void Multiplayer_Receive_GhostData(u16 senderID) {
     GhostData ghostData;
-    u32 packetSize = sizeof(GhostData);
-    if (!playingOnCitra) {
-        packetSize -= sizeof(ghostData.jointTable);
-    }
+    u32 packetSize = sizeof(GhostData) - sizeof(ghostData.jointTable);
     memcpy(&ghostData, &mBuffer[1], packetSize);
 
     Multiplayer_Ghosts_UpdateGhostData(senderID, &ghostData);
+}
+
+void Multiplayer_Send_GhostData_JointTable(void) {
+    if (!IsSendReceiveReady()) {
+        return;
+    }
+    memset(mBuffer, 0, mBufSize);
+    u16 memSpacer        = 0;
+    mBuffer[memSpacer++] = PACKET_GHOSTDATA_JOINTTABLE; // 0: Identifier
+
+    memcpy(&mBuffer[memSpacer], &PLAYER->jointTable, sizeof(PLAYER->jointTable));
+    memSpacer += sizeof(PLAYER->jointTable) / 4;
+
+    Multiplayer_SendPacket(memSpacer, UDS_BROADCAST_NETWORKNODEID);
+}
+
+void Multiplayer_Receive_GhostData_JointTable(u16 senderID) {
+    Multiplayer_Ghosts_UpdateGhostData_JointTable(senderID, (LimbData*)&mBuffer[1]);
 }
 
 void Multiplayer_Send_LinkSFX(u32 sfxID_) {
@@ -2459,7 +2473,7 @@ void Multiplayer_Receive_ActorUpdate(u16 senderID) {
                 Flags_SetSwitch(gGlobalContext, lastBeanPlant_Params & 0x3F);
                 Actor_Spawn(&gGlobalContext->actorCtx, gGlobalContext, actorId, lastBeanPlant_Home.pos.x,
                             lastBeanPlant_Home.pos.y, lastBeanPlant_Home.pos.z, lastBeanPlant_Home.rot.x,
-                            lastBeanPlant_Home.rot.y, lastBeanPlant_Home.rot.z, lastBeanPlant_Params);
+                            lastBeanPlant_Home.rot.y, lastBeanPlant_Home.rot.z, lastBeanPlant_Params, FALSE);
             }
             break;
     }
@@ -2501,7 +2515,7 @@ void Multiplayer_Receive_ActorSpawn(u16 senderID) {
     s16 params = mBuffer[memSpacer++];
 
     Actor_Spawn(&gGlobalContext->actorCtx, gGlobalContext, actorId, rcvdPosRot.pos.x, rcvdPosRot.pos.y,
-                rcvdPosRot.pos.z, rcvdPosRot.rot.x, rcvdPosRot.rot.y, rcvdPosRot.rot.z, params);
+                rcvdPosRot.pos.z, rcvdPosRot.rot.x, rcvdPosRot.rot.y, rcvdPosRot.rot.z, params, FALSE);
 }
 
 // Etc
@@ -2696,6 +2710,7 @@ static void Multiplayer_UnpackPacket(u16 senderID) {
         // Ghost Data
         Multiplayer_Receive_GhostPing,
         Multiplayer_Receive_GhostData,
+        Multiplayer_Receive_GhostData_JointTable,
         Multiplayer_Receive_LinkSFX,
         // Shared Progress
         Multiplayer_Receive_FullSyncRequest,

--- a/code/src/multiplayer.c
+++ b/code/src/multiplayer.c
@@ -937,17 +937,27 @@ void Multiplayer_Send_GhostData(void) {
         ghostData.meshGroups1 |= 0x7000000;
     }
 
-    memcpy(&ghostData.jointTable, PLAYER->skelAnime.jointTable, sizeof(Vec3s[LINK_JOINT_COUNT]));
+    if (playingOnCitra) {
+        memcpy(&ghostData.jointTable, PLAYER->skelAnime.jointTable, sizeof(Vec3s[LINK_JOINT_COUNT]));
+    }
 
     memcpy(&mBuffer[memSpacer], &ghostData, sizeof(GhostData));
     memSpacer += sizeof(GhostData) / 4;
+
+    if (!playingOnCitra) {
+        memSpacer -= sizeof(Vec3s[LINK_JOINT_COUNT]) / 4;
+    }
 
     Multiplayer_SendPacket(memSpacer, UDS_BROADCAST_NETWORKNODEID);
 }
 
 void Multiplayer_Receive_GhostData(u16 senderID) {
     GhostData ghostData;
-    memcpy(&ghostData, &mBuffer[1], sizeof(GhostData));
+    u32 packetSize = sizeof(GhostData);
+    if (!playingOnCitra) {
+        packetSize -= sizeof(Vec3s[LINK_JOINT_COUNT]);
+    }
+    memcpy(&ghostData, &mBuffer[1], packetSize);
 
     Multiplayer_Ghosts_UpdateGhostData(senderID, &ghostData);
 }

--- a/code/src/multiplayer.h
+++ b/code/src/multiplayer.h
@@ -21,6 +21,7 @@ void Multiplayer_OnFileLoad(void);
 // Ghost Data
 void Multiplayer_Send_GhostPing(void);
 void Multiplayer_Send_GhostData(void);
+void Multiplayer_Send_GhostData_JointTable(void);
 void Multiplayer_Send_LinkSFX(u32 sfxID);
 // Shared Progress
 u8 Multiplayer_GetNeededPacketsMask(void);

--- a/code/src/multiplayer_ghosts.c
+++ b/code/src/multiplayer_ghosts.c
@@ -99,6 +99,7 @@ void Multiplayer_Ghosts_SpawnPuppets(void) {
             if (puppet == NULL) {
                 continue;
             }
+            // It's important to run the init after this is set
             puppet->ghostPtr = ghost;
         }
     }

--- a/code/src/multiplayer_ghosts.h
+++ b/code/src/multiplayer_ghosts.h
@@ -17,7 +17,7 @@ typedef struct {
     // Animation vars here
     u32 meshGroups1;
     u32 meshGroups2;
-    Vec3s jointTable[LINK_JOINT_COUNT];
+    Vec3s jointTable[LINK_JOINT_COUNT]; // ALWAYS KEEP LAST
 } GhostData;
 
 typedef struct {

--- a/code/src/multiplayer_ghosts.h
+++ b/code/src/multiplayer_ghosts.h
@@ -4,16 +4,33 @@
 #include "3ds/types.h"
 #include "z3D/z3D.h"
 
+// ASSUMED! Game crashes when copying more than this while paused.
+#define LINK_JOINT_COUNT 217
+// 48 for adult, 26 for child?
+#define LINK_MESH_GROUP_COUNT 48
+
 typedef struct {
     s16 currentScene;
     s32 age;
     Vec3f position;
+    Vec3s rotation;
     // Animation vars here
+    u32 meshGroups1;
+    u32 meshGroups2;
+    Vec3s jointTable[LINK_JOINT_COUNT];
 } GhostData;
 
+typedef struct {
+    bool inUse;
+    u64 lastTick;
+    u16 networkID;
+    GhostData ghostData;
+} LinkGhost;
+
 void Multiplayer_Ghosts_Tick(void);
-void Multiplayer_Ghosts_UpdateGhost(u16 networkID, GhostData* ghostData);
+void Multiplayer_Ghosts_UpdateGhostData(u16 networkID, GhostData* ghostData);
 GhostData* Multiplayer_Ghosts_GetGhostData(u16 networkID);
-void Multiplayer_Ghosts_DrawAll(void);
+// Updates the data of the existing puppet actors, or spawns new ones in the scene
+void Multiplayer_Ghosts_SpawnPuppets(void);
 
 #endif //_MULTIPLAYER_GHOSTS_H_

--- a/code/src/multiplayer_ghosts.h
+++ b/code/src/multiplayer_ghosts.h
@@ -9,17 +9,17 @@
 // Filler struct to match allocated size in SkelAnime_InitLink
 typedef struct {
     u8 data[0x34];
-} JointData;
+} LimbData;
 
 typedef struct {
-    s16 currentScene;
+    s32 currentScene;
     s32 age;
     Vec3f position;
     Vec3s rotation;
     u32 meshGroups1;
     u32 meshGroups2;
-    s8 currentTunic;
-    JointData jointTable[LINK_LIMB_COUNT]; // ALWAYS KEEP LAST
+    s32 currentTunic;
+    LimbData jointTable[LINK_LIMB_COUNT]; // ALWAYS KEEP LAST
 } GhostData;
 
 typedef struct {
@@ -31,8 +31,9 @@ typedef struct {
 
 void Multiplayer_Ghosts_Tick(void);
 void Multiplayer_Ghosts_UpdateGhostData(u16 networkID, GhostData* ghostData);
+void Multiplayer_Ghosts_UpdateGhostData_JointTable(u16 networkID, LimbData* limbData);
+void Multiplayer_Ghosts_UpdateGhostData_MorphTable(u16 networkID, LimbData* limbData);
 GhostData* Multiplayer_Ghosts_GetGhostData(u16 networkID);
-// Updates the data of the existing puppet actors, or spawns new ones in the scene
 void Multiplayer_Ghosts_SpawnPuppets(void);
 
 #endif //_MULTIPLAYER_GHOSTS_H_

--- a/code/src/multiplayer_ghosts.h
+++ b/code/src/multiplayer_ghosts.h
@@ -32,7 +32,6 @@ typedef struct {
 void Multiplayer_Ghosts_Tick(void);
 void Multiplayer_Ghosts_UpdateGhostData(u16 networkID, GhostData* ghostData);
 void Multiplayer_Ghosts_UpdateGhostData_JointTable(u16 networkID, LimbData* limbData);
-void Multiplayer_Ghosts_UpdateGhostData_MorphTable(u16 networkID, LimbData* limbData);
 GhostData* Multiplayer_Ghosts_GetGhostData(u16 networkID);
 void Multiplayer_Ghosts_SpawnPuppets(void);
 

--- a/code/src/multiplayer_ghosts.h
+++ b/code/src/multiplayer_ghosts.h
@@ -4,20 +4,22 @@
 #include "3ds/types.h"
 #include "z3D/z3D.h"
 
-// ASSUMED! Game crashes when copying more than this while paused.
-#define LINK_JOINT_COUNT 217
-// 48 for adult, 26 for child?
-#define LINK_MESH_GROUP_COUNT 48
+#define LINK_LIMB_COUNT 25
+
+// Filler struct to match allocated size in SkelAnime_InitLink
+typedef struct {
+    u8 data[0x34];
+} JointData;
 
 typedef struct {
     s16 currentScene;
     s32 age;
     Vec3f position;
     Vec3s rotation;
-    // Animation vars here
     u32 meshGroups1;
     u32 meshGroups2;
-    Vec3s jointTable[LINK_JOINT_COUNT]; // ALWAYS KEEP LAST
+    s8 currentTunic;
+    JointData jointTable[LINK_LIMB_COUNT]; // ALWAYS KEEP LAST
 } GhostData;
 
 typedef struct {


### PR DESCRIPTION
https://github.com/gamestabled/OoT3D_Randomizer/assets/5352197/379219c8-57fd-4f3d-bb2b-70eeaf115159

- If too many extra Links are drawn, the game gets graphical glitches that last until the game is restarted, so limit the amount to three. The extra Links will be shown as flames like before.
- On 64, Link's joint table is 22 in length of Vec3s. Here on 3DS I don't actually know but just assumed that it's still Vec3s. However, to get the full animation here we need to copy 217! Maybe there's a better way to set the pose with an animation index and current frame? Regardless as of now just for the posing it'll send 1300 bytes per frame per player. Most likely this will have to be skipped for when playing on console, so Links will just be T-posing.
- Puppet Child Link works weird for some reason. The position is off when standing and climbing. ~I don't know how to fix.~ Workaround by moving the actor's position down 12 units. There were other issues that happened along side this before, but they don't seem to happen any longer?
- ~Custom tunic colors mess up the graphics on the puppet's tunic.~