### PR TITLE
Fix playthrough items for in-game spoiler log

### DIFF
--- a/source/spoiler_log.cpp
+++ b/source/spoiler_log.cpp
@@ -147,16 +147,13 @@ void WriteIngameSpoilerLog() {
         if (loc->IsExcluded()) {
             continue;
         }
-        // Master Sword
-        else if (!Settings::ShuffleMasterSword && key == TOT_MASTER_SWORD) {
-            continue;
-        }
         // Cows
         else if (!Settings::ShuffleCows && loc->IsCategory(Category::cCow)) {
             continue;
         }
         // Merchants
-        else if (Settings::ShuffleMerchants.Is(SHUFFLEMERCHANTS_OFF) && loc->IsCategory(Category::cMerchant)) {
+        else if (Settings::ShuffleMerchants.Is(SHUFFLEMERCHANTS_OFF) && loc->IsCategory(Category::cMerchant) &&
+                 key != WASTELAND_BOMBCHU_SALESMAN) { // The bombchu salesman is handled below
             continue;
         }
         // Adult Trade
@@ -233,6 +230,9 @@ void WriteIngameSpoilerLog() {
             splrDatLoc->ItemLocations[spoilerItemIndex].RevealType  = REVEALTYPE_ALWAYS;
         } else if (key == ZR_MAGIC_BEAN_SALESMAN && !Settings::ShuffleMagicBeans) {
             splrDatLoc->ItemLocations[spoilerItemIndex].RevealType = REVEALTYPE_ALWAYS;
+        } else if (key == WASTELAND_BOMBCHU_SALESMAN && Settings::ShuffleMerchants.Is(SHUFFLEMERCHANTS_OFF)) {
+            splrDatLoc->ItemLocations[spoilerItemIndex].CollectType = COLLECTTYPE_REPEATABLE;
+            splrDatLoc->ItemLocations[spoilerItemIndex].RevealType  = REVEALTYPE_ALWAYS;
         }
         // Shops
         else if (loc->IsShop()) {


### PR DESCRIPTION
This PR makes the ToT Master Sword and Wasteland Bombchus locations appear in the in-game spoiler log even if they're not shuffled, because in that case they hold advancement items that could be placed in the intended playthrough.
This fixes a bug where an error message would appear during seed generation when in-game spoilers are set to "show".