### PR TITLE
Cosmetics: Beta Sold-Out Model

### DIFF
--- a/source/descriptions.cpp
+++ b/source/descriptions.cpp
@@ -1222,6 +1222,13 @@ string_view mirrorWorldEntranceDesc   = "Different entrances to the same region 
 string_view mirrorWorldRandomDesc     = "Whether the world is mirrored may change after\n" //
                                         "every loading zone inconsistently.";              //
 /*------------------------------                                                           //
+| SOLD OUT COSMETIC SHOP MODEL |                                                           //
+------------------------------*/                                                           //
+string_view betaSoldOutDesc           = "The game contains an unused model for sold out\n" //
+                                        "items in shops. It's a remade version of the N64\n"
+                                        "model, spelling \"Sold Out\" in English.\n\n"     //
+                                        "This setting enables its use in shops.";          //
+/*------------------------------                                                           //
 |        SHUFFLE MUSIC         |                                                           //
 ------------------------------*/                                                           //
 string_view musicRandoDesc            = "Randomize the music in the game.";                //

--- a/source/descriptions.hpp
+++ b/source/descriptions.hpp
@@ -379,6 +379,8 @@ extern string_view mirrorWorldSceneDesc;
 extern string_view mirrorWorldEntranceDesc;
 extern string_view mirrorWorldRandomDesc;
 
+extern string_view betaSoldOutDesc;
+
 extern string_view musicRandoDesc;
 extern string_view shuffleBGMDesc;
 extern string_view shuffleMelodiesDesc;

--- a/source/patch.cpp
+++ b/source/patch.cpp
@@ -644,6 +644,21 @@ bool WriteAllPatches() {
         return false;
     }
 
+    /*---------------------------------
+    |   Sold Out Cosmetic Shop Model  |
+    ---------------------------------*/
+
+    const u32 SHOPITEMENTRY_SOLDOUT_CMBINDEX_ADDR = 0x525672;
+    char soldOutCMBIndex                          = 0;
+
+    patchOffset = V_TO_P(SHOPITEMENTRY_SOLDOUT_CMBINDEX_ADDR);
+    patchSize   = 1;
+
+    if (Settings::BetaSoldOut &&
+        !WritePatch(patchOffset, patchSize, &soldOutCMBIndex, code, bytesWritten, totalRW, buf)) {
+        return false;
+    }
+
     /*-------------------------
     |           EOF           |
     --------------------------*/

--- a/source/settings.cpp
+++ b/source/settings.cpp
@@ -1261,6 +1261,7 @@ std::string finalChuTrailOuterColor   = BombchuTrailOuterColor.GetSelectedOption
 Option ColoredKeys =     Option::Bool("Colored Small Keys", {"Off", "On"},                                {coloredKeysDesc},                                                                                                                                  OptionCategory::Cosmetic);
 Option ColoredBossKeys = Option::Bool("Colored Boss Keys",  {"Off", "On"},                                {coloredBossKeysDesc},                                                                                                                              OptionCategory::Cosmetic);
 Option MirrorWorld =     Option::U8  ("Mirror World",       {"Off", "On", "Scene", "Entrance", "Random"}, {mirrorWorldOffDesc, mirrorWorldOnDesc, mirrorWorldSceneDesc, mirrorWorldEntranceDesc, mirrorWorldRandomDesc},                                      OptionCategory::Cosmetic);
+Option BetaSoldOut =     Option::Bool("Beta Sold-Out Model",{"Off", "On"},                                {betaSoldOutDesc},                                                                                                                                  OptionCategory::Cosmetic);
 
 std::vector<Option *> cosmeticOptions = {
     &CustomTunicColors,
@@ -1292,6 +1293,7 @@ std::vector<Option *> cosmeticOptions = {
     &ColoredKeys,
     &ColoredBossKeys,
     &MirrorWorld,
+    &BetaSoldOut,
 };
 
 static std::vector<std::string> musicOptions = {"Off", "On (Mixed)", "On (Grouped)", "On (Own)"};

--- a/source/settings.hpp
+++ b/source/settings.hpp
@@ -814,6 +814,7 @@ extern std::string finalChuTrailOuterColor;
 extern Option ColoredKeys;
 extern Option ColoredBossKeys;
 extern Option MirrorWorld;
+extern Option BetaSoldOut;
 
 extern Option ShuffleMusic;
 extern Option ShuffleBGM;


### PR DESCRIPTION
This adds a cosmetic setting to display the beta model for sold-out items in shops.

![sold-out](https://github.com/gamestabled/OoT3D_Randomizer/assets/82058772/0855cfc2-737c-44bd-9ab4-2ca8eaa2b923)
