### PR TITLE
Bug fixes for Enemy Randomizer

### DIFF
--- a/code/include/z3D/z3Dactor_id.h
+++ b/code/include/z3D/z3Dactor_id.h
@@ -3,6 +3,7 @@
 
 enum ActorId {
     ACTOR_STALFOS            = 0x002,
+    ACTOR_EN_PART            = 0x007,
     ACTOR_POE                = 0x00D,
     ACTOR_OCTOROK            = 0x00E,
     ACTOR_WALLMASTER         = 0x011,

--- a/code/src/actor.c
+++ b/code/src/actor.c
@@ -294,6 +294,8 @@ void Actor_Init() {
 
     gActorOverlayTable[0x192].initInfo->init = EnHintnuts_rInit;
 
+    gActorOverlayTable[0x193].initInfo->update = EnNutsball_rUpdate;
+
     gActorOverlayTable[0x195].initInfo->init = EnShopnuts_rInit;
 
     gActorOverlayTable[0x197].initInfo->update = EnGeldB_rUpdate;

--- a/code/src/actors/deku_scrubs.c
+++ b/code/src/actors/deku_scrubs.c
@@ -9,6 +9,11 @@
 
 #define EnHintnuts_Init ((ActorFunc)GAME_ADDR(0x22AB2C))
 
+#define EnNutsball_Update ((ActorFunc)GAME_ADDR(0x26BD8C))
+
+#define NUTSBALL_TYPE_DEKUNUTS 0
+#define NUTSBALL_TYPE_HINTNUTS 1
+
 void EnDntNomal_rUpdate(Actor* thisx, GlobalContext* globalCtx) {
     EnDntNomal* this = (EnDntNomal*)thisx;
 
@@ -30,4 +35,20 @@ void EnHintnuts_rInit(Actor* thisx, GlobalContext* globalCtx) {
     if (Enemizer_IsEnemyRandomized(ENEMY_HINT_DEKU_SCRUB)) {
         thisx->textId = this->textIdCopy = 0x3033; // "B-b-b-boooo hooooo!"
     }
+}
+
+void EnNutsball_rUpdate(Actor* thisx, GlobalContext* globalCtx) {
+    EnNutsball* this = (EnNutsball*)thisx;
+
+    const u8 isFromRandomizedEnemy =
+        (thisx->params == NUTSBALL_TYPE_HINTNUTS && Enemizer_IsEnemyRandomized(ENEMY_HINT_DEKU_SCRUB)) ||
+        (thisx->params == NUTSBALL_TYPE_DEKUNUTS && Enemizer_IsEnemyRandomized(ENEMY_MAD_SCRUB));
+
+    if (isFromRandomizedEnemy && thisx->bgCheckFlags & BGCHECKFLAG_GROUND && this->timer > 20) {
+        // Don't break the projectile if it touches the ground too quickly after being shot, so the player can still
+        // reflect it even if the enemy is surrounded by higher ground (like in the GTG Like-Like room).
+        thisx->bgCheckFlags &= ~BGCHECKFLAG_GROUND;
+    }
+
+    EnNutsball_Update(thisx, globalCtx);
 }

--- a/code/src/actors/deku_scrubs.h
+++ b/code/src/actors/deku_scrubs.h
@@ -26,8 +26,20 @@ typedef struct EnHintnuts {
 } EnHintnuts;
 _Static_assert(sizeof(EnHintnuts) == 0x638, "EnHintnuts size");
 
+typedef struct EnNutsball {
+    /* 0x0000 */ Actor actor;
+    /* 0x01A4 */ void* actionFunc;
+    /* 0x01A8 */ s8 requiredObjectSlot;
+    /* 0x01AA */ s16 timer;
+    /* 0x01AC */ ColliderCylinder collider;
+    /* 0x0204 */ SkeletonAnimationModel* saModel;
+} EnNutsball;
+_Static_assert(sizeof(EnNutsball) == 0x208, "EnNutsball size");
+
 void EnDntNomal_rUpdate(Actor* thisx, GlobalContext* globalCtx);
 
 void EnHintnuts_rInit(Actor* thisx, GlobalContext* globalCtx);
+
+void EnNutsball_rUpdate(Actor* thisx, GlobalContext* globalCtx);
 
 #endif

--- a/code/src/actors/iron_knuckle.c
+++ b/code/src/actors/iron_knuckle.c
@@ -2,6 +2,17 @@
 #include "settings.h"
 
 #define EnIk_Init ((ActorFunc)GAME_ADDR(0x164B0C))
+#define EnIk_UpdateEnemy ((ActorFunc)GAME_ADDR(0x1008B4))
+
+void EnIk_Update_Randomized(Actor* thisx, GlobalContext* globalCtx) {
+    EnIk_UpdateEnemy(thisx, globalCtx);
+
+    // Change wallCheckHeight from 75 to 50, to prevent falling out of bounds through low walls
+    // (e.g. near the crawlspace in Spirit Temple).
+    Actor_UpdateBgCheckInfo(globalCtx, thisx, 50.0f, 30.0f, 30.0f,
+                            UPDBGCHECKINFO_WALL | UPDBGCHECKINFO_FLOOR_WATER | UPDBGCHECKINFO_FLAG_3 |
+                                UPDBGCHECKINFO_FLAG_4);
+}
 
 void EnIk_rInit(Actor* thisx, GlobalContext* globalCtx) {
     EnIk* this = (EnIk*)thisx;
@@ -11,5 +22,7 @@ void EnIk_rInit(Actor* thisx, GlobalContext* globalCtx) {
     if (Enemizer_IsEnemyRandomized(ENEMY_IRON_KNUCKLE)) {
         // Wake up immediately
         this->skelAnime.playSpeed = 1.0f;
+        // Override update here because it's also set in EnIk_Init
+        this->actor.update = EnIk_Update_Randomized;
     }
 }

--- a/code/src/actors/moblin.c
+++ b/code/src/actors/moblin.c
@@ -62,7 +62,8 @@ void EnMb_rUpdate(Actor* thisx, GlobalContext* globalCtx) {
         }
 
         Actor* shockwave = thisx->child;
-        if (shockwave != NULL && shockwave->update == NULL && shockwave->draw == NULL) {
+        if (shockwave != NULL &&
+            ((shockwave->update == NULL && shockwave->draw == NULL) || shockwave->id != ACTOR_EN_PART)) {
             // When the shockwave despawns, clear the child pointer.
             thisx->child = shockwave = NULL;
         }
@@ -79,6 +80,7 @@ void EnMb_rUpdate(Actor* thisx, GlobalContext* globalCtx) {
                 shockwave->world.pos.y = yGroundIntersect;
             } else {
                 Actor_Kill(shockwave);
+                thisx->child = shockwave = NULL;
             }
         }
     }

--- a/source/enemizer.hpp
+++ b/source/enemizer.hpp
@@ -15,6 +15,7 @@ namespace Enemizer {
 // Conditions used for the logic to place enemies.
 enum class LocType {
     ABOVE_GROUND,  // Location is on or above walkable ground.
+    NARROW_GROUND, // Location is on ground near a pit which the enemy must not be able to fall into.
     ABOVE_VOID,    // Location is over a void plane. Enemy must be able to fly.
     UNDERWATER,    // Location is underwater. Enemy must be defeatable with hookshot and iron boots.
     ABOVE_WATER,   // Location is in the air above a water surface. Enemy must be able to float or fly.

--- a/source/enemizer_list.cpp
+++ b/source/enemizer_list.cpp
@@ -13,31 +13,31 @@ EnemyLocationsMap enemyLocations = {};
 void InitEnemyTypes(void) {
     enemyTypes[ENEMY_INVALID] = EnemyType("Invalid Enemy", &noVariable, 0, { 0 }, {});
     enemyTypes[ENEMY_POE] = EnemyType("Poe", &SoulPoe, ACTOR_POE, { 0x0000, 0x0002, 0x0003 }, // normal, Sharp, Flat
-        { LocType::ABOVE_GROUND, LocType::ABOVE_VOID, LocType::UNDERWATER, LocType::ABOVE_WATER, LocType::SHALLOW_WATER, LocType::SPAWNER });
+        { LocType::ABOVE_GROUND, LocType::NARROW_GROUND, LocType::ABOVE_VOID, LocType::UNDERWATER, LocType::ABOVE_WATER, LocType::SHALLOW_WATER, LocType::SPAWNER });
     enemyTypes[ENEMY_STALFOS] = EnemyType("Stalfos", &SoulStalfos, ACTOR_STALFOS, { 0x0002, 0x0003 }, // rises from ground / drops from above when approached
-        { LocType::ABOVE_GROUND, LocType::SHALLOW_WATER, LocType::SPAWNER });
+        { LocType::ABOVE_GROUND, LocType::NARROW_GROUND, LocType::SHALLOW_WATER, LocType::SPAWNER });
     enemyTypes[ENEMY_OCTOROK] = EnemyType("Octorok", &SoulOctorok, ACTOR_OCTOROK, { 0x0000 },
         { LocType::ABOVE_WATER, LocType::SHALLOW_WATER });
     enemyTypes[ENEMY_WALLMASTER] = EnemyType("Wallmaster", &SoulWallmaster, ACTOR_WALLMASTER, { 0x0000 },
-        { LocType::ABOVE_GROUND, LocType::ABOVE_VOID, LocType::ABOVE_WATER, LocType::SHALLOW_WATER });
+        { LocType::ABOVE_GROUND, LocType::NARROW_GROUND, LocType::ABOVE_VOID, LocType::ABOVE_WATER, LocType::SHALLOW_WATER });
     enemyTypes[ENEMY_DODONGO] = EnemyType("Dodongo (Normal)", &SoulDodongo, ACTOR_DODONGO, { 0x0000 },
-        { LocType::ABOVE_GROUND, LocType::SHALLOW_WATER });
+        { LocType::ABOVE_GROUND, LocType::NARROW_GROUND, LocType::SHALLOW_WATER });
     enemyTypes[ENEMY_KEESE_NORMAL] = EnemyType("Keese (Normal)", &SoulKeese, ACTOR_KEESE, { 0x0002 },
-        { LocType::ABOVE_GROUND, LocType::ABOVE_VOID, LocType::UNDERWATER, LocType::ABOVE_WATER, LocType::SHALLOW_WATER });
+        { LocType::ABOVE_GROUND, LocType::NARROW_GROUND, LocType::ABOVE_VOID, LocType::UNDERWATER, LocType::ABOVE_WATER, LocType::SHALLOW_WATER });
     enemyTypes[ENEMY_KEESE_FIRE] = EnemyType("Keese (Fire)", &SoulKeese, ACTOR_KEESE, { 0x0001 },
-        { LocType::ABOVE_GROUND, LocType::ABOVE_VOID, LocType::ABOVE_WATER, LocType::SHALLOW_WATER });
+        { LocType::ABOVE_GROUND, LocType::NARROW_GROUND, LocType::ABOVE_VOID, LocType::ABOVE_WATER, LocType::SHALLOW_WATER });
     enemyTypes[ENEMY_KEESE_ICE] = EnemyType("Keese (Ice)", &SoulKeese, ACTOR_KEESE, { 0x0004 },
-        { LocType::ABOVE_GROUND, LocType::ABOVE_VOID, LocType::UNDERWATER, LocType::ABOVE_WATER, LocType::SHALLOW_WATER });
+        { LocType::ABOVE_GROUND, LocType::NARROW_GROUND, LocType::ABOVE_VOID, LocType::UNDERWATER, LocType::ABOVE_WATER, LocType::SHALLOW_WATER });
     enemyTypes[ENEMY_TEKTITE_RED] = EnemyType("Tektite (Red)", &SoulTektite, ACTOR_TEKTITE, { 0xFFFF },
         { LocType::ABOVE_GROUND, LocType::SHALLOW_WATER });
     enemyTypes[ENEMY_TEKTITE_BLUE] = EnemyType("Tektite (Blue)", &SoulTektite, ACTOR_TEKTITE, { 0xFFFE },
         { LocType::ABOVE_GROUND, LocType::ABOVE_WATER, LocType::SHALLOW_WATER });
     enemyTypes[ENEMY_LEEVER] = EnemyType("Leever", &SoulLeever, ACTOR_LEEVER, { 0x0000, 0x0001 }, // normal / big
-        { LocType::ABOVE_GROUND, LocType::SHALLOW_WATER, LocType::SPAWNER });
+        { LocType::ABOVE_GROUND, LocType::NARROW_GROUND, LocType::SHALLOW_WATER, LocType::SPAWNER });
     enemyTypes[ENEMY_PEAHAT] = EnemyType("Peahat", &SoulPeahat, ACTOR_PEAHAT, { 0xFFFF },
-        { LocType::ABOVE_GROUND, LocType::ABOVE_WATER, LocType::SHALLOW_WATER });
+        { LocType::ABOVE_GROUND, LocType::NARROW_GROUND, LocType::ABOVE_WATER, LocType::SHALLOW_WATER });
     enemyTypes[ENEMY_PEAHAT_LARVA] = EnemyType("Peahat Larva", &SoulPeahat, ACTOR_PEAHAT, { 0x0001 },
-        { LocType::ABOVE_GROUND, LocType::ABOVE_VOID, LocType::UNDERWATER, LocType::ABOVE_WATER, LocType::SHALLOW_WATER });
+        { LocType::ABOVE_GROUND, LocType::NARROW_GROUND, LocType::ABOVE_VOID, LocType::UNDERWATER, LocType::ABOVE_WATER, LocType::SHALLOW_WATER });
     enemyTypes[ENEMY_LIZALFOS] = EnemyType("Lizalfos", &SoulLizalfosDinolfos, ACTOR_LIZALFOS, { 0xFF80, 0xFFFF }, // normal / drops from above when approached
         { LocType::ABOVE_GROUND, LocType::SHALLOW_WATER });
     enemyTypes[ENEMY_DINOLFOS] = EnemyType("Dinolfos", &SoulLizalfosDinolfos, ACTOR_LIZALFOS, { 0xFFFE },
@@ -47,45 +47,45 @@ void InitEnemyTypes(void) {
     enemyTypes[ENEMY_SHABOM] = EnemyType("Shabom", &SoulShabom, ACTOR_SHABOM, { 0x0000 },
         { LocType::ABOVE_GROUND, LocType::ABOVE_WATER, LocType::SHALLOW_WATER, LocType::SPAWNER });
     enemyTypes[ENEMY_DODONGO_BABY] = EnemyType("Dodongo (Baby)", &SoulDodongo, ACTOR_BABY_DODONGO, { 0x0000 },
-        { LocType::ABOVE_GROUND, LocType::SHALLOW_WATER, LocType::SPAWNER });
+        { LocType::ABOVE_GROUND, LocType::NARROW_GROUND, LocType::SHALLOW_WATER, LocType::SPAWNER });
     enemyTypes[ENEMY_DARK_LINK] = EnemyType("Dark Link", &SoulDarkLink, ACTOR_DARK_LINK, { 0x0000 },
         { LocType::ABOVE_GROUND, LocType::SHALLOW_WATER });
     enemyTypes[ENEMY_BIRI] = EnemyType("Biri", &SoulBiriBari, ACTOR_BIRI, { 0xFFFF },
-        { LocType::ABOVE_GROUND, LocType::ABOVE_VOID, LocType::UNDERWATER, LocType::ABOVE_WATER, LocType::SHALLOW_WATER });
+        { LocType::ABOVE_GROUND, LocType::NARROW_GROUND, LocType::ABOVE_VOID, LocType::UNDERWATER, LocType::ABOVE_WATER, LocType::SHALLOW_WATER });
     enemyTypes[ENEMY_TAILPASARAN] = EnemyType("Tailpasaran", &SoulTailpasaran, ACTOR_TAILPASARAN, { 0xFFFF },
-        { LocType::ABOVE_GROUND, LocType::SHALLOW_WATER });
+        { LocType::ABOVE_GROUND, LocType::NARROW_GROUND, LocType::SHALLOW_WATER });
     enemyTypes[ENEMY_SKULLTULA] = EnemyType("Skulltula", &SoulSkulltula, ACTOR_SKULLTULA, { 0x0000, 0x0001 },
-        { LocType::ABOVE_GROUND, LocType::ABOVE_VOID, LocType::UNDERWATER, LocType::ABOVE_WATER, LocType::SHALLOW_WATER });
+        { LocType::ABOVE_GROUND, LocType::NARROW_GROUND, LocType::ABOVE_VOID, LocType::UNDERWATER, LocType::ABOVE_WATER, LocType::SHALLOW_WATER });
     enemyTypes[ENEMY_TORCH_SLUG] = EnemyType("Torch Slug", &SoulTorchSlug, ACTOR_TORCH_SLUG, { 0xFFFF },
-        { LocType::ABOVE_GROUND });
+        { LocType::ABOVE_GROUND, LocType::NARROW_GROUND });
     enemyTypes[ENEMY_STINGER_FLOOR] = EnemyType("Stinger (Floor)", &SoulStinger, ACTOR_STINGER_FLOOR, { 0x000A },
-        { LocType::ABOVE_GROUND, LocType::UNDERWATER, LocType::SHALLOW_WATER });
+        { LocType::ABOVE_GROUND, LocType::NARROW_GROUND, LocType::UNDERWATER, LocType::SHALLOW_WATER });
     enemyTypes[ENEMY_MOBLIN_CLUB] = EnemyType("Moblin (Club)", &SoulMoblin, ACTOR_MOBLIN, { 0x0000 },
-        { LocType::ABOVE_GROUND, LocType::SHALLOW_WATER });
+        { LocType::ABOVE_GROUND, LocType::NARROW_GROUND, LocType::SHALLOW_WATER });
     enemyTypes[ENEMY_MOBLIN_SPEAR] = EnemyType("Moblin (Spear)", &SoulMoblin, ACTOR_MOBLIN, { 0xFFFF },
         { LocType::ABOVE_GROUND, LocType::SHALLOW_WATER });
     enemyTypes[ENEMY_ARMOS] = EnemyType("Armos", &SoulArmos, ACTOR_ARMOS, { 0xFFFF },
-        { LocType::ABOVE_GROUND, LocType::SHALLOW_WATER });
+        { LocType::ABOVE_GROUND, LocType::NARROW_GROUND, LocType::SHALLOW_WATER });
     enemyTypes[ENEMY_DEKU_BABA_SMALL] = EnemyType("Deku Baba (Small)", &SoulDekuBaba, ACTOR_DEKU_BABA, { 0x0000 },
-        { LocType::ABOVE_GROUND, LocType::UNDERWATER, LocType::SHALLOW_WATER });
+        { LocType::ABOVE_GROUND, LocType::NARROW_GROUND, LocType::UNDERWATER, LocType::SHALLOW_WATER });
     enemyTypes[ENEMY_DEKU_BABA_BIG] = EnemyType("Deku Baba (Big)", &SoulDekuBaba, ACTOR_DEKU_BABA, { 0x0001 },
-        { LocType::ABOVE_GROUND, LocType::SHALLOW_WATER });
+        { LocType::ABOVE_GROUND, LocType::NARROW_GROUND, LocType::SHALLOW_WATER });
     enemyTypes[ENEMY_MAD_SCRUB] = EnemyType("Mad Scrub", &SoulDekuScrub, ACTOR_MAD_SCRUB, { 0x0100, 0x0300, 0x0500 }, // shoots 1, 3 or 5 nuts in a row
         { LocType::ABOVE_GROUND, LocType::UNDERWATER, LocType::SHALLOW_WATER });
     enemyTypes[ENEMY_BARI] = EnemyType("Bari", &SoulBiriBari, ACTOR_BARI, { 0xFFFF },
-        { LocType::ABOVE_GROUND, LocType::UNDERWATER, LocType::SHALLOW_WATER });
+        { LocType::ABOVE_GROUND, LocType::NARROW_GROUND, LocType::UNDERWATER, LocType::SHALLOW_WATER });
     enemyTypes[ENEMY_BUBBLE_BLUE] = EnemyType("Bubble (Blue)", &SoulBubble, ACTOR_BUBBLE, { 0xFFFF },
         { LocType::ABOVE_GROUND, LocType::SHALLOW_WATER });
     enemyTypes[ENEMY_BUBBLE_FIRE] = EnemyType("Bubble (Fire)", &SoulBubble, ACTOR_BUBBLE, { 0xFFFE },
         { LocType::ABOVE_GROUND });
     enemyTypes[ENEMY_BUBBLE_GREEN] = EnemyType("Bubble (Green)", &SoulBubble, ACTOR_BUBBLE, { 0x02FC, 0x00FB }, // small / big
-        { LocType::ABOVE_GROUND, LocType::ABOVE_VOID, LocType::ABOVE_WATER, LocType::SHALLOW_WATER });
+        { LocType::ABOVE_GROUND, LocType::NARROW_GROUND, LocType::ABOVE_VOID, LocType::ABOVE_WATER, LocType::SHALLOW_WATER });
     enemyTypes[ENEMY_BUBBLE_WHITE] = EnemyType("Bubble (White)", &SoulBubble, ACTOR_BUBBLE, { 0x00FD },
-        { LocType::ABOVE_GROUND, LocType::ABOVE_VOID, LocType::ABOVE_WATER, LocType::SHALLOW_WATER });
+        { LocType::ABOVE_GROUND, LocType::NARROW_GROUND, LocType::ABOVE_VOID, LocType::ABOVE_WATER, LocType::SHALLOW_WATER });
     enemyTypes[ENEMY_FLYING_FLOOR_TILE] = EnemyType("Flying Floor Tile", &SoulFlyingTrap, ACTOR_FLYING_FLOOR_TILE, { 0x0000 },
-        { LocType::ABOVE_GROUND, LocType::UNDERWATER, LocType::SHALLOW_WATER });
+        { LocType::ABOVE_GROUND, LocType::NARROW_GROUND, LocType::UNDERWATER, LocType::SHALLOW_WATER });
     enemyTypes[ENEMY_BEAMOS] = EnemyType("Beamos", &SoulBeamos, ACTOR_BEAMOS, { 0x0500, 0x0501 }, // big / small
-        { LocType::ABOVE_GROUND, LocType::SHALLOW_WATER });
+        { LocType::ABOVE_GROUND, LocType::NARROW_GROUND, LocType::SHALLOW_WATER });
     enemyTypes[ENEMY_FLOORMASTER] = EnemyType("Floormaster", &SoulWallmaster, ACTOR_FLOORMASTER, { 0x0000 },
         { LocType::ABOVE_GROUND, LocType::SHALLOW_WATER });
     enemyTypes[ENEMY_REDEAD] = EnemyType("Redead", &SoulRedeadGibdo, ACTOR_REDEAD, { 0x7F01, 0x7F02 }, // standing / crouching
@@ -95,9 +95,9 @@ void InitEnemyTypes(void) {
     enemyTypes[ENEMY_POE_SISTER] = EnemyType("Poe Sister", &SoulPoe, ACTOR_POE_SISTER, { 0x0000 },
         { /* Unimplemented */ });
     enemyTypes[ENEMY_DEAD_HAND_HAND] = EnemyType("Dead Hand's Hand", &SoulDeadHand, ACTOR_DEAD_HAND_HAND, { 0x0000 },
-        { LocType::ABOVE_GROUND, LocType::SHALLOW_WATER });
+        { LocType::ABOVE_GROUND, LocType::NARROW_GROUND, LocType::SHALLOW_WATER });
     enemyTypes[ENEMY_SKULLWALLTULA] = EnemyType("Skullwalltula", &SoulSkulltula, ACTOR_SKULLWALLTULA, { 0x0000 },
-        { LocType::ABOVE_GROUND, LocType::UNDERWATER, LocType::SHALLOW_WATER });
+        { LocType::ABOVE_GROUND, LocType::NARROW_GROUND, LocType::UNDERWATER, LocType::SHALLOW_WATER });
     enemyTypes[ENEMY_FLARE_DANCER] = EnemyType("Flare Dancer", &SoulFlareDancer, ACTOR_FLARE_DANCER, { 0x0000 },
         { LocType::ABOVE_GROUND });
     enemyTypes[ENEMY_DEAD_HAND] = EnemyType("Dead Hand", &SoulDeadHand, ACTOR_DEAD_HAND, { 0x0000 },
@@ -107,7 +107,7 @@ void InitEnemyTypes(void) {
     enemyTypes[ENEMY_BIG_OCTO] = EnemyType("Big Octo", &SoulOctorok, ACTOR_BIG_OCTO, { 0x0000 },
         { /* Unimplemented */ });
     enemyTypes[ENEMY_DEKU_BABA_WITHERED] = EnemyType("Deku Baba (Withered)", &SoulDekuBaba, ACTOR_WITHERED_DEKU_BABA, { 0x0000 },
-        { LocType::ABOVE_GROUND, LocType::SHALLOW_WATER });
+        { LocType::ABOVE_GROUND, LocType::NARROW_GROUND, LocType::SHALLOW_WATER });
     enemyTypes[ENEMY_LIKE_LIKE] = EnemyType("Like Like", &SoulLikeLike, ACTOR_LIKE_LIKE, { 0x0000 },
         { LocType::ABOVE_GROUND, LocType::SHALLOW_WATER });
     enemyTypes[ENEMY_PARASITIC_TENTACLE] = EnemyType("Parasitic Tentacle", &SoulParasiticTentacle, ACTOR_PARASITIC_TENTACLE, { 0x0000 },
@@ -115,7 +115,7 @@ void InitEnemyTypes(void) {
     enemyTypes[ENEMY_SPIKE] = EnemyType("Spike", &SoulSpike, ACTOR_SPIKE, { 0x0000 },
         { LocType::ABOVE_GROUND, LocType::UNDERWATER, LocType::SHALLOW_WATER });
     enemyTypes[ENEMY_ANUBIS] = EnemyType("Anubis", &SoulAnubis, ACTOR_ANUBIS_SPAWNER, { 0x0003 },
-        { LocType::ABOVE_GROUND, LocType::SHALLOW_WATER });
+        { LocType::ABOVE_GROUND, LocType::NARROW_GROUND, LocType::SHALLOW_WATER });
     enemyTypes[ENEMY_IRON_KNUCKLE] = EnemyType("Iron Knuckle", &SoulGerudo, ACTOR_IRON_KNUCKLE, { 0xFF01, 0xFF02, 0xFF03 }, // silver / black / white
         { LocType::ABOVE_GROUND, LocType::SHALLOW_WATER });
     enemyTypes[ENEMY_SKULL_KID] = EnemyType("Skull Kid", &SoulSkullKid, ACTOR_SKULL_KID, { 0xFFFF },
@@ -123,7 +123,7 @@ void InitEnemyTypes(void) {
     enemyTypes[ENEMY_FLYING_POT] = EnemyType("Flying Pot", &SoulFlyingTrap, ACTOR_FLYING_POT, { 0x0000 },
         { LocType::ABOVE_GROUND, LocType::SHALLOW_WATER });
     enemyTypes[ENEMY_FREEZARD] = EnemyType("Freezard", &SoulFreezard, ACTOR_FREEZARD, { 0x0000, 0xFFFF }, // normal / appears and moves when approached
-        { LocType::ABOVE_GROUND, LocType::UNDERWATER, LocType::SHALLOW_WATER });
+        { LocType::ABOVE_GROUND, LocType::NARROW_GROUND, LocType::UNDERWATER, LocType::SHALLOW_WATER });
     enemyTypes[ENEMY_STINGER_WATER] = EnemyType("Stinger (Water)", &SoulStinger, ACTOR_STINGER_WATER, { 0x0000 },
         { LocType::UNDERWATER, LocType::SHALLOW_WATER });
     enemyTypes[ENEMY_HINT_DEKU_SCRUB] = EnemyType("Deku Scrub", &SoulDekuScrub, ACTOR_HINT_DEKU_SCRUB, { 0x0000 },
@@ -135,7 +135,7 @@ void InitEnemyTypes(void) {
     enemyTypes[ENEMY_STALCHILD] = EnemyType("Stalchild", &SoulStalchild, ACTOR_STALCHILD, { 0x0000, 0x0005 }, // normal / big (20 kills)
         { LocType::ABOVE_GROUND, LocType::SHALLOW_WATER, LocType::SPAWNER });
     enemyTypes[ENEMY_GUAY] = EnemyType("Guay", &SoulGuay, ACTOR_GUAY, { 0x0000, 0x0001 }, // normal / big
-        { LocType::ABOVE_GROUND, LocType::ABOVE_VOID, LocType::UNDERWATER, LocType::ABOVE_WATER, LocType::SHALLOW_WATER });
+        { LocType::ABOVE_GROUND, LocType::NARROW_GROUND, LocType::ABOVE_VOID, LocType::UNDERWATER, LocType::ABOVE_WATER, LocType::SHALLOW_WATER });
 };
 
 void InitEnemyLocations(void) {
@@ -674,10 +674,10 @@ void InitEnemyLocations(void) {
         enemyLocations[6][0][15][11]     = EnemyLocation(ENEMY_FLYING_POT,         LocType::ABOVE_GROUND);
         enemyLocations[6][0][15][12]     = EnemyLocation(ENEMY_FLYING_POT,         LocType::ABOVE_GROUND);
         enemyLocations[6][0][16][0]      = EnemyLocation(ENEMY_BEAMOS,             LocType::ABOVE_GROUND);
-        enemyLocations[6][0][17][0]      = EnemyLocation(ENEMY_ANUBIS,             LocType::ABOVE_GROUND);
-        enemyLocations[6][0][17][1]      = EnemyLocation(ENEMY_ANUBIS,             LocType::ABOVE_GROUND);
-        enemyLocations[6][0][17][2]      = EnemyLocation(ENEMY_ANUBIS,             LocType::ABOVE_GROUND);
-        enemyLocations[6][0][17][3]      = EnemyLocation(ENEMY_BEAMOS,             LocType::ABOVE_GROUND);
+        enemyLocations[6][0][17][0]      = EnemyLocation(ENEMY_ANUBIS,             LocType::NARROW_GROUND);
+        enemyLocations[6][0][17][1]      = EnemyLocation(ENEMY_ANUBIS,             LocType::NARROW_GROUND);
+        enemyLocations[6][0][17][2]      = EnemyLocation(ENEMY_ANUBIS,             LocType::NARROW_GROUND);
+        enemyLocations[6][0][17][3]      = EnemyLocation(ENEMY_BEAMOS,             LocType::NARROW_GROUND);
         enemyLocations[6][0][18][0]      = EnemyLocation(ENEMY_ARMOS,              LocType::ABOVE_GROUND);
         enemyLocations[6][0][18][1]      = EnemyLocation(ENEMY_ARMOS,              LocType::ABOVE_GROUND);
         enemyLocations[6][0][18][2]      = EnemyLocation(ENEMY_ARMOS,              LocType::ABOVE_GROUND);
@@ -704,7 +704,7 @@ void InitEnemyLocations(void) {
         enemyLocations[6][0][26][2]      = EnemyLocation(ENEMY_BUBBLE_WHITE,       LocType::ABOVE_GROUND);
         enemyLocations[6][0][26][3]      = EnemyLocation(ENEMY_LIZALFOS,           LocType::ABOVE_GROUND);
         enemyLocations[6][0][26][4]      = EnemyLocation(ENEMY_LIZALFOS,           LocType::ABOVE_GROUND);
-        enemyLocations[6][0][27][0]      = EnemyLocation(ENEMY_ANUBIS,             LocType::ABOVE_GROUND);
+        enemyLocations[6][0][27][0]      = EnemyLocation(ENEMY_ANUBIS,             LocType::NARROW_GROUND);
     }
     if (Dungeon::ShadowTemple.IsVanilla()) {
         enemyLocations[7][0][0][5]       = EnemyLocation(ENEMY_FLYING_POT,         LocType::ABOVE_GROUND);
@@ -1172,10 +1172,10 @@ void InitEnemyLocations(void) {
         enemyLocations[6][0][15][7]      = EnemyLocation(ENEMY_WALLMASTER,         LocType::ABOVE_GROUND);
         enemyLocations[6][0][15][9]      = EnemyLocation(ENEMY_WALLMASTER,         LocType::ABOVE_GROUND);
         enemyLocations[6][0][15][11]     = EnemyLocation(ENEMY_WALLMASTER,         LocType::ABOVE_GROUND);
-        enemyLocations[6][0][17][6]      = EnemyLocation(ENEMY_BEAMOS,             LocType::ABOVE_GROUND);
-        enemyLocations[6][0][17][7]      = EnemyLocation(ENEMY_BEAMOS,             LocType::ABOVE_GROUND);
-        enemyLocations[6][0][17][8]      = EnemyLocation(ENEMY_BEAMOS,             LocType::ABOVE_GROUND);
-        enemyLocations[6][0][17][9]      = EnemyLocation(ENEMY_BEAMOS,             LocType::ABOVE_GROUND);
+        enemyLocations[6][0][17][6]      = EnemyLocation(ENEMY_BEAMOS,             LocType::NARROW_GROUND);
+        enemyLocations[6][0][17][7]      = EnemyLocation(ENEMY_BEAMOS,             LocType::NARROW_GROUND);
+        enemyLocations[6][0][17][8]      = EnemyLocation(ENEMY_BEAMOS,             LocType::NARROW_GROUND);
+        enemyLocations[6][0][17][9]      = EnemyLocation(ENEMY_BEAMOS,             LocType::NARROW_GROUND);
         enemyLocations[6][0][18][0]      = EnemyLocation(ENEMY_DINOLFOS,           LocType::ABOVE_GROUND);
         enemyLocations[6][0][18][1]      = EnemyLocation(ENEMY_DINOLFOS,           LocType::ABOVE_GROUND);
         enemyLocations[6][0][19][0]      = EnemyLocation(ENEMY_FLOORMASTER,        LocType::ABOVE_GROUND);
@@ -1193,7 +1193,7 @@ void InitEnemyLocations(void) {
         enemyLocations[6][0][26][1]      = EnemyLocation(ENEMY_DINOLFOS,           LocType::ABOVE_GROUND);
         enemyLocations[6][0][26][6]      = EnemyLocation(ENEMY_BUBBLE_GREEN,       LocType::ABOVE_GROUND);
         enemyLocations[6][0][26][7]      = EnemyLocation(ENEMY_BUBBLE_GREEN,       LocType::ABOVE_GROUND);
-        enemyLocations[6][0][27][7]      = EnemyLocation(ENEMY_STALFOS,            LocType::ABOVE_GROUND);
+        enemyLocations[6][0][27][7]      = EnemyLocation(ENEMY_STALFOS,            LocType::ABOVE_VOID);
     }
     if (Dungeon::ShadowTemple.IsMQ()) {
         enemyLocations[7][0][0][6]       = EnemyLocation(ENEMY_FLYING_POT,         LocType::ABOVE_GROUND);

--- a/source/location_access/locacc_ice_cavern.cpp
+++ b/source/location_access/locacc_ice_cavern.cpp
@@ -24,22 +24,8 @@ void AreaTable_Init_IceCavern() {
     |     VANILLA DUNGEON      |
     ---------------------------*/
     if (Dungeon::IceCavern.IsVanilla()) {
-
-        static constexpr auto ForEachEnemy_Beginning = [](auto& enemyCheckFn) {
-            return enemyCheckFn(9, 0, 3, {}) || enemyCheckFn(9, 0, 5, {}) || enemyCheckFn(9, 0, 8, {}) ||
-                   enemyCheckFn(9, 0, 9, {}) || enemyCheckFn(9, 0, 11, {}) || enemyCheckFn(9, 0, 6, { 18 }) ||
-                   (CanPassEnemy(9, 0, 6, 18) && enemyCheckFn(9, 0, 6, { 17 }));
-        };
         areaTable[ICE_CAVERN_BEGINNING] =
-            Area("Ice Cavern Beginning", "Ice Cavern", ICE_CAVERN, NO_DAY_NIGHT_CYCLE,
-                 {
-                     // Events
-                     EventAccess(&DekuBabaSticks,
-                                 { [] { return DekuBabaSticks || ForEachEnemy_Beginning(CanGetDekuBabaSticks); } }),
-                     EventAccess(&DekuBabaNuts,
-                                 { [] { return DekuBabaNuts || ForEachEnemy_Beginning(CanGetDekuBabaNuts); } }),
-                 },
-                 {},
+            Area("Ice Cavern Beginning", "Ice Cavern", ICE_CAVERN, NO_DAY_NIGHT_CYCLE, {}, {},
                  {
                      // Exits
                      Entrance(ICE_CAVERN_ENTRYWAY, { [] { return true; } }),
@@ -47,11 +33,21 @@ void AreaTable_Init_IceCavern() {
                               { [] { return Here(ICE_CAVERN_BEGINNING, [] { return CanDefeatEnemies(9, 0, 1); }); } }),
                  });
 
+        static constexpr auto ForEachEnemy_Main = [](auto& enemyCheckFn) {
+            return enemyCheckFn(9, 0, 3, {}) || enemyCheckFn(9, 0, 5, {}) || enemyCheckFn(9, 0, 8, {}) ||
+                   enemyCheckFn(9, 0, 9, {}) || enemyCheckFn(9, 0, 11, {}) || enemyCheckFn(9, 0, 6, { 18 }) ||
+                   (CanPassEnemy(9, 0, 6, 18) && enemyCheckFn(9, 0, 6, { 17 }));
+        };
         areaTable[ICE_CAVERN_MAIN] = Area(
             "Ice Cavern", "Ice Cavern", ICE_CAVERN, NO_DAY_NIGHT_CYCLE,
             {
                 // Events
                 EventAccess(&BlueFireAccess, { [] { return BlueFireAccess || (IsAdult && HasBottle); } }),
+                // Events
+                EventAccess(&DekuBabaSticks,
+                            { [] { return DekuBabaSticks || ForEachEnemy_Main(CanGetDekuBabaSticks); } }),
+                EventAccess(&DekuBabaNuts, { [] { return DekuBabaNuts || ForEachEnemy_Main(CanGetDekuBabaNuts); } }),
+
             },
             {
                 // Locations


### PR DESCRIPTION
- Fix a stale reference that caused randomized Club Moblins to delete the wrong actor, like the player's hookshot.
- Fix the enemy loop function in Ice Cavern logic being applied to the wrong Area.
- Fix Deku Scrubs projectiles breaking too quickly to be reflected in the GTG Like-Like room.
- For the Spirit Temple rooms that normally have Anubis, select only enemies that cannot get stuck in the pits.
- Fix Iron Knuckles falling out of bounds in Spirit Temple, in the room after the first crawlspace.

Development build here: https://github.com/HylianFreddy/OoT3D_Randomizer/releases/latest