### PR TITLE
Music Shuffle: Always remove old sound archive

### DIFF
--- a/source/menu.cpp
+++ b/source/menu.cpp
@@ -746,6 +746,7 @@ void GenerateRandomizer() {
         }
     }
 
+    Music::DeleteOldArchive();
     if (Settings::ShuffleMusic) {
         printf("\x1b[12;10HShuffling Music...");
         auto musicRes = Music::ShuffleMusic_Archive();

--- a/source/music.cpp
+++ b/source/music.cpp
@@ -368,6 +368,17 @@ void CreateMusicDirectories(FS_Archive sdmcArchive) {
     musicDirsCreated = true;
 }
 
+void DeleteOldArchive() {
+    FS_Archive sdmcArchive;
+    if (!R_SUCCEEDED(FSUSER_OpenArchive(&sdmcArchive, ARCHIVE_SDMC, fsMakePath(PATH_EMPTY, "")))) {
+        return;
+    }
+
+    static const std::string soundPath = "/luma/titles/" + Settings::TitleId() + "/romfs/sound";
+    FSUSER_DeleteDirectoryRecursively(sdmcArchive, fsMakePath(PATH_ASCII, soundPath.c_str()));
+    FSUSER_CloseArchive(sdmcArchive);
+}
+
 int ShuffleMusic_Archive() {
     if (!musicDirsCreated) {
         return SARSHUFFLE_NO_DIRS;
@@ -378,20 +389,11 @@ int ShuffleMusic_Archive() {
         return SARSHUFFLE_SDMC_ARCHIVE_FAIL;
     }
 
-    // Title ID
-    std::string titleId;
-    if (Settings::Region == REGION_EUR) {
-        titleId = "0004000000033600";
-    } else { // REGION_NA
-        titleId = "0004000000033500";
-    }
+    std::string titleId = Settings::TitleId();
 
     // Archive Paths
     static const std::string bcsarPath    = CustomMusicRootPath + "QueenSound.bcsar";
     static const std::string newBcsarPath = "/luma/titles/" + titleId + "/romfs/sound/QueenSound.bcsar";
-
-    // Delete previous
-    FSUSER_DeleteFile(sdmcArchive, fsMakePath(PATH_ASCII, newBcsarPath.c_str()));
 
     // Create new archive
     SoundArchive sar(sdmcArchive, bcsarPath);

--- a/source/music.hpp
+++ b/source/music.hpp
@@ -47,6 +47,7 @@ typedef enum {
 extern bool archiveFound;
 extern bool musicDirsCreated;
 void CreateMusicDirectories(FS_Archive sdmcArchive);
+void DeleteOldArchive();
 int ShuffleMusic_Archive();
 
 } // namespace Music

--- a/source/patch.cpp
+++ b/source/patch.cpp
@@ -124,13 +124,11 @@ bool WriteAllPatches() {
     u32 bytesWritten = 0;
     u32 totalRW      = 0;
     char buf[512];
-    std::string titleId;
+    std::string titleId = Settings::TitleId();
     PatchSymbols patchSymbols;
     if (Settings::Region == REGION_EUR) {
-        titleId      = "0004000000033600";
         patchSymbols = EurSymbols;
     } else { // REGION_NA
-        titleId      = "0004000000033500";
         patchSymbols = UsaSymbols;
     }
 

--- a/source/settings.cpp
+++ b/source/settings.cpp
@@ -3305,4 +3305,12 @@ bool ValidateSettings() {
     return valid;
 }
 
+std::string TitleId() {
+    if (Region == REGION_EUR) {
+        return "0004000000033600";
+    } else { // REGION_NA
+        return "0004000000033500";
+    }
+}
+
 } // namespace Settings

--- a/source/settings.hpp
+++ b/source/settings.hpp
@@ -360,6 +360,8 @@ bool GlitchEnabled(Option& glitchOption);
 /// @brief Checks if incompatible settings are selected and prints error message.
 /// @return True if settings are valid.
 bool ValidateSettings();
+/// Returns the full title id of the selected region.
+std::string TitleId();
 
 extern std::string seed;
 extern std::string version;


### PR DESCRIPTION
Previously it was only deleted if music shuffle was enabled.