### PR TITLE
Update appearance for soulless flying traps

### DIFF
--- a/code/src/actor.c
+++ b/code/src/actor.c
@@ -525,9 +525,9 @@ void Actor_rDraw(Actor* actor, GlobalContext* globalCtx) {
 
     // As a temporary way to mark invulnerable enemies whose soul has not been collected yet,
     // the model will not be rendered and a flame will take its place.
-    s32 shouldDrawSoulless = !EnemySouls_CheckSoulForActor(actor) &&   // soul not owned;
-                             actor->scale.x != 0 &&                    // if scale is 0, enemy is invisible;
-                             actor->id != 0x11D && actor->id != 0x06B; // flying traps will appear normal.
+    s32 shouldDrawSoulless = !EnemySouls_CheckSoulForActor(actor) && // soul not owned;
+                             actor->scale.x != 0 &&                  // if scale is 0, enemy is invisible;
+                             !FlyingTraps_IsHiddenTrap(actor);       // hidden flying traps will appear normal.
     if (shouldDrawSoulless && (PauseContext_GetState() == 0) &&
         gSettingsContext.soullessEnemiesLook == SOULLESSLOOK_PURPLE_FLAME) {
         s32 velFrameIdx = (rGameplayFrames % 16);

--- a/code/src/actors/flying_traps.c
+++ b/code/src/actors/flying_traps.c
@@ -14,6 +14,7 @@ s32 FlyingTraps_Tile_OnImpact(EnYukabyun* this) {
     if (!EnemySouls_CheckSoulForActor(&this->base)) {
         this->actionFunc  = EnYukabyun_Levitate;
         this->waitCounter = 0;
+        this->base.flags |= 0b101; // keep targetable and hostile flags
         return 0;
     }
     return 1;
@@ -24,9 +25,21 @@ s32 FlyingTraps_Pot_OnImpact(EnTuboTrap* this) {
         this->actionFunc   = EnTuboTrap_WaitForProximity;
         this->base.gravity = 0;
         this->base.speedXZ = 0;
+        this->base.flags &= ~1; // remove targetable flag
     }
 
     return EnemySouls_CheckSoulForActor(&this->base);
+}
+
+u8 FlyingTraps_IsHiddenTrap(Actor* actor) {
+    switch (actor->id) {
+        case ACTOR_FLYING_FLOOR_TILE:
+            return ((EnYukabyun*)actor)->actionFunc == EnYukabyun_Wait;
+        case ACTOR_FLYING_POT:
+            return ((EnTuboTrap*)actor)->actionFunc == EnTuboTrap_WaitForProximity;
+        default:
+            return FALSE;
+    }
 }
 
 void EnYukabyun_rUpdate(Actor* thisx, GlobalContext* globalCtx) {

--- a/code/src/actors/flying_traps.h
+++ b/code/src/actors/flying_traps.h
@@ -28,5 +28,6 @@ typedef struct EnTuboTrap {
 } EnTuboTrap;
 
 void EnYukabyun_rUpdate(Actor* thisx, GlobalContext* globalCtx);
+u8 FlyingTraps_IsHiddenTrap(Actor* actor);
 
 #endif //_FLYING_TRAPS_H_


### PR DESCRIPTION
This makes flying pots and flying tiles follow the same soulless look as other enemies when they're flying around. They will still appear normal when stationary.


https://github.com/user-attachments/assets/859a7466-de26-4761-bc0f-b3853f68891f



Development build here: https://github.com/HylianFreddy/OoT3D_Randomizer/releases/latest