### PR TITLE
Update actions for Node.js 20

### DIFF
--- a/.github/workflows/checks.yml
+++ b/.github/workflows/checks.yml
@@ -10,7 +10,7 @@ jobs:
 
     steps:
     - name: Checkout Project
-      uses: actions/checkout@v3
+      uses: actions/checkout@v4.1.3
 
     - name: Format Project
       uses: DoozyX/clang-format-lint-action@v0.15
@@ -27,7 +27,7 @@ jobs:
 
     steps:
     - name: Checkout Project
-      uses: actions/checkout@v3
+      uses: actions/checkout@v4.1.3
 
     - name: Compile Project
       run: make -j

--- a/.github/workflows/clang_format_code.yml
+++ b/.github/workflows/clang_format_code.yml
@@ -14,7 +14,7 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v4.1.3
 
     - uses: DoozyX/clang-format-lint-action@v0.15
       with:
@@ -24,7 +24,7 @@ jobs:
         style: file
         inplace: True
 
-    - uses: EndBug/add-and-commit@v9.1.0
+    - uses: EndBug/add-and-commit@v9.1.4
       with:
         committer_name: GitHub Actions
         committer_email: 41898282+github-actions[bot]@users.noreply.github.com

--- a/.github/workflows/create_build.yml
+++ b/.github/workflows/create_build.yml
@@ -20,7 +20,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout Project
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4.1.3
         with:
           fetch-depth: 0
       - name: Get Last Nightly
@@ -29,7 +29,7 @@ jobs:
           echo "last_nightly=$(git describe --tags $(git rev-list --tags --max-count=1))" >> $GITHUB_ENV
       - name: Generate changelog
         id: changelog
-        uses: metcalfc/changelog-generator@v4.0.1
+        uses: metcalfc/changelog-generator@v4.3.1
         with:
           myToken: ${{ secrets.GITHUB_TOKEN }}
           base-ref: ${{ env.last_nightly }}
@@ -46,7 +46,7 @@ jobs:
 
     steps:
       - name: Checkout Project
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4.1.3
 
       - name: Run Build Script
         run: |
@@ -59,7 +59,7 @@ jobs:
 
       - if: ${{ github.event.inputs.build_type == 'Nightly' }}
         name: Create Pre-release
-        uses: ncipollo/release-action@v1.12.0
+        uses: ncipollo/release-action@v1.14.0
         with:
           token: "${{ secrets.GITHUB_TOKEN }}"
           artifacts: "OoT3D_Randomizer.cia,OoT3D_Randomizer.3dsx,cia.png,3dsx.png"
@@ -82,7 +82,7 @@ jobs:
 
       - if: ${{ github.event.inputs.build_type == 'Release' }}
         name: Create Release
-        uses: ncipollo/release-action@v1.12.0
+        uses: ncipollo/release-action@v1.14.0
         with:
           token: "${{ secrets.GITHUB_TOKEN }}"
           artifacts: "OoT3D_Randomizer.cia,OoT3D_Randomizer.3dsx,cia.png,3dsx.png"


### PR DESCRIPTION
[Last build](https://github.com/gamestabled/OoT3D_Randomizer/actions/runs/8811220562) gave warnings that Node.js needs to be updated, which all actions except [deploy-gist](https://github.com/exuanbo/actions-deploy-gist) has done. It does have a PR open for it, but seems inactive at the moment.