### PR TITLE
Display custom tunic on Title Screen

### DIFF
--- a/code/oot.ld
+++ b/code/oot.ld
@@ -1271,6 +1271,10 @@ SECTIONS
 		*(.patch_ItemsMenuDraw)
 	}
 
+	.patch_PlayInit 0x4352F4 + region_offset : {
+		*(.patch_PlayInit)
+	}
+
 	/* Variation of regional differences: 0x436690 */
 	region_offset = DEFINED(_EUR_) ? 0x20 : 0;
 
@@ -1673,6 +1677,10 @@ SECTIONS
 
 	.patch_TycoonWalletSize 0x53CC08 : {
 		*(.patch_TycoonWalletSize)
+	}
+
+	.patch_TitleLinkObject 0x53CCF0 : {
+		*(.patch_TitleLinkObject)
 	}
 
 	. = 0x005C7000;

--- a/code/src/actors/player.c
+++ b/code/src/actors/player.c
@@ -34,12 +34,6 @@ void** Player_EditAndRetrieveCMB(ZARInfo* zarInfo, u32 objModelIdx) {
     void** cmbMan = ZAR_GetCMBByIndex(zarInfo, objModelIdx);
     void* cmb     = *cmbMan;
 
-    if (gActorOverlayTable[0].initInfo->objectId == OBJECT_LINK_OPENING) {
-        // Title Screen Link uses a different object, so don't apply the custom tunic patches
-        // to avoid displaying a broken tunic.
-        return cmbMan;
-    }
-
     if (gSettingsContext.customTunicColors == ON) {
         if (gSaveContext.linkAge == AGE_ADULT) {
             CustomModel_EditLinkToCustomTunic(cmb);

--- a/code/src/hooks.s
+++ b/code/src/hooks.s
@@ -2130,6 +2130,14 @@ hook_CheckForTextControlCode:
     pop {r1-r12, lr}
     bx lr
 
+.global hook_PlayInit
+hook_PlayInit:
+    push {r0-r12, lr}
+    bl before_Play_Init
+    pop {r0-r12, lr}
+    cpy r5,r0
+    bx lr
+
 @ ----------------------------------
 @ ----------------------------------
 

--- a/code/src/main.c
+++ b/code/src/main.c
@@ -23,10 +23,6 @@ GlobalContext* gGlobalContext = NULL;
 static u8 rRandomizerInit     = 0;
 u32 rGameplayFrames           = 0;
 
-void set_GlobalContext(GlobalContext* globalCtx) {
-    gGlobalContext = globalCtx;
-}
-
 void Randomizer_Init() {
     rHeap_Init();
     Actor_Init();
@@ -34,18 +30,21 @@ void Randomizer_Init() {
     ItemOverride_Init();
     extDataInit();
     irrstInit();
+
+    s64 output = 0;
+    svcGetSystemInfo(&output, 0x20000, 0);
+    playingOnCitra = (output != 0);
+}
+
+void before_Play_Init(GlobalContext* globalCtx) {
+    if (!rRandomizerInit) {
+        Randomizer_Init();
+        rRandomizerInit = 1;
+    }
+    gGlobalContext = globalCtx;
 }
 
 void before_GlobalContext_Update(GlobalContext* globalCtx) {
-    if (!rRandomizerInit) {
-        Randomizer_Init();
-        set_GlobalContext(globalCtx);
-        rRandomizerInit = 1;
-
-        s64 output = 0;
-        svcGetSystemInfo(&output, 0x20000, 0);
-        playingOnCitra = (output != 0);
-    }
     rGameplayFrames++;
     ItemOverride_Update();
     ActorSetup_Extra();

--- a/code/src/patches.s
+++ b/code/src/patches.s
@@ -2247,6 +2247,16 @@ HandleTextControlCode_patch:
 CheckForTextControlCode_patch:
     bl hook_CheckForTextControlCode
 
+.section .patch_PlayInit
+.global PlayInit_patch
+PlayInit_patch:
+    bl hook_PlayInit
+
+.section .patch_TitleLinkObject
+.global TitleLinkObject_patch
+TitleLinkObject_patch:
+    .word 0xFFFF0014
+
 @ ----------------------------------
 @ ----------------------------------
 


### PR DESCRIPTION
- Use normal Adult Link Object on Title Screen, so the custom tunic patches can be applied.
- Move Randomizer_Init to before Play_Init, so the custom Player_rDraw function will be called on the Title Screen even the first time after booting the game. This is required for the rainbow tunic to work.