### PR TITLE
Clear gExtSaveData on savefile init

### DIFF
--- a/code/src/savefile.c
+++ b/code/src/savefile.c
@@ -710,14 +710,12 @@ s8 SaveFile_GetIgnoreMaskReactionOption(u32 reactionSet) {
 }
 
 void SaveFile_InitExtSaveData(u32 saveNumber, u8 fromSaveCreation) {
+    // Reset entire struct to 0 before setting specific fields.
+    memset(&gExtSaveData, 0, sizeof(gExtSaveData));
+
     gExtSaveData.version = EXTSAVEDATA_VERSION; // Do not change this line
-    memset(&gExtSaveData.extInf, 0, sizeof(gExtSaveData.extInf));
     gExtSaveData.extInf[EXTINF_MASTERSWORDFLAGS] =
         (gSettingsContext.shuffleMasterSword && !(gSettingsContext.startingEquipment & 0x2)) ? 0 : 1;
-    memset(&gExtSaveData.fwStored, 0, sizeof(gExtSaveData.fwStored));
-    gExtSaveData.playtimeSeconds = 0;
-    memset(&gExtSaveData.scenesDiscovered, 0, sizeof(gExtSaveData.scenesDiscovered));
-    memset(&gExtSaveData.entrancesDiscovered, 0, sizeof(gExtSaveData.entrancesDiscovered));
     gExtSaveData.permadeath = fromSaveCreation ? gSettingsContext.permadeath : 0;
     // Ingame Options
     gExtSaveData.option_EnableBGM          = gSettingsContext.playMusic;


### PR DESCRIPTION
This fixes the triforce piece counter not being reset to 0, which could make it carry over from another savefile. To avoid similar mistakes in the future, I changed the function to first initialize the entire `gExtSaveData` struct to 0, then populate the fields that require other values.