### PR TITLE
Some multiplayer fixes

### DIFF
--- a/code/src/actors/link_puppet.c
+++ b/code/src/actors/link_puppet.c
@@ -99,13 +99,16 @@ void EnLinkPuppet_Destroy(EnLinkPuppet* this, GlobalContext* globalCtx) {
 }
 
 void EnLinkPuppet_Update(EnLinkPuppet* this, GlobalContext* globalCtx) {
-    if (!this->ghostPtr->inUse || this->ghostPtr->ghostData.currentScene != gGlobalContext->sceneNum) {
+    if (!this->ghostPtr->inUse || !this->ghostPtr->isInGame ||
+        this->ghostPtr->ghostData.currentScene != gGlobalContext->sceneNum) {
         Actor_Kill(&this->base);
         return;
     }
 
     this->base.world.pos = this->ghostPtr->ghostData.position;
     this->base.shape.rot = this->ghostPtr->ghostData.rotation;
+    // Overwrite prevPos so model doesn't get stuck to terrain because of Actor_UpdateBgCheckInfo
+    this->base.prevPos = this->base.world.pos;
 
     // Mesh Groups
     for (size_t index = 0; index < BIT_COUNT(this->ghostPtr->ghostData.meshGroups1); index++) {

--- a/code/src/multiplayer.c
+++ b/code/src/multiplayer.c
@@ -895,11 +895,13 @@ void Multiplayer_Send_GhostPing(void) {
     memset(mBuffer, 0, mBufSize);
     u8 memSpacer         = 0;
     mBuffer[memSpacer++] = PACKET_GHOSTPING; // 0: Identifier
+    mBuffer[memSpacer++] = IsInGameOrBossChallenge();
     Multiplayer_SendPacket(memSpacer, UDS_BROADCAST_NETWORKNODEID);
 }
 
 void Multiplayer_Receive_GhostPing(u16 senderID) {
-    Multiplayer_Ghosts_UpdateGhostData(senderID, NULL);
+    u8 isInGame = mBuffer[1];
+    Multiplayer_Ghosts_UpdateGhostData(senderID, NULL, isInGame);
 }
 
 void Multiplayer_Send_GhostData(void) {
@@ -957,7 +959,7 @@ void Multiplayer_Receive_GhostData(u16 senderID) {
     u32 packetSize = sizeof(GhostData) - sizeof(ghostData.jointTable);
     memcpy(&ghostData, &mBuffer[1], packetSize);
 
-    Multiplayer_Ghosts_UpdateGhostData(senderID, &ghostData);
+    Multiplayer_Ghosts_UpdateGhostData(senderID, &ghostData, TRUE);
 }
 
 void Multiplayer_Send_GhostData_JointTable(void) {

--- a/code/src/multiplayer_ghosts.c
+++ b/code/src/multiplayer_ghosts.c
@@ -19,7 +19,7 @@ void Multiplayer_Ghosts_Tick(void) {
     }
 }
 
-void Multiplayer_Ghosts_UpdateGhostData(u16 networkID, GhostData* ghostData) {
+void Multiplayer_Ghosts_UpdateGhostData(u16 networkID, GhostData* ghostData, u8 isInGame) {
     LinkGhost* ghostX = NULL;
     // Find existing ghost
     for (size_t i = 0; i < ARRAY_SIZE(ghosts); i++) {
@@ -47,6 +47,7 @@ void Multiplayer_Ghosts_UpdateGhostData(u16 networkID, GhostData* ghostData) {
     }
     // Set vars
     ghostX->lastTick = svcGetSystemTick();
+    ghostX->isInGame = isInGame;
     if (ghostData != NULL) {
         memcpy(&ghostX->ghostData, ghostData, sizeof(GhostData) - sizeof(ghostData->jointTable));
     }
@@ -90,7 +91,9 @@ void Multiplayer_Ghosts_SpawnPuppets(void) {
     for (size_t i = 0; i < ARRAY_SIZE(ghosts); i++) {
         LinkGhost* ghost = &ghosts[i];
 
-        if (ghost->inUse && ghost->ghostData.currentScene == gGlobalContext->sceneNum && !IsPuppetSpawned(ghost)) {
+        if (ghost->inUse && ghost->isInGame && ghost->ghostData.currentScene == gGlobalContext->sceneNum &&
+            !IsPuppetSpawned(ghost)) {
+
             EnLinkPuppet_InitVars.objectId = (gSaveContext.linkAge == 0) ? 20 : 21;
             EnLinkPuppet* puppet           = (EnLinkPuppet*)Actor_Spawn(
                           &gGlobalContext->actorCtx, gGlobalContext, EnLinkPuppet_InitVars.id,                   //

--- a/code/src/multiplayer_ghosts.h
+++ b/code/src/multiplayer_ghosts.h
@@ -26,11 +26,12 @@ typedef struct {
     bool inUse;
     u64 lastTick;
     u16 networkID;
+    u8 isInGame;
     GhostData ghostData;
 } LinkGhost;
 
 void Multiplayer_Ghosts_Tick(void);
-void Multiplayer_Ghosts_UpdateGhostData(u16 networkID, GhostData* ghostData);
+void Multiplayer_Ghosts_UpdateGhostData(u16 networkID, GhostData* ghostData, u8 isInGame);
 void Multiplayer_Ghosts_UpdateGhostData_JointTable(u16 networkID, LimbData* limbData);
 GhostData* Multiplayer_Ghosts_GetGhostData(u16 networkID);
 void Multiplayer_Ghosts_SpawnPuppets(void);


### PR DESCRIPTION
- Fix puppet models getting stuck on terrain by overwriting `prevPos`, used in `Actor_UpdateBgCheckInfo`
- Despawn puppets when they go back to the main menu