### PR TITLE
Fix draw item model for rupees collected by diving

### DIFF
--- a/code/oot.ld
+++ b/code/oot.ld
@@ -1601,8 +1601,12 @@ SECTIONS
 	/* End of regional differences: 0x4A5AE0 */
 	region_offset = 0;
 
-	.patch_OverrideGiDrawIdPlusOne 0x4BC610 : {
-		*(.patch_OverrideGiDrawIdPlusOne)
+	.patch_OverrideGiDrawIdPlusOne_Ground 0x4BC610 : {
+		*(.patch_OverrideGiDrawIdPlusOne_Ground)
+	}
+
+	.patch_OverrideGiDrawIdPlusOne_Water 0x4BD5DC : {
+		*(.patch_OverrideGiDrawIdPlusOne_Water)
 	}
 
 	.patch_EditDrawGetItemBeforeModelSpawn 0x4C0FD0 : {

--- a/code/src/patches.s
+++ b/code/src/patches.s
@@ -61,9 +61,14 @@ OverrideDrawItemTwo_patch:
 OverrideDrawItemThree_patch:
     bl hook_OverrideDrawItemThree
 
-.section .patch_OverrideGiDrawIdPlusOne
-.global OverrideGiDrawIdPlusOne_patch
-OverrideGiDrawIdPlusOne_patch:
+.section .patch_OverrideGiDrawIdPlusOne_Ground
+.global OverrideGiDrawIdPlusOne_Ground_patch
+OverrideGiDrawIdPlusOne_Ground_patch:
+    bl hook_OverrideGiDrawIdPlusOne
+
+.section .patch_OverrideGiDrawIdPlusOne_Water
+.global OverrideGiDrawIdPlusOne_Water_patch
+OverrideGiDrawIdPlusOne_Water_patch:
     bl hook_OverrideGiDrawIdPlusOne
 
 .section .patch_EditDrawGetItemBeforeModelSpawn


### PR DESCRIPTION
This fixes a bug with the overhead item model when collecting underwater rupees by diving.

A field in the player actor needs to be properly updated to display the correct rupee mesh, but the existing patch was only working for items obtained while standing, not swimming. I duplicated the patch to apply to the swimming action too.