### PR TITLE
Fix effect crashes and other minor issues

### DIFF
--- a/code/include/z3D/z3D.h
+++ b/code/include/z3D/z3D.h
@@ -11,6 +11,8 @@
 #include "z3Dbgcheck.h"
 #include "z3Dscene.h"
 #include "z3Dactor_id.h"
+#include "z3Deffect.h"
+#include "z3Dcolor.h"
 
 // #include "hid.h"
 

--- a/code/include/z3D/z3Dcolor.h
+++ b/code/include/z3D/z3Dcolor.h
@@ -1,0 +1,14 @@
+#ifndef _Z3DCOLOR_H_
+#define _Z3DCOLOR_H_
+
+#include "z3Dvec.h"
+
+typedef struct {
+    u8 r, g, b, a;
+} Color_RGBA8;
+
+typedef struct {
+    f32 r, g, b, a;
+} Color_RGBAf;
+
+#endif //_Z3DCOLOR_H_

--- a/code/include/z3D/z3Deffect.h
+++ b/code/include/z3D/z3Deffect.h
@@ -1,0 +1,159 @@
+#ifndef _Z3DEFFECT_H_
+#define _Z3DEFFECT_H_
+
+#include "z3Dvec.h"
+#include "z3Dcolor.h"
+
+/* Effects */
+
+#define SPARK_COUNT 24
+#define BLURE_COUNT 25
+#define SHIELD_PARTICLE_COUNT 10
+
+typedef struct EffectStatus {
+    /* 0x00 */ u8 active;
+    /* 0x01 */ u8 unk_01;
+    /* 0x02 */ u8 unk_02;
+    /* 0x02 */ char _pad_04;
+} EffectStatus;
+
+typedef struct EffectSpark {
+    /* 0x000 */ char unk_000[0x550];
+} EffectSpark;
+_Static_assert(sizeof(EffectSpark) == 0x550, "EffectSpark size");
+
+typedef struct {
+    /* 0x00 */ s32 state;
+    /* 0x04 */ s32 timer;
+    /* 0x08 */ Vec3f p1;
+    /* 0x14 */ Vec3f p2;
+    /* 0x20 */ u32 flags;
+} EffectBlureElement;
+_Static_assert(sizeof(EffectBlureElement) == 0x24, "EffectBlureElement size");
+
+typedef struct EffectBlure {
+    /* 0x000 */ EffectBlureElement elements[16];
+    /* 0x240 */ char unk_240[0x08];
+    /* 0x248 */ u16 flags;
+    /* 0x24A */ char unk_24A[0x04];
+    /* 0x24E */ Color_RGBA8 p1StartColor;
+    /* 0x252 */ Color_RGBA8 p2StartColor;
+    /* 0x256 */ Color_RGBA8 p1EndColor;
+    /* 0x25A */ Color_RGBA8 p2EndColor;
+    /* 0x25E */ u8 numElements;
+    /* 0x25F */ u8 elemDuration;
+    /* 0x260 */ u8 unkFlag;
+    /* 0x261 */ u8 drawMode;
+    /* 0x262 */ char unk_262[0x0A];
+    /* 0x26C */ u32 unk_pointer_26C;
+    /* 0x270 */ u32 unk_pointer_270;
+    /* 0x274 */ char unk_274[0x0E];
+    /* 0x282 */ u8 unkDrawMode1;
+    /* 0x283 */ u8 unkDrawMode2;
+    /* 0x284 */ char unk_284[0x4];
+} EffectBlure;
+_Static_assert(sizeof(EffectBlure) == 0x288, "EffectBlure size");
+
+typedef struct EffectShieldParticle {
+    /* 0x000 */ char unk_000[0x1DC];
+} EffectShieldParticle;
+_Static_assert(sizeof(EffectShieldParticle) == 0x1DC, "EffectShieldParticle size");
+
+typedef struct EffectContext {
+    /* 0x0000 */ struct GlobalContext* play;
+    struct {
+        EffectStatus status;
+        EffectSpark effect;
+    } /* 0x0004 */ sparks[SPARK_COUNT];
+    struct {
+        EffectStatus status;
+        EffectBlure effect;
+    } /* 0x7FE4 */ blures[BLURE_COUNT];
+    struct {
+        EffectStatus status;
+        EffectShieldParticle effect;
+    } /* 0xBF90 */ shieldParticles[SHIELD_PARTICLE_COUNT];
+} EffectContext;
+_Static_assert(sizeof(EffectContext) == 0xD250, "EffectContext size");
+
+#define gEffectContext (*(EffectContext*)GAME_ADDR(0x58B2E0))
+
+#define EffectBlure_Update ((void (*)(EffectBlure*))GAME_ADDR(0x227000))
+
+typedef void (*Effect_Delete_proc)(struct GlobalContext* globalCtx, s32 index);
+#define Effect_Delete ((Effect_Delete_proc)GAME_ADDR(0x34F0F4))
+
+/* Effect Soft Sprites */
+
+typedef enum EffectSsType {
+    /* 0x00 */ EFFECT_SS_DUST,
+    /* 0x01 */ EFFECT_SS_KIRAKIRA,
+    /* 0x02 */ EFFECT_SS_BOMB,
+    /* 0x03 */ EFFECT_SS_BOMB2,
+    /* 0x04 */ EFFECT_SS_BLAST,
+    /* 0x05 */ EFFECT_SS_G_SPK,
+    /* 0x06 */ EFFECT_SS_D_FIRE,
+    /* 0x07 */ EFFECT_SS_BUBBLE,
+    /* 0x08 */ EFFECT_SS_UNSET,
+    /* 0x09 */ EFFECT_SS_G_RIPPLE,
+    /* 0x0A */ EFFECT_SS_G_SPLASH,
+    /* 0x0B */ EFFECT_SS_G_MAGMA,
+    /* 0x0C */ EFFECT_SS_G_FIRE,
+    /* 0x0D */ EFFECT_SS_LIGHTNING,
+    /* 0x0E */ EFFECT_SS_DT_BUBBLE,
+    /* 0x0F */ EFFECT_SS_HAHEN,
+    /* 0x10 */ EFFECT_SS_STICK,
+    /* 0x11 */ EFFECT_SS_SIBUKI,
+    /* 0x12 */ EFFECT_SS_SIBUKI2,
+    /* 0x13 */ EFFECT_SS_G_MAGMA2,
+    /* 0x14 */ EFFECT_SS_STONE1,
+    /* 0x15 */ EFFECT_SS_HITMARK,
+    /* 0x16 */ EFFECT_SS_FHG_FLASH,
+    /* 0x17 */ EFFECT_SS_K_FIRE,
+    /* 0x18 */ EFFECT_SS_SOLDER_SRCH_BALL,
+    /* 0x19 */ EFFECT_SS_KAKERA,
+    /* 0x1A */ EFFECT_SS_ICE_PIECE,
+    /* 0x1B */ EFFECT_SS_EN_ICE,
+    /* 0x1C */ EFFECT_SS_FIRE_TAIL,
+    /* 0x1D */ EFFECT_SS_EN_FIRE,
+    /* 0x1E */ EFFECT_SS_EXTRA,
+    /* 0x1F */ EFFECT_SS_FCIRCLE,
+    /* 0x20 */ EFFECT_SS_DEAD_DB,
+    /* 0x21 */ EFFECT_SS_DEAD_DD,
+    /* 0x22 */ EFFECT_SS_DEAD_DS,
+    /* 0x23 */ EFFECT_SS_DEAD_SOUND,
+    /* 0x24 */ EFFECT_SS_ICE_SMOKE,
+    /* 0x25 */ EFFECT_SS_TYPE_MAX,
+} EffectSsType;
+
+typedef struct EffectSs {
+    /* 0x00 */ Vec3f pos;
+    /* 0x0C */ Vec3f velocity;
+    /* 0x18 */ Vec3f accel;
+    /* 0x24 */ void* update;
+    /* 0x28 */ void* draw;
+    /* 0x2C */ Vec3f vec;           // usage specific per effect
+    /* 0x38 */ void* gfx;           // mostly used for display lists, sometimes textures
+    /* 0x3C */ struct Actor* actor; // interfacing actor, usually the actor that spawned the effect
+    /* 0x40 */ char unk_40[0x04];
+    /* 0x44 */ s16 regs[13]; // specific per effect
+    /* 0x5E */ u16 flags;
+    /* 0x60 */ s16 life;    // -1 means this entry is free
+    /* 0x62 */ u8 priority; // Lower value means higher priority
+    /* 0x63 */ u8 type;
+    /* 0x64 */ char unk_64[0x24];
+} EffectSs;
+_Static_assert(sizeof(EffectSs) == 0x88, "EffectSs size");
+
+typedef struct EffectSsInfo {
+    /* 0x00 */ EffectSs* table;
+    /* 0x04 */ s32 tableSize;
+    // ...
+} EffectSsInfo;
+
+#define gEffectSsInfo (*(EffectSsInfo*)GAME_ADDR(0x598530))
+
+typedef void (*EffectSs_Delete_proc)(EffectSs* effectSs);
+#define EffectSs_Delete ((EffectSs_Delete_proc)GAME_ADDR(0x2D6A50))
+
+#endif //_Z3DEFFECT_H_

--- a/code/oot.ld
+++ b/code/oot.ld
@@ -1192,6 +1192,10 @@ SECTIONS
 		*(.patch_OverrideDrawItemThree)
 	}
 
+	.patch_AfterInvalidatingRoomObjects 0x3A7698 : {
+		*(.patch_AfterInvalidatingRoomObjects)
+	}
+
 	.patch_AfterObjectListCommand 0x3A7708 : {
 		*(.patch_AfterObjectListCommand)
 	}

--- a/code/src/actor.c
+++ b/code/src/actor.c
@@ -165,8 +165,9 @@ void Actor_Init() {
 
     gActorOverlayTable[0x66].initInfo->init = ArmsHook_rInit;
 
-    gActorOverlayTable[0x69].initInfo->init   = EnBb_rInit;
-    gActorOverlayTable[0x69].initInfo->update = EnBb_rUpdate;
+    gActorOverlayTable[0x69].initInfo->init    = EnBb_rInit;
+    gActorOverlayTable[0x69].initInfo->update  = EnBb_rUpdate;
+    gActorOverlayTable[0x69].initInfo->destroy = EnBb_rDestroy;
 
     gActorOverlayTable[0x6B].initInfo->update = EnYukabyun_rUpdate;
 

--- a/code/src/actors/bubble.c
+++ b/code/src/actors/bubble.c
@@ -4,6 +4,7 @@
 
 #define EnBb_Init ((ActorFunc)GAME_ADDR(0x162328))
 #define EnBb_Update ((ActorFunc)GAME_ADDR(0x1005ec))
+#define EnBb_Destroy ((ActorFunc)GAME_ADDR(0x162C28))
 
 #define Bubble_GetType(actor) ((s16)(thisx->params | 0xFF00))
 
@@ -78,4 +79,16 @@ void EnBb_rInit(Actor* thisx, GlobalContext* globalCtx) {
 
 void EnBb_rUpdate(Actor* thisx, GlobalContext* globalCtx) {
     Bubble_CallActorFunc(EnBb_Update, thisx, globalCtx);
+}
+
+void EnBb_rDestroy(Actor* thisx, GlobalContext* globalCtx) {
+    EnBb* this = (EnBb*)thisx;
+
+    EnBb_Destroy(thisx, globalCtx);
+
+    if (thisx->params == ENBB_WHITE) {
+        // Fix vanilla bug: White Bubbles never delete their own "blure" effect, causing
+        // a memory leak which can lead to a crash if the space for blures is filled up.
+        Effect_Delete(globalCtx, this->blureIdx);
+    }
 }

--- a/code/src/actors/bubble.h
+++ b/code/src/actors/bubble.h
@@ -21,11 +21,14 @@ typedef struct EnBb {
     /* 0x564 */ Vec3f waypointPos;
     /* 0x570 */ u8 path;
     /* 0x571 */ u8 waypoint;
-    /* 0x572 */ char unk_572[0x96];
+    /* 0x572 */ char unk_572[0x06];
+    /* 0x578 */ s32 blureIdx;
+    /* 0x57C */ char unk_57C[0x8C];
 } EnBb;
 _Static_assert(sizeof(EnBb) == 0x608, "EnBb size");
 
 void EnBb_rInit(Actor* thisx, GlobalContext* globalCtx);
 void EnBb_rUpdate(Actor* thisx, GlobalContext* globalCtx);
+void EnBb_rDestroy(Actor* thisx, GlobalContext* globalCtx);
 
 #endif //_BUBBLE_H_

--- a/code/src/actors/flare_dancer.h
+++ b/code/src/actors/flare_dancer.h
@@ -2,7 +2,6 @@
 #define _FLARE_DANCER_H_
 
 #include "z3D/z3D.h"
-#include "colors.h"
 
 struct EnFd;
 struct EnFdFire;

--- a/code/src/colors.h
+++ b/code/src/colors.h
@@ -1,13 +1,7 @@
 #ifndef _COLORS_H_
 #define _COLORS_H_
 
-typedef struct {
-    u8 r, g, b, a;
-} Color_RGBA8;
-
-typedef struct {
-    f32 r, g, b, a;
-} Color_RGBAf;
+#include "z3D/z3D.h"
 
 Color_RGBA8 Colors_GetRainbowColor(u32 curFrame, u32 stepFrames);
 

--- a/code/src/effects.c
+++ b/code/src/effects.c
@@ -2,37 +2,6 @@
 #include "settings.h"
 #include "colors.h"
 
-typedef struct {
-    /* 0x00 */ s32 state;
-    /* 0x04 */ s32 timer;
-    /* 0x08 */ Vec3f p1;
-    /* 0x14 */ Vec3f p2;
-    /* 0x20 */ u32 flags;
-} EffectBlureElement; // size = 0x24
-
-typedef struct {
-    /* 0x000 */ EffectBlureElement elements[16];
-    /* 0x240 */ char unk_240[0x08];
-    /* 0x248 */ u16 flags;
-    /* 0x24A */ char unk_24A[0x04];
-    /* 0x24E */ Color_RGBA8 p1StartColor;
-    /* 0x252 */ Color_RGBA8 p2StartColor;
-    /* 0x256 */ Color_RGBA8 p1EndColor;
-    /* 0x25A */ Color_RGBA8 p2EndColor;
-    /* 0x25E */ u8 numElements;
-    /* 0x25F */ u8 elemDuration;
-    /* 0x260 */ u8 unkFlag;
-    /* 0x261 */ u8 drawMode;
-    /* 0x262 */ char unk_262[0x0A];
-    /* 0x26C */ u32 unk_pointer_26C;
-    /* 0x270 */ u32 unk_pointer_270;
-    /* 0x274 */ char unk_274[0x0E];
-    /* 0x282 */ u8 unkDrawMode1;
-    /* 0x283 */ u8 unkDrawMode2;
-} EffectBlure; // size = ??
-
-#define EffectBlure_Update ((void (*)(EffectBlure*))GAME_ADDR(0x227000))
-
 // This function is called when a new effect element tries to spawn but there's no space left.
 // The vanilla game simply fails to spawn the new element, but with the randomizer extended duration setting,
 // it is best to clear the oldest element to make space instead.

--- a/code/src/effects.c
+++ b/code/src/effects.c
@@ -1,6 +1,7 @@
 #include "z3D/z3D.h"
 #include "settings.h"
 #include "colors.h"
+#include "objects.h"
 
 // This function is called when a new effect element tries to spawn but there's no space left.
 // The vanilla game simply fails to spawn the new element, but with the randomizer extended duration setting,
@@ -150,4 +151,30 @@ u32 updateChuTrailColors(EffectBlure* effect, Vec3f* p1, Vec3f* p2) {
     }
 
     return handleLongTrails(gSettingsContext.bombchuTrailDuration, effect, p1, p2);
+}
+
+void EffectSs_ClearAllWithMissingObject(void) {
+    for (u32 i = 0; i < gEffectSsInfo.tableSize; i++) {
+        EffectSs* effectSs = &gEffectSsInfo.table[i];
+        s16 objRegIdx      = -1;
+
+        switch (effectSs->type) {
+            case EFFECT_SS_D_FIRE:
+                objRegIdx = 10;
+                break;
+            case EFFECT_SS_HAHEN:
+                objRegIdx = 5;
+                break;
+            case EFFECT_SS_KAKERA:
+                objRegIdx = 11;
+                break;
+            case EFFECT_SS_ICE_SMOKE:
+                objRegIdx = 0;
+                break;
+        }
+
+        if (objRegIdx >= 0 && !Object_IsLoaded(&gGlobalContext->objectCtx, effectSs->regs[objRegIdx])) {
+            EffectSs_Delete(effectSs);
+        }
+    }
 }

--- a/code/src/effects.h
+++ b/code/src/effects.h
@@ -1,0 +1,8 @@
+#ifndef _EFFECTS_H_
+#define _EFFECTS_H_
+
+#include "z3D/z3D.h"
+
+void EffectSs_ClearAllWithMissingObject(void);
+
+#endif //_EFFECTS_H_

--- a/code/src/enemizer.c
+++ b/code/src/enemizer.c
@@ -283,6 +283,10 @@ static void Enemizer_MoveSpecificLocations(ActorEntry* actorEntry, s32 actorEntr
             // Move Gerudo Fighter down inside the room
             actorEntry->pos.y = -120;
             break;
+        case LOC(85, 2, 1, 6):
+            // Move a Deku Baba in Kokiri Forest above the floor
+            actorEntry->pos.y = -150;
+            break;
         case LOC(86, 0, 0, 1):
             // Move the SFM wolfos more towards the center, some enemies might jump over the fence
             actorEntry->pos.x = -195;

--- a/code/src/fairy.c
+++ b/code/src/fairy.c
@@ -3,6 +3,7 @@
 #include "settings.h"
 #include "objects.h"
 #include "common.h"
+#include "colors.h"
 
 #define NAVI_COLORS_ARRAY ((Color_RGBA8*)GAME_ADDR(0x50C998))
 

--- a/code/src/fairy.h
+++ b/code/src/fairy.h
@@ -2,7 +2,6 @@
 #define _FAIRY_H_
 
 #include "z3D/z3D.h"
-#include "colors.h"
 
 typedef struct EnElf {
     /* 0x000 */ Actor actor;

--- a/code/src/hooks.s
+++ b/code/src/hooks.s
@@ -2450,3 +2450,11 @@ hook_FixActorKillLoop:
     cmp r0,#0x0
     pop {r0-r12, lr}
     bx lr
+
+.global hook_AfterInvalidatingRoomObjects
+hook_AfterInvalidatingRoomObjects:
+    push {r0-r12, lr}
+    bl ExtendedObject_InvalidateRoomObjects
+    pop {r0-r12, lr}
+    ldr r0,[sp,#0x18]
+    bx lr

--- a/code/src/objects.c
+++ b/code/src/objects.c
@@ -5,6 +5,7 @@
 #include "custom_models.h"
 #include "oot_malloc.h"
 #include "enemizer.h"
+#include "effects.h"
 
 #include <stddef.h>
 
@@ -56,9 +57,16 @@ void ExtendedObject_AfterObjectListCommand(void) {
         Object_FindSlotOrSpawn(OBJECT_CUSTOM_GENERAL_ASSETS);
         Object_FindSlotOrSpawn(3); // zelda_dangeon_keep (main dungeon object)
         rExtendedObjectCtx.numPersistentEntries = rExtendedObjectCtx.numEntries;
-    } else { // (state.running == 2) Loading room
+    }
+}
+
+// Called from Scene_CommandObjectList, after the object slots from the vanilla ObjectContext
+// have been invalidated and before new ones get loaded.
+void ExtendedObject_InvalidateRoomObjects(void) {
+    if (gGlobalContext->state.running == 2) { // Loading room
         ExtendedObject_ClearNonPersistent();
         Actor_KillAllWithMissingObject(gGlobalContext, &gGlobalContext->actorCtx);
+        EffectSs_ClearAllWithMissingObject();
         Model_DestroyAll();
     }
 }

--- a/code/src/patches.s
+++ b/code/src/patches.s
@@ -2526,3 +2526,8 @@ GerudoBattleMusic_patch:
 .global FixActorKillLoop_patch
 FixActorKillLoop_patch:
     bl hook_FixActorKillLoop
+
+.section .patch_AfterInvalidatingRoomObjects
+.global AfterInvalidatingRoomObjects_patch
+AfterInvalidatingRoomObjects_patch:
+    bl hook_AfterInvalidatingRoomObjects

--- a/code/src/settings.h
+++ b/code/src/settings.h
@@ -2,7 +2,6 @@
 #define _SETTINGS_H_
 
 #include "../include/z3D/z3D.h"
-#include "colors.h"
 #include "enemizer.h"
 
 typedef enum {

--- a/source/cosmetics.hpp
+++ b/source/cosmetics.hpp
@@ -4,6 +4,8 @@
 #include <string>
 #include <vector>
 
+#include "../code/include/z3D/z3Dcolor.h"
+
 namespace Cosmetics {
 constexpr std::string_view RANDOM_CHOICE_STR   = "Random Choice";
 constexpr std::string_view RANDOM_COLOR_STR    = "Random Color";
@@ -19,20 +21,6 @@ enum CosmeticSettings {
     RANDOM_COLOR,
     CUSTOM_COLOR,
     NON_COLOR_COUNT,
-};
-
-struct Color_RGBAf {
-    float r;
-    float g;
-    float b;
-    float a;
-};
-
-struct Color_RGBA8 {
-    uint8_t r;
-    uint8_t g;
-    uint8_t b;
-    uint8_t a;
 };
 
 extern const std::array<std::string_view, 13> gauntletColors;

--- a/source/patch.cpp
+++ b/source/patch.cpp
@@ -490,10 +490,10 @@ bool WriteAllPatches() {
     ---------------------------------*/
 
     const u32 SWORDTRAILCOLORSARRAY_ADDR = 0x0053C136;
-    Cosmetics::Color_RGBA8 p1StartColor  = Cosmetics::HexStrToColorRGBA8(Settings::finalSwordTrailOuterColor);
-    Cosmetics::Color_RGBA8 p2StartColor  = Cosmetics::HexStrToColorRGBA8(Settings::finalSwordTrailInnerColor);
-    Cosmetics::Color_RGBA8 p1EndColor    = Cosmetics::HexStrToColorRGBA8(Settings::finalSwordTrailOuterColor);
-    Cosmetics::Color_RGBA8 p2EndColor    = Cosmetics::HexStrToColorRGBA8(Settings::finalSwordTrailInnerColor);
+    Color_RGBA8 p1StartColor             = Cosmetics::HexStrToColorRGBA8(Settings::finalSwordTrailOuterColor);
+    Color_RGBA8 p2StartColor             = Cosmetics::HexStrToColorRGBA8(Settings::finalSwordTrailInnerColor);
+    Color_RGBA8 p1EndColor               = Cosmetics::HexStrToColorRGBA8(Settings::finalSwordTrailOuterColor);
+    Color_RGBA8 p2EndColor               = Cosmetics::HexStrToColorRGBA8(Settings::finalSwordTrailInnerColor);
     bool shouldDrawSimple                = Settings::ChosenSimpleMode ||
                             (p1StartColor.r != 0xFF && p1StartColor.g != 0xFF && p1StartColor.b != 0xFF) ||
                             (p2StartColor.r != 0xFF && p2StartColor.g != 0xFF && p2StartColor.b != 0xFF);
@@ -690,10 +690,10 @@ bool WriteAllPatches() {
     |       custom assets      |
     --------------------------*/
 
-    Cosmetics::Color_RGBAf childTunicColor  = Cosmetics::HexStrToColorRGBAf(Settings::finalChildTunicColor);
-    Cosmetics::Color_RGBAf kokiriTunicColor = Cosmetics::HexStrToColorRGBAf(Settings::finalKokiriTunicColor);
-    Cosmetics::Color_RGBAf goronTunicColor  = Cosmetics::HexStrToColorRGBAf(Settings::finalGoronTunicColor);
-    Cosmetics::Color_RGBAf zoraTunicColor   = Cosmetics::HexStrToColorRGBAf(Settings::finalZoraTunicColor);
+    Color_RGBAf childTunicColor  = Cosmetics::HexStrToColorRGBAf(Settings::finalChildTunicColor);
+    Color_RGBAf kokiriTunicColor = Cosmetics::HexStrToColorRGBAf(Settings::finalKokiriTunicColor);
+    Color_RGBAf goronTunicColor  = Cosmetics::HexStrToColorRGBAf(Settings::finalGoronTunicColor);
+    Color_RGBAf zoraTunicColor   = Cosmetics::HexStrToColorRGBAf(Settings::finalZoraTunicColor);
 
     // Delete assets if it exists
     Handle assetsOut;

--- a/source/settings.cpp
+++ b/source/settings.cpp
@@ -1268,7 +1268,7 @@ std::string finalEnemyNaviOuterColor  = EnemyNaviOuterColor.GetSelectedOptionTex
 std::string finalPropNaviOuterColor   = PropNaviOuterColor.GetSelectedOptionText();
 std::string finalSwordTrailOuterColor = SwordTrailOuterColor.GetSelectedOptionText();
 std::string finalSwordTrailInnerColor = SwordTrailInnerColor.GetSelectedOptionText();
-Cosmetics::Color_RGBA8 finalBoomerangColor = {0};
+Color_RGBA8 finalBoomerangColor = {0};
 u8 boomerangTrailColorMode = 0;
 std::string finalChuTrailInnerColor   = BombchuTrailInnerColor.GetSelectedOptionText();
 std::string finalChuTrailOuterColor   = BombchuTrailOuterColor.GetSelectedOptionText();
@@ -2996,7 +2996,7 @@ static void UpdateCosmetics() {
     }
     // Boomerang Trail
     std::string tempString;
-    Cosmetics::Color_RGBA8 tempColor;
+    Color_RGBA8 tempColor;
     ChooseFinalColor(BoomerangTrailColor, tempString, weaponTrailColors);
     tempColor             = Cosmetics::HexStrToColorRGBA8(tempString);
     finalBoomerangColor.r = tempColor.r;

--- a/source/settings.hpp
+++ b/source/settings.hpp
@@ -812,7 +812,7 @@ extern std::string finalEnemyNaviOuterColor;
 extern std::string finalPropNaviOuterColor;
 extern std::string finalSwordTrailInnerColor;
 extern std::string finalSwordTrailOuterColor;
-extern Cosmetics::Color_RGBA8 finalBoomerangColor;
+extern Color_RGBA8 finalBoomerangColor;
 extern u8 boomerangTrailColorMode;
 extern std::string finalChuTrailInnerColor;
 extern std::string finalChuTrailOuterColor;


### PR DESCRIPTION
This fixes 2 crashes caused by effects used by randomized enemies.

1. The EffectBlure spawned by White Bubbles normally never gets deleted. This can cause a crash even in the vanilla game if you enter their room in Spirit Temple 8 times to fill up the Effect Context and then shoot an arrow. Now they will delete their own effect on actor destruction.

2. Flying Tiles spawn particle effects of type EFFECT_SS_HAHEN which depend on the enemy's object. Loading another room to unload the object could make the effect's draw function use stale memory and crash. Now effects with missing object dependencies will be deleted on room change.

I also fixed the position of a randomized enemy in Kokiri Forest.

While adding a new header file for effects (`z3Deffect.h`), I moved the color typedefs to their own header (`z3Dcolor.h`) and included it in the app's files too.