### PR TITLE
Correctly handle ExtData when copying savefiles

### DIFF
--- a/code/oot.ld
+++ b/code/oot.ld
@@ -744,6 +744,10 @@ SECTIONS
 		*(.patch_ChildCanOpenBowSubMenu)
 	}
 
+	.patch_FileSelect_CopyFile 0x2EDA04 : {
+		*(.patch_FileSelect_CopyFile)
+	}
+
 	.patch_CorrectCompassChests 0x2F161C : {
 		*(.patch_CorrectCompassChests)
 	}

--- a/code/src/hooks.s
+++ b/code/src/hooks.s
@@ -1051,6 +1051,14 @@ hook_AfterLoadGame:
     pop {r0-r12, lr}
     pop {r4-r6, pc}
 
+.global hook_FileSelect_CopyFile
+hook_FileSelect_CopyFile:
+    push {r0-r12, lr}
+    bl SaveFile_BeforeCopy
+    pop {r0-r12, lr}
+    sub sp,sp,#0x240
+    bx lr
+
 .global hook_SaveGame
 hook_SaveGame:
     cmp r5, #0

--- a/code/src/patches.s
+++ b/code/src/patches.s
@@ -1577,6 +1577,11 @@ BeforeLoadGame_patch:
 AfterLoadGame_patch:
     b hook_AfterLoadGame
 
+.section .patch_FileSelect_CopyFile
+.global FileSelect_CopyFile_patch
+FileSelect_CopyFile_patch:
+    bl hook_FileSelect_CopyFile
+
 .section .patch_SaveGame
 .global .SaveGame_patch
 SaveGame_patch:

--- a/code/src/savefile.c
+++ b/code/src/savefile.c
@@ -785,6 +785,12 @@ void SaveFile_SaveExtSaveData(u32 saveNumber) {
     extDataUnmount(fsa);
 }
 
+void SaveFile_BeforeCopy(s32 srcFileNum) {
+    // When the game writes the copied savefile, it calls SaveFile_SaveExtSaveData,
+    // so in order to properly copy the ExtData they first need to be loaded from the source savefile.
+    SaveFile_LoadExtSaveData(srcFileNum);
+}
+
 void SaveFile_EnforceHealthLimit(void) {
     u16 healthLimit = (gSaveContext.healthCapacity == 0) ? 2 : gSaveContext.healthCapacity;
     if (gSaveContext.health > healthLimit) {


### PR DESCRIPTION
Currently if you copy a save file to a different slot the extdata are not properly handled, and whatever stale data is in the `gExtSaveData` struct will be saved onto the target slot.
This fixes it so the extdata are properly loaded from the source slot before they get saved on the target slot.