### PR TITLE
Logic updates for hazard timers

### DIFF
--- a/source/fill.cpp
+++ b/source/fill.cpp
@@ -447,7 +447,9 @@ std::vector<LocationKey> GetAccessibleLocations(const std::vector<LocationKey>& 
     if (mode == SearchMode::AllLocationsReachable) {
         allLocationsReachable = true;
         for (const LocationKey loc : allLocations) {
-            if (!Location(loc)->IsAddedToPool()) {
+            bool excludedForGloom = GloomMode.IsNot(GLOOMMODE_OFF) && !(GoronTunicAsChild && AgeItemsInLogic) &&
+                                    ElementInContainer(loc, childOnlyHotLocations);
+            if (!Location(loc)->IsAddedToPool() && !excludedForGloom) {
                 allLocationsReachable = false;
                 auto message          = "Location " + Location(loc)->GetName() + " not reachable\n";
                 PlacementLog_Msg(message);

--- a/source/gold_skulltulas/gs_death_mountain.cpp
+++ b/source/gold_skulltulas/gs_death_mountain.cpp
@@ -243,7 +243,7 @@ void GsTable_Init_DeathMountain() {
             DMC_CENTRAL_LOCAL,
             GsScene{ 0x61 },
             Room{ 1 },
-            { [] { return (FireTimer >= 8 || Hearts >= 3) && CanPlantBugs && CanChildAttack; } },
+            { [] { return CanSurviveHeatFor(8, 24) && CanPlantBugs && CanChildAttack; } },
         },
         {
             // https://noclip.website/#oot3d/spot17;ShareData=AMk+}9mA?=T^3^@UsEevWN?3f6Z60NUnX8|9e]*HV3wA49l9U09A]r*93*?L+5
@@ -256,7 +256,7 @@ void GsTable_Init_DeathMountain() {
                   { 20000, 21000, 0 },
               },
               { [] {
-                  return IsChild && CanGetNightTimeGS && (FireTimer >= 24 || Hearts >= 3) && HookshotOrBoomerang;
+                  return IsChild && CanGetNightTimeGS && CanSurviveHeatFor(-1, 24) && HookshotOrBoomerang;
               } } },
             // https://noclip.website/#oot3d/spot17;ShareData=AHX1u95iw:T^=RM9J9=GV$ak(RM+:+UiJa*UV-z1WEp7{T{IM~Ua1$k96]jt+d
             { DMC_UPPER_LOCAL,
@@ -276,7 +276,7 @@ void GsTable_Init_DeathMountain() {
               { [] { return false; },
                 /*Glitched*/
                 [] {
-                    return IsChild && CanGetNightTimeGS && FireTimer >= 48 &&
+                    return IsChild && CanGetNightTimeGS && CanSurviveHeatFor(48) &&
                            ((CanDoGlitch(GlitchType::ISG, GlitchDifficulty::INTERMEDIATE) &&
                              (HasBombchus && CanDoGlitch(GlitchType::BombHover, GlitchDifficulty::INTERMEDIATE))) ||
                             CanDoGlitch(GlitchType::Megaflip, GlitchDifficulty::ADVANCED));
@@ -291,7 +291,7 @@ void GsTable_Init_DeathMountain() {
                   { 18000, 5000, 0 },
               },
               { [] {
-                  return IsChild && CanGetNightTimeGS && (FireTimer >= 16 || Hearts >= 3) && HookshotOrBoomerang;
+                  return IsChild && CanGetNightTimeGS && CanSurviveHeatFor(16, 24) && HookshotOrBoomerang;
               } } },
         });
 
@@ -302,7 +302,7 @@ void GsTable_Init_DeathMountain() {
             DMC_UPPER_LOCAL,
             GsScene{ 0x61 },
             Room{ 1 },
-            { [] { return IsChild && (FireTimer >= 8 || Hearts >= 3) && CanChildAttack; } },
+            { [] { return IsChild && CanSurviveHeatFor(8, 24) && CanChildAttack; } },
         },
         {
             // https://noclip.website/#oot3d/spot17;ShareData=AUFyuUi+-FUMXB)9MV(y=GY[ARBWLdUqoxlUYej?V|L=ZUNl?!9e:uhUh}L)V[
@@ -314,10 +314,10 @@ void GsTable_Init_DeathMountain() {
                   { -505, 1145, 1075 },
                   { 0, 0, 0 },
               },
-              { [] { return IsChild && CanGetNightTimeGS && (FireTimer >= 16 || Hearts >= 3) && CanBlastOrSmash; },
+              { [] { return IsChild && CanGetNightTimeGS && CanSurviveHeatFor(16, 24) && CanBlastOrSmash; },
                 /*Glitched*/
                 [] {
-                    return IsChild && CanGetNightTimeGS && (FireTimer >= 24 || Hearts >= 3) && CanUse(STICKS) &&
+                    return IsChild && CanGetNightTimeGS && CanSurviveHeatFor(-1, 24) && CanUse(STICKS) &&
                            CanDoGlitch(GlitchType::QPA, GlitchDifficulty::ADVANCED);
                 } } },
             // https://noclip.website/#oot3d/spot17;ShareData=AK?tEUbd9z9XTW:Uoz2[=U/t~Qw8W8UmeMxUU|fqWO3(I978]E9I=$aUSLi&V[
@@ -330,13 +330,13 @@ void GsTable_Init_DeathMountain() {
                   { 16384, 7000, 0 },
               },
               { [] {
-                   return IsChild && CanGetNightTimeGS && (FireTimer >= 24 || Hearts >= 3) &&
+                   return IsChild && CanGetNightTimeGS && CanSurviveHeatFor(-1, 24) &&
                           (CanUse(SLINGSHOT) || CanUse(BOW) || CanUse(BOOMERANG) || CanUse(HOOKSHOT) ||
                            CanUse(DINS_FIRE));
                },
                 /*Glitched*/
                 [] {
-                    return IsChild && CanGetNightTimeGS && (FireTimer >= 24 || Hearts >= 3) &&
+                    return IsChild && CanGetNightTimeGS && CanSurviveHeatFor(-1, 24) &&
                            (CanDoGlitch(GlitchType::ISG, GlitchDifficulty::INTERMEDIATE) ||
                             CanDoGlitch(GlitchType::SuperStab, GlitchDifficulty::NOVICE));
                 } } },
@@ -350,7 +350,7 @@ void GsTable_Init_DeathMountain() {
                   { -16384, 0, 0 },
               },
               { [] {
-                  return IsChild && (FireTimer >= 24 || Hearts >= 3) && CanBlastOrSmash && HookshotOrBoomerang;
+                  return IsChild && CanSurviveHeatFor(-1, 24) && CanBlastOrSmash && HookshotOrBoomerang;
               } } },
         });
 

--- a/source/gold_skulltulas/gs_death_mountain.cpp
+++ b/source/gold_skulltulas/gs_death_mountain.cpp
@@ -255,9 +255,7 @@ void GsTable_Init_DeathMountain() {
                   { 925, 490, -85 },
                   { 20000, 21000, 0 },
               },
-              { [] {
-                  return IsChild && CanGetNightTimeGS && CanSurviveHeatFor(-1, 24) && HookshotOrBoomerang;
-              } } },
+              { [] { return IsChild && CanGetNightTimeGS && CanSurviveHeatFor(-1, 24) && HookshotOrBoomerang; } } },
             // https://noclip.website/#oot3d/spot17;ShareData=AHX1u95iw:T^=RM9J9=GV$ak(RM+:+UiJa*UV-z1WEp7{T{IM~Ua1$k96]jt+d
             { DMC_UPPER_LOCAL,
               "On top of the east volcano.",
@@ -290,9 +288,7 @@ void GsTable_Init_DeathMountain() {
                   { -60, 600, -630 },
                   { 18000, 5000, 0 },
               },
-              { [] {
-                  return IsChild && CanGetNightTimeGS && CanSurviveHeatFor(16, 24) && HookshotOrBoomerang;
-              } } },
+              { [] { return IsChild && CanGetNightTimeGS && CanSurviveHeatFor(16, 24) && HookshotOrBoomerang; } } },
         });
 
     gsTable[DMC_GS_CRATE] = new GoldSkulltulaData( //
@@ -349,9 +345,7 @@ void GsTable_Init_DeathMountain() {
                   { 1300, 1600, 1710 },
                   { -16384, 0, 0 },
               },
-              { [] {
-                  return IsChild && CanSurviveHeatFor(-1, 24) && CanBlastOrSmash && HookshotOrBoomerang;
-              } } },
+              { [] { return IsChild && CanSurviveHeatFor(-1, 24) && CanBlastOrSmash && HookshotOrBoomerang; } } },
         });
 
     gsTable[GC_GS_CENTER_PLATFORM] = new GoldSkulltulaData( //

--- a/source/gold_skulltulas/gs_gerudo_valley.cpp
+++ b/source/gold_skulltulas/gs_gerudo_valley.cpp
@@ -139,7 +139,8 @@ void GsTable_Init_GerudoValley() {
                   { 16384, 0, 0 },
               },
               { [] {
-                   return IsAdult && ((CanUse(IRON_BOOTS) && CanSurviveUnderwaterFor(8) && CanUse(HOOKSHOT)) || CanUse(LONGSHOT));
+                   return IsAdult &&
+                          ((CanUse(IRON_BOOTS) && CanSurviveUnderwaterFor(8) && CanUse(HOOKSHOT)) || CanUse(LONGSHOT));
                },
                 /*Glitched*/
                 [] {
@@ -156,7 +157,8 @@ void GsTable_Init_GerudoValley() {
                   { 18000, 0, 0 },
               },
               { [] {
-                  return IsAdult && CanGetNightTimeGS && CanUse(IRON_BOOTS) && CanSurviveUnderwaterFor(8) && CanUse(HOOKSHOT);
+                  return IsAdult && CanGetNightTimeGS && CanUse(IRON_BOOTS) && CanSurviveUnderwaterFor(8) &&
+                         CanUse(HOOKSHOT);
               } } },
             // https://noclip.website/#oot3d/spot09;ShareData=AY2,KUg}!@9OlCDUiCkjWM@&E6HP$eUaP*^UcqK{+4l/G9nJ7C9MO7MUu4Z2VS
             { GERUDO_VALLEY,

--- a/source/gold_skulltulas/gs_gerudo_valley.cpp
+++ b/source/gold_skulltulas/gs_gerudo_valley.cpp
@@ -139,7 +139,7 @@ void GsTable_Init_GerudoValley() {
                   { 16384, 0, 0 },
               },
               { [] {
-                   return IsAdult && ((CanUse(IRON_BOOTS) && WaterTimer >= 8 && CanUse(HOOKSHOT)) || CanUse(LONGSHOT));
+                   return IsAdult && ((CanUse(IRON_BOOTS) && CanSurviveUnderwaterFor(8) && CanUse(HOOKSHOT)) || CanUse(LONGSHOT));
                },
                 /*Glitched*/
                 [] {
@@ -156,7 +156,7 @@ void GsTable_Init_GerudoValley() {
                   { 18000, 0, 0 },
               },
               { [] {
-                  return IsAdult && CanGetNightTimeGS && CanUse(IRON_BOOTS) && WaterTimer >= 8 && CanUse(HOOKSHOT);
+                  return IsAdult && CanGetNightTimeGS && CanUse(IRON_BOOTS) && CanSurviveUnderwaterFor(8) && CanUse(HOOKSHOT);
               } } },
             // https://noclip.website/#oot3d/spot09;ShareData=AY2,KUg}!@9OlCDUiCkjWM@&E6HP$eUaP*^UcqK{+4l/G9nJ7C9MO7MUu4Z2VS
             { GERUDO_VALLEY,

--- a/source/gold_skulltulas/gs_hyrule_field.cpp
+++ b/source/gold_skulltulas/gs_hyrule_field.cpp
@@ -451,7 +451,7 @@ void GsTable_Init_HyruleField() {
               { [] { return false; },
                 /*Glitched*/
                 [] {
-                    return IsAdult && CanUse(IRON_BOOTS) && WaterTimer >= 16 &&
+                    return IsAdult && CanUse(IRON_BOOTS) && CanSurviveUnderwaterFor(16) &&
                            CanDoGlitch(GlitchType::HookshotClip, GlitchDifficulty::NOVICE);
                 } } },
             // https://noclip.website/#oot3d/turibori;ShareData=ACqN3UFMsI9ZYaMUweleV3fZOQ!QfOUpRw}UKf/n+tUKh9r)})9eF&KUK[xmVS
@@ -518,7 +518,7 @@ void GsTable_Init_HyruleField() {
                   { 16384, 12000, 0 },
               },
               { [] {
-                  return IsAdult && CanGetNightTimeGS && CanUse(IRON_BOOTS) && WaterTimer >= 8 && CanUse(HOOKSHOT);
+                  return IsAdult && CanGetNightTimeGS && CanUse(IRON_BOOTS) && CanSurviveUnderwaterFor(8) && CanUse(HOOKSHOT);
               } } },
             // https://noclip.website/#oot3d/spot06;ShareData=ACvGwUt!c*TR+=h8pA=J=HD];6u)Y3Udom^UAVJ5=WTr{Tn_y29agDYUq{pSWP
             { LAKE_HYLIA,

--- a/source/gold_skulltulas/gs_hyrule_field.cpp
+++ b/source/gold_skulltulas/gs_hyrule_field.cpp
@@ -518,7 +518,8 @@ void GsTable_Init_HyruleField() {
                   { 16384, 12000, 0 },
               },
               { [] {
-                  return IsAdult && CanGetNightTimeGS && CanUse(IRON_BOOTS) && CanSurviveUnderwaterFor(8) && CanUse(HOOKSHOT);
+                  return IsAdult && CanGetNightTimeGS && CanUse(IRON_BOOTS) && CanSurviveUnderwaterFor(8) &&
+                         CanUse(HOOKSHOT);
               } } },
             // https://noclip.website/#oot3d/spot06;ShareData=ACvGwUt!c*TR+=h8pA=J=HD];6u)Y3Udom^UAVJ5=WTr{Tn_y29agDYUq{pSWP
             { LAKE_HYLIA,

--- a/source/gold_skulltulas/gs_zoras_domain.cpp
+++ b/source/gold_skulltulas/gs_zoras_domain.cpp
@@ -471,7 +471,8 @@ void GsTable_Init_ZorasDomain() {
                   { -32768, 0, 0 },
               },
               { [] {
-                   return IsAdult && CanGetNightTimeGS && CanSurviveUnderwaterFor(16) && CanUse(IRON_BOOTS) && CanUse(LONGSHOT);
+                   return IsAdult && CanGetNightTimeGS && CanSurviveUnderwaterFor(16) && CanUse(IRON_BOOTS) &&
+                          CanUse(LONGSHOT);
                },
                 /*Glitched*/
                 [] {

--- a/source/gold_skulltulas/gs_zoras_domain.cpp
+++ b/source/gold_skulltulas/gs_zoras_domain.cpp
@@ -227,7 +227,7 @@ void GsTable_Init_ZorasDomain() {
               { [] { return false; },
                 /*Glitched*/
                 [] {
-                    return IsAdult && WaterTimer >= 16 && CanUse(IRON_BOOTS) &&
+                    return IsAdult && CanSurviveUnderwaterFor(16) && CanUse(IRON_BOOTS) &&
                            (CanUse(HOOKSHOT) || CanDoGlitch(GlitchType::ISG, GlitchDifficulty::NOVICE) ||
                             CanDoGlitch(GlitchType::SuperStab, GlitchDifficulty::NOVICE));
                 } } },
@@ -242,7 +242,7 @@ void GsTable_Init_ZorasDomain() {
               },
               { [] { return false; },
                 /*Glitched*/
-                [] { return IsAdult && WaterTimer >= 8 && CanUse(IRON_BOOTS) && CanAdultAttack; } } },
+                [] { return IsAdult && CanSurviveUnderwaterFor(8) && CanUse(IRON_BOOTS) && CanAdultAttack; } } },
             // https://noclip.website/#oot3d/spot07;ShareData=AQI(B9x*+Q8rWf!8sn=[WC1&*Q9/KCUZE;s9Qf|dV|R@aTYn0)9WQQI9t|yV=a
             { ZD_BEHIND_KING_ZORA,
               "Behind the metal Zora emblem behind King Zora.",
@@ -332,12 +332,12 @@ void GsTable_Init_ZorasDomain() {
                   { 0, 0, 0 },
               },
               { [] {
-                   return IsChild && CanGetNightTimeGS && (WaterTimer >= 16 || Hearts >= 3) && CanUse(IRON_BOOTS) &&
+                   return IsChild && CanGetNightTimeGS && CanSurviveUnderwaterFor(16, 24) && CanUse(IRON_BOOTS) &&
                           CanUse(HOOKSHOT);
                },
                 /*Glitched*/
                 [] {
-                    return IsChild && CanGetNightTimeGS && (WaterTimer >= 16 || Hearts >= 3) && CanUse(IRON_BOOTS) &&
+                    return IsChild && CanGetNightTimeGS && CanSurviveUnderwaterFor(16, 24) && CanUse(IRON_BOOTS) &&
                            (CanDoGlitch(GlitchType::ISG, GlitchDifficulty::NOVICE) ||
                             CanDoGlitch(GlitchType::SuperStab, GlitchDifficulty::NOVICE));
                 } } },
@@ -471,11 +471,11 @@ void GsTable_Init_ZorasDomain() {
                   { -32768, 0, 0 },
               },
               { [] {
-                   return IsAdult && CanGetNightTimeGS && WaterTimer >= 16 && CanUse(IRON_BOOTS) && CanUse(LONGSHOT);
+                   return IsAdult && CanGetNightTimeGS && CanSurviveUnderwaterFor(16) && CanUse(IRON_BOOTS) && CanUse(LONGSHOT);
                },
                 /*Glitched*/
                 [] {
-                    return IsAdult && CanGetNightTimeGS && WaterTimer >= 8 && CanUse(IRON_BOOTS) &&
+                    return IsAdult && CanGetNightTimeGS && CanSurviveUnderwaterFor(8) && CanUse(IRON_BOOTS) &&
                            (CanDoGlitch(GlitchType::ISG, GlitchDifficulty::NOVICE) ||
                             CanDoGlitch(GlitchType::SuperStab, GlitchDifficulty::NOVICE));
                 } } },

--- a/source/item_location.cpp
+++ b/source/item_location.cpp
@@ -1432,7 +1432,14 @@ std::vector<LocationKey> overworldLocations = {
   LLR_GS_HOUSE_WINDOW,
   LLR_GS_TREE,
 };
+
+std::vector<LocationKey> childOnlyHotLocations = {
+    DMC_DEKU_SCRUB,
+    DMC_GS_CRATE,
+    DMC_GS_BEAN_PATCH,
+};
 // clang-format on
+
 ItemLocation* Location(LocationKey locKey) {
     return &(locationTable[locKey]);
 }

--- a/source/item_location.hpp
+++ b/source/item_location.hpp
@@ -477,6 +477,10 @@ extern std::vector<LocationKey> overworldLocations;
 extern std::vector<LocationKey> allLocations;
 extern std::vector<LocationKey> everyPossibleLocation;
 
+// Item locations that only exist as child Link in hot areas.
+// When Gloom Mode is enabled these will be automatically excluded and excepted from reachability validation.
+extern std::vector<LocationKey> childOnlyHotLocations;
+
 // set of overrides to write to the patch
 extern std::set<ItemOverride, ItemOverride_Compare> overrides;
 

--- a/source/location_access/locacc_death_mountain.cpp
+++ b/source/location_access/locacc_death_mountain.cpp
@@ -357,17 +357,17 @@ void AreaTable_Init_DeathMountain() {
     areaTable[DMC_UPPER_NEARBY] =
         Area("DMC Upper Nearby", "Death Mountain Crater", DEATH_MOUNTAIN_CRATER, NO_DAY_NIGHT_CYCLE, {}, {},
              { // Exits
-               Entrance(DMC_UPPER_LOCAL, { [] { return FireTimer >= 48; } }),
+               Entrance(DMC_UPPER_LOCAL, { [] { return CanSurviveHeatFor(48); } }),
                Entrance(DEATH_MOUNTAIN_SUMMIT, { [] { return true; } }),
                Entrance(DMC_UPPER_GROTTO, { [] {
                                                return Here(DMC_UPPER_NEARBY, [] {
-                                                   return CanBlastOrSmash && (FireTimer >= 8 || Hearts >= 3);
+                                                   return CanBlastOrSmash && CanSurviveHeatFor(8, 24);
                                                });
                                            },
                                             /*Glitched*/
                                             [] {
                                                 return Here(DMC_UPPER_NEARBY, [] {
-                                                    return CanUse(STICKS) && FireTimer >= 48 &&
+                                                    return CanUse(STICKS) && CanSurviveHeatFor(48) &&
                                                            CanDoGlitch(GlitchType::QPA, GlitchDifficulty::ADVANCED);
                                                 });
                                             } }) });
@@ -378,18 +378,18 @@ void AreaTable_Init_DeathMountain() {
             // Events
             EventAccess(&GossipStoneFairy, { [] {
                 return GossipStoneFairy ||
-                       (HasExplosives && CanSummonGossipFairyWithoutSuns && (FireTimer >= 16 || Hearts >= 3));
+                       (HasExplosives && CanSummonGossipFairyWithoutSuns && CanSurviveHeatFor(16, 24));
             } }),
         },
         {
             // Locations
-            LocationAccess(DMC_WALL_FREESTANDING_POH, { [] { return FireTimer >= 16 || Hearts >= 3; } }),
-            LocationAccess(DMC_GOSSIP_STONE, { [] { return HasExplosives && (FireTimer >= 16 || Hearts >= 3); } }),
+            LocationAccess(DMC_WALL_FREESTANDING_POH, { [] { return CanSurviveHeatFor(16, 24); } }),
+            LocationAccess(DMC_GOSSIP_STONE, { [] { return HasExplosives && CanSurviveHeatFor(16, 24); } }),
         },
         {
             // Exits
             Entrance(DMC_UPPER_NEARBY, { [] { return true; } }),
-            Entrance(DMC_LADDER_AREA_NEARBY, { [] { return FireTimer >= 16 || Hearts >= 3; } }),
+            Entrance(DMC_LADDER_AREA_NEARBY, { [] { return CanSurviveHeatFor(16, 24); } }),
             Entrance(DMC_CENTRAL_NEARBY, { [] {
                                               return IsAdult && CanUse(GORON_TUNIC) && CanUse(DISTANT_SCARECROW) &&
                                                      ((EffectiveHealth > 2) ||
@@ -398,13 +398,13 @@ void AreaTable_Init_DeathMountain() {
                                           },
                                            /*Glitched*/
                                            [] {
-                                               return FireTimer >= 24 && CanTakeDamage &&
+                                               return CanSurviveHeatFor(24) && CanTakeDamage &&
                                                       CanDoGlitch(GlitchType::Megaflip, GlitchDifficulty::NOVICE);
                                            } }),
             Entrance(DMC_LOWER_NEARBY,
                      { [] { return false; },
                        /*Glitched*/
-                       [] { return FireTimer >= 24 && CanDoGlitch(GlitchType::Megaflip, GlitchDifficulty::NOVICE); } }),
+                       [] { return CanSurviveHeatFor(24) && CanDoGlitch(GlitchType::Megaflip, GlitchDifficulty::NOVICE); } }),
         });
 
     areaTable[DMC_LADDER_AREA_NEARBY] =
@@ -415,9 +415,9 @@ void AreaTable_Init_DeathMountain() {
              },
              {
                  // Exits
-                 Entrance(DMC_UPPER_NEARBY, { [] { return Hearts >= 3; } }),
+                 Entrance(DMC_UPPER_NEARBY, { [] { return CanSurviveHeatFor(-1, 24); } }),
                  Entrance(DMC_LOWER_NEARBY, { [] {
-                              return Hearts >= 3 && (CanUse(HOVER_BOOTS) ||
+                              return CanSurviveHeatFor(-1, 24) && (CanUse(HOVER_BOOTS) ||
                                                      (LogicCraterUpperToLower && IsAdult && CanUse(MEGATON_HAMMER)));
                           } }),
              });
@@ -426,17 +426,17 @@ void AreaTable_Init_DeathMountain() {
         "DMC Lower Nearby", "Death Mountain Crater", DEATH_MOUNTAIN_CRATER, NO_DAY_NIGHT_CYCLE, {}, {},
         {
             // Exits
-            Entrance(DMC_LOWER_LOCAL, { [] { return FireTimer >= 48; } }),
+            Entrance(DMC_LOWER_LOCAL, { [] { return CanSurviveHeatFor(48); } }),
             Entrance(GC_DARUNIAS_CHAMBER, { [] { return true; } }),
             Entrance(DMC_GREAT_FAIRY_FOUNTAIN,
                      { [] { return CanUse(MEGATON_HAMMER); },
                        /*Glitched*/
                        [] {
                            return CanDoGlitch(GlitchType::ASlide, GlitchDifficulty::INTERMEDIATE) ||
-                                  (FireTimer >= 48 && CanUse(STICKS) &&
+                                  (CanSurviveHeatFor(48) && CanUse(STICKS) &&
                                    CanDoGlitch(GlitchType::QPA, GlitchDifficulty::NOVICE) &&
                                    (CanTakeDamageTwice || CanDoGlitch(GlitchType::QPA, GlitchDifficulty::ADVANCED))) ||
-                                  (Bombs && CanShield && FireTimer >= 48 &&
+                                  (Bombs && CanShield && CanSurviveHeatFor(48) &&
                                    CanDoGlitch(GlitchType::SuperSlide, GlitchDifficulty::EXPERT)) ||
                                   Here(DMC_UPPER_LOCAL,
                                        [] { return CanDoGlitch(GlitchType::Megaflip, GlitchDifficulty::ADVANCED); });
@@ -444,7 +444,7 @@ void AreaTable_Init_DeathMountain() {
             Entrance(DMC_HAMMER_GROTTO, { [] { return IsAdult && CanUse(MEGATON_HAMMER); },
                                           /*Glitched*/
                                           [] {
-                                              return IsAdult && FireTimer >= 48 && CanUse(STICKS) &&
+                                              return IsAdult && CanSurviveHeatFor(48) && CanUse(STICKS) &&
                                                      CanDoGlitch(GlitchType::QPA, GlitchDifficulty::NOVICE) &&
                                                      (CanTakeDamageTwice ||
                                                       CanDoGlitch(GlitchType::QPA, GlitchDifficulty::ADVANCED));
@@ -456,16 +456,16 @@ void AreaTable_Init_DeathMountain() {
              {
                  // Exits
                  Entrance(DMC_LOWER_NEARBY, { [] { return true; } }),
-                 Entrance(DMC_LADDER_AREA_NEARBY, { [] { return FireTimer >= 8 || Hearts >= 3; } }),
+                 Entrance(DMC_LADDER_AREA_NEARBY, { [] { return CanSurviveHeatFor(8, 24); } }),
                  Entrance(DMC_CENTRAL_NEARBY,
-                          { [] { return (CanUse(HOVER_BOOTS) || CanUse(HOOKSHOT)) && (FireTimer >= 8 || Hearts >= 3); },
+                          { [] { return (CanUse(HOVER_BOOTS) || CanUse(HOOKSHOT)) && CanSurviveHeatFor(8, 24); },
                             /*Glitched*/
                             [] {
                                 return CanDoGlitch(GlitchType::Megaflip, GlitchDifficulty::NOVICE) &&
-                                       (FireTimer >= 8 || Hearts >= 3);
+                                       CanSurviveHeatFor(8, 24);
                             } }),
                  Entrance(DMC_CENTRAL_LOCAL,
-                          { [] { return (CanUse(HOVER_BOOTS) || CanUse(HOOKSHOT)) && FireTimer >= 24; } }),
+                          { [] { return (CanUse(HOVER_BOOTS) || CanUse(HOOKSHOT)) && CanSurviveHeatFor(24); } }),
              });
 
     areaTable[DMC_CENTRAL_NEARBY] = Area(
@@ -473,7 +473,7 @@ void AreaTable_Init_DeathMountain() {
         {
             // Locations
             LocationAccess(DMC_VOLCANO_FREESTANDING_POH, { [] {
-                                                              return IsAdult && Hearts >= 3 &&
+                                                              return IsAdult && CanSurviveHeatFor(-1, 24) &&
                                                                      (CanPlantBean(DMC_CENTRAL_LOCAL) ||
                                                                       (LogicCraterBeanPoHWithHovers && HoverBoots));
                                                           },
@@ -482,14 +482,14 @@ void AreaTable_Init_DeathMountain() {
                                                                return Here(DMC_LOWER_LOCAL, [] {
                                                                    return CanDoGlitch(GlitchType::Megaflip,
                                                                                       GlitchDifficulty::NOVICE) &&
-                                                                          FireTimer >= 24;
+                                                                          CanSurviveHeatFor(24);
                                                                });
                                                            } }),
-            LocationAccess(SHEIK_IN_CRATER, { [] { return IsAdult && (FireTimer >= 8 || Hearts >= 3); } }),
+            LocationAccess(SHEIK_IN_CRATER, { [] { return IsAdult && CanSurviveHeatFor(8, 24); } }),
         },
         {
             // Exits
-            Entrance(DMC_CENTRAL_LOCAL, { [] { return FireTimer >= 48; } }),
+            Entrance(DMC_CENTRAL_LOCAL, { [] { return CanSurviveHeatFor(48); } }),
         });
 
     areaTable[DMC_CENTRAL_LOCAL] = Area(
@@ -510,18 +510,18 @@ void AreaTable_Init_DeathMountain() {
                                         },
                                          /*Glitched*/
                                          [] {
-                                             return IsChild && Hearts >= 3 && HasBombchus &&
+                                             return IsChild && CanSurviveHeatFor(-1, 24) && HasBombchus &&
                                                     CanDoGlitch(GlitchType::BombHover, GlitchDifficulty::NOVICE);
                                          } }),
             Entrance(DMC_UPPER_NEARBY, { [] { return IsAdult && CanPlantBean(DMC_CENTRAL_LOCAL); } }),
             Entrance(
                 FIRE_TEMPLE_ENTRYWAY,
                 { [] {
-                     return (IsChild && Hearts >= 3 && ShuffleDungeonEntrances.IsNot(SHUFFLEDUNGEONS_OFF)) ||
-                            (IsAdult && FireTimer >= 24);
+                     return (IsChild && CanSurviveHeatFor(-1, 24) && ShuffleDungeonEntrances.IsNot(SHUFFLEDUNGEONS_OFF)) ||
+                            (IsAdult && CanSurviveHeatFor(24));
                  },
                   /*Glitched*/
-                  [] { return CanDoGlitch(GlitchType::ASlide, GlitchDifficulty::INTERMEDIATE) && FireTimer >= 48; } }),
+                  [] { return CanDoGlitch(GlitchType::ASlide, GlitchDifficulty::INTERMEDIATE) && CanSurviveHeatFor(48); } }),
         });
 
     areaTable[DMC_GREAT_FAIRY_FOUNTAIN] =

--- a/source/location_access/locacc_death_mountain.cpp
+++ b/source/location_access/locacc_death_mountain.cpp
@@ -354,23 +354,20 @@ void AreaTable_Init_DeathMountain() {
                                     Entrance(GC_GROTTO_PLATFORM, { [] { return true; } }),
                                 });
 
-    areaTable[DMC_UPPER_NEARBY] =
-        Area("DMC Upper Nearby", "Death Mountain Crater", DEATH_MOUNTAIN_CRATER, NO_DAY_NIGHT_CYCLE, {}, {},
-             { // Exits
-               Entrance(DMC_UPPER_LOCAL, { [] { return CanSurviveHeatFor(48); } }),
-               Entrance(DEATH_MOUNTAIN_SUMMIT, { [] { return true; } }),
-               Entrance(DMC_UPPER_GROTTO, { [] {
-                                               return Here(DMC_UPPER_NEARBY, [] {
-                                                   return CanBlastOrSmash && CanSurviveHeatFor(8, 24);
-                                               });
-                                           },
-                                            /*Glitched*/
-                                            [] {
-                                                return Here(DMC_UPPER_NEARBY, [] {
-                                                    return CanUse(STICKS) && CanSurviveHeatFor(48) &&
-                                                           CanDoGlitch(GlitchType::QPA, GlitchDifficulty::ADVANCED);
-                                                });
-                                            } }) });
+    areaTable[DMC_UPPER_NEARBY] = Area(
+        "DMC Upper Nearby", "Death Mountain Crater", DEATH_MOUNTAIN_CRATER, NO_DAY_NIGHT_CYCLE, {}, {},
+        { // Exits
+          Entrance(DMC_UPPER_LOCAL, { [] { return CanSurviveHeatFor(48); } }),
+          Entrance(DEATH_MOUNTAIN_SUMMIT, { [] { return true; } }),
+          Entrance(DMC_UPPER_GROTTO,
+                   { [] { return Here(DMC_UPPER_NEARBY, [] { return CanBlastOrSmash && CanSurviveHeatFor(8, 24); }); },
+                     /*Glitched*/
+                     [] {
+                         return Here(DMC_UPPER_NEARBY, [] {
+                             return CanUse(STICKS) && CanSurviveHeatFor(48) &&
+                                    CanDoGlitch(GlitchType::QPA, GlitchDifficulty::ADVANCED);
+                         });
+                     } }) });
 
     areaTable[DMC_UPPER_LOCAL] = Area(
         "DMC Upper Local", "Death Mountain Crater", DEATH_MOUNTAIN_CRATER, NO_DAY_NIGHT_CYCLE,
@@ -401,26 +398,28 @@ void AreaTable_Init_DeathMountain() {
                                                return CanSurviveHeatFor(24) && CanTakeDamage &&
                                                       CanDoGlitch(GlitchType::Megaflip, GlitchDifficulty::NOVICE);
                                            } }),
-            Entrance(DMC_LOWER_NEARBY,
-                     { [] { return false; },
-                       /*Glitched*/
-                       [] { return CanSurviveHeatFor(24) && CanDoGlitch(GlitchType::Megaflip, GlitchDifficulty::NOVICE); } }),
+            Entrance(DMC_LOWER_NEARBY, { [] { return false; },
+                                         /*Glitched*/
+                                         [] {
+                                             return CanSurviveHeatFor(24) &&
+                                                    CanDoGlitch(GlitchType::Megaflip, GlitchDifficulty::NOVICE);
+                                         } }),
         });
 
-    areaTable[DMC_LADDER_AREA_NEARBY] =
-        Area("DMC Ladder Area Nearby", "Death Mountain Crater", DEATH_MOUNTAIN_CRATER, NO_DAY_NIGHT_CYCLE, {},
-             {
-                 // Locations
-                 LocationAccess(DMC_DEKU_SCRUB, { [] { return IsChild && CanStunDeku; } }),
-             },
-             {
-                 // Exits
-                 Entrance(DMC_UPPER_NEARBY, { [] { return CanSurviveHeatFor(-1, 24); } }),
-                 Entrance(DMC_LOWER_NEARBY, { [] {
-                              return CanSurviveHeatFor(-1, 24) && (CanUse(HOVER_BOOTS) ||
-                                                     (LogicCraterUpperToLower && IsAdult && CanUse(MEGATON_HAMMER)));
-                          } }),
-             });
+    areaTable[DMC_LADDER_AREA_NEARBY] = Area(
+        "DMC Ladder Area Nearby", "Death Mountain Crater", DEATH_MOUNTAIN_CRATER, NO_DAY_NIGHT_CYCLE, {},
+        {
+            // Locations
+            LocationAccess(DMC_DEKU_SCRUB, { [] { return IsChild && CanStunDeku; } }),
+        },
+        {
+            // Exits
+            Entrance(DMC_UPPER_NEARBY, { [] { return CanSurviveHeatFor(-1, 24); } }),
+            Entrance(DMC_LOWER_NEARBY, { [] {
+                         return CanSurviveHeatFor(-1, 24) &&
+                                (CanUse(HOVER_BOOTS) || (LogicCraterUpperToLower && IsAdult && CanUse(MEGATON_HAMMER)));
+                     } }),
+        });
 
     areaTable[DMC_LOWER_NEARBY] = Area(
         "DMC Lower Nearby", "Death Mountain Crater", DEATH_MOUNTAIN_CRATER, NO_DAY_NIGHT_CYCLE, {}, {},
@@ -492,37 +491,40 @@ void AreaTable_Init_DeathMountain() {
             Entrance(DMC_CENTRAL_LOCAL, { [] { return CanSurviveHeatFor(48); } }),
         });
 
-    areaTable[DMC_CENTRAL_LOCAL] = Area(
-        "DMC Central Local", "Death Mountain Crater", DEATH_MOUNTAIN_CRATER, NO_DAY_NIGHT_CYCLE,
-        {
-            // Events
-            EventAccess(&BeanPlantFairy, { [] {
-                return BeanPlantFairy || (CanPlantBean(DMC_CENTRAL_LOCAL) && CanPlay(SongOfStorms));
-            } }),
-        },
-        {},
-        {
-            // Exits
-            Entrance(DMC_CENTRAL_NEARBY, { [] { return true; } }),
-            Entrance(DMC_LOWER_NEARBY, { [] {
-                                            return (IsAdult && CanPlantBean(DMC_CENTRAL_LOCAL)) ||
-                                                   CanUse(HOVER_BOOTS) || CanUse(HOOKSHOT);
-                                        },
-                                         /*Glitched*/
-                                         [] {
-                                             return IsChild && CanSurviveHeatFor(-1, 24) && HasBombchus &&
-                                                    CanDoGlitch(GlitchType::BombHover, GlitchDifficulty::NOVICE);
-                                         } }),
-            Entrance(DMC_UPPER_NEARBY, { [] { return IsAdult && CanPlantBean(DMC_CENTRAL_LOCAL); } }),
-            Entrance(
-                FIRE_TEMPLE_ENTRYWAY,
-                { [] {
-                     return (IsChild && CanSurviveHeatFor(-1, 24) && ShuffleDungeonEntrances.IsNot(SHUFFLEDUNGEONS_OFF)) ||
-                            (IsAdult && CanSurviveHeatFor(24));
-                 },
-                  /*Glitched*/
-                  [] { return CanDoGlitch(GlitchType::ASlide, GlitchDifficulty::INTERMEDIATE) && CanSurviveHeatFor(48); } }),
-        });
+    areaTable[DMC_CENTRAL_LOCAL] =
+        Area("DMC Central Local", "Death Mountain Crater", DEATH_MOUNTAIN_CRATER, NO_DAY_NIGHT_CYCLE,
+             {
+                 // Events
+                 EventAccess(&BeanPlantFairy, { [] {
+                     return BeanPlantFairy || (CanPlantBean(DMC_CENTRAL_LOCAL) && CanPlay(SongOfStorms));
+                 } }),
+             },
+             {},
+             {
+                 // Exits
+                 Entrance(DMC_CENTRAL_NEARBY, { [] { return true; } }),
+                 Entrance(DMC_LOWER_NEARBY, { [] {
+                                                 return (IsAdult && CanPlantBean(DMC_CENTRAL_LOCAL)) ||
+                                                        CanUse(HOVER_BOOTS) || CanUse(HOOKSHOT);
+                                             },
+                                              /*Glitched*/
+                                              [] {
+                                                  return IsChild && CanSurviveHeatFor(-1, 24) && HasBombchus &&
+                                                         CanDoGlitch(GlitchType::BombHover, GlitchDifficulty::NOVICE);
+                                              } }),
+                 Entrance(DMC_UPPER_NEARBY, { [] { return IsAdult && CanPlantBean(DMC_CENTRAL_LOCAL); } }),
+                 Entrance(FIRE_TEMPLE_ENTRYWAY, { [] {
+                                                     return (IsChild && CanSurviveHeatFor(-1, 24) &&
+                                                             ShuffleDungeonEntrances.IsNot(SHUFFLEDUNGEONS_OFF)) ||
+                                                            (IsAdult && CanSurviveHeatFor(24));
+                                                 },
+                                                  /*Glitched*/
+                                                  [] {
+                                                      return CanDoGlitch(GlitchType::ASlide,
+                                                                         GlitchDifficulty::INTERMEDIATE) &&
+                                                             CanSurviveHeatFor(48);
+                                                  } }),
+             });
 
     areaTable[DMC_GREAT_FAIRY_FOUNTAIN] =
         Area("DMC Great Fairy Fountain", "DMC Great Fairy Fountain", NONE, NO_DAY_NIGHT_CYCLE, {},

--- a/source/location_access/locacc_fire_temple.cpp
+++ b/source/location_access/locacc_fire_temple.cpp
@@ -35,7 +35,7 @@ void AreaTable_Init_FireTemple() {
             {
                 // Exits
                 Entrance(FIRE_TEMPLE_ENTRYWAY, { [] { return true; } }),
-                Entrance(FIRE_TEMPLE_NEAR_BOSS_ROOM, { [] { return FireTimer >= 24; } }),
+                Entrance(FIRE_TEMPLE_NEAR_BOSS_ROOM, { [] { return CanSurviveHeatFor(24); } }),
                 Entrance(FIRE_TEMPLE_LOOP_ENEMIES, { [] {
                                                         return Here(FIRE_TEMPLE_FIRST_ROOM,
                                                                     [] { return CanUse(MEGATON_HAMMER); }) &&
@@ -50,7 +50,7 @@ void AreaTable_Init_FireTemple() {
                                                                 (SmallKeys(FIRE_TEMPLE, 8) || !IsKeysanity);
                                                      } }),
                 Entrance(FIRE_TEMPLE_LOOP_EXIT, { [] { return true; } }),
-                Entrance(FIRE_TEMPLE_BIG_LAVA_ROOM, { [] { return SmallKeys(FIRE_TEMPLE, 2) && FireTimer >= 24; } }),
+                Entrance(FIRE_TEMPLE_BIG_LAVA_ROOM, { [] { return SmallKeys(FIRE_TEMPLE, 2) && CanSurviveHeatFor(24); } }),
             });
 
         areaTable[FIRE_TEMPLE_NEAR_BOSS_ROOM] =
@@ -192,7 +192,7 @@ void AreaTable_Init_FireTemple() {
                               { [] { return IsAdult && (CanPlay(SongOfTime) || LogicFireSongOfTime); },
                                 /*Glitched*/
                                 [] {
-                                    return FireTimer >= 48 &&
+                                    return CanSurviveHeatFor(48) &&
                                            ((CanDoGlitch(GlitchType::BombHover, GlitchDifficulty::INTERMEDIATE) &&
                                              CanDoGlitch(GlitchType::ISG, GlitchDifficulty::INTERMEDIATE)) ||
                                             (IsAdult &&
@@ -205,7 +205,7 @@ void AreaTable_Init_FireTemple() {
                               { [] { return IsAdult && HasExplosives; },
                                 /*Glitched*/
                                 [] {
-                                    return FireTimer >= 48 &&
+                                    return CanSurviveHeatFor(48) &&
                                            CanDoGlitch(GlitchType::BombHover, GlitchDifficulty::INTERMEDIATE) &&
                                            CanDoGlitch(GlitchType::ISG, GlitchDifficulty::INTERMEDIATE);
                                 } }),
@@ -262,7 +262,7 @@ void AreaTable_Init_FireTemple() {
             {
                 // Exits
                 Entrance(FIRE_TEMPLE_BIG_LAVA_ROOM, { [] { return SmallKeys(FIRE_TEMPLE, 3); } }),
-                Entrance(FIRE_TEMPLE_SHORTCUT_ROOM, { [] { return FireTimer >= 56 && SmallKeys(FIRE_TEMPLE, 4); } }),
+                Entrance(FIRE_TEMPLE_SHORTCUT_ROOM, { [] { return CanSurviveHeatFor(56) && SmallKeys(FIRE_TEMPLE, 4); } }),
             });
 
         areaTable[FIRE_TEMPLE_SHORTCUT_ROOM] = Area(
@@ -376,21 +376,21 @@ void AreaTable_Init_FireTemple() {
                  {
                      // Exits
                      Entrance(FIRE_TEMPLE_EAST_CENTRAL_ROOM,
-                              { [] { return FireTimer >= 24 && SmallKeys(FIRE_TEMPLE, 6, 8); } }),
+                              { [] { return CanSurviveHeatFor(24) && SmallKeys(FIRE_TEMPLE, 6, 8); } }),
                      Entrance(FIRE_TEMPLE_MAP_AREA, { [] { return IsAdult; } }),
                      Entrance(FIRE_TEMPLE_BOULDER_MAZE_UPPER,
-                              { [] { return FireTimer >= 24 && IsAdult; },
+                              { [] { return CanSurviveHeatFor(24) && IsAdult; },
                                 /*Glitched*/
                                 [] {
-                                    return FireTimer >= 32 &&
+                                    return CanSurviveHeatFor(32) &&
                                            CanDoGlitch(GlitchType::BombHover, GlitchDifficulty::NOVICE) &&
                                            CanDoGlitch(GlitchType::ISG, GlitchDifficulty::INTERMEDIATE);
                                 } }),
                      Entrance(FIRE_TEMPLE_CORRIDOR,
-                              { [] { return FireTimer >= 24 && IsAdult && SmallKeys(FIRE_TEMPLE, 7); },
+                              { [] { return CanSurviveHeatFor(24) && IsAdult && SmallKeys(FIRE_TEMPLE, 7); },
                                 /*Glitched*/
                                 [] {
-                                    return FireTimer >= 32 && SmallKeys(FIRE_TEMPLE, 7) &&
+                                    return CanSurviveHeatFor(32) && SmallKeys(FIRE_TEMPLE, 7) &&
                                            CanDoGlitch(GlitchType::BombHover, GlitchDifficulty::NOVICE) && Bombs &&
                                            HasBombchus && CanDoGlitch(GlitchType::ISG, GlitchDifficulty::INTERMEDIATE);
                                 } }),
@@ -674,7 +674,7 @@ void AreaTable_Init_FireTemple() {
                                           CanUse(DINS_FIRE);
                                } }),
                 LocationAccess(FIRE_TEMPLE_MQ_NEAR_BOSS_CHEST, { [] {
-                                   return IsAdult && FireTimer >= 24 && (CanUse(HOVER_BOOTS) || CanUse(HOOKSHOT)) &&
+                                   return IsAdult && CanSurviveHeatFor(24) && (CanUse(HOVER_BOOTS) || CanUse(HOOKSHOT)) &&
                                           (CanUse(FIRE_ARROWS) ||
                                            (CanUse(DINS_FIRE) &&
                                             ((DamageMultiplier.IsNot(DAMAGEMULTIPLIER_OHKO) &&
@@ -704,7 +704,7 @@ void AreaTable_Init_FireTemple() {
                                     (CanUse(KOKIRI_SWORD) || CanUse(MASTER_SWORD) || CanUse(BIGGORON_SWORD));
                          } }),
                 Entrance(FIRE_TEMPLE_MQ_BIG_LAVA_ROOM,
-                         { [] { return IsAdult && FireTimer >= 24 && CanUse(MEGATON_HAMMER); } }),
+                         { [] { return IsAdult && CanSurviveHeatFor(24) && CanUse(MEGATON_HAMMER); } }),
             });
 
         areaTable[FIRE_TEMPLE_MQ_LOWER_LOCKED_DOOR] =
@@ -836,10 +836,10 @@ void AreaTable_Init_FireTemple() {
         {
             // Events
             EventAccess(&FireTempleClear,
-                        { [] { return FireTempleClear || (SoulVolvagia && FireTimer >= 64 && CanUse(MEGATON_HAMMER)); },
+                        { [] { return FireTempleClear || (SoulVolvagia && CanSurviveHeatFor(64) && CanUse(MEGATON_HAMMER)); },
                           /*Glitched*/
                           [] {
-                              return SoulVolvagia && FireTimer >= 48 &&
+                              return SoulVolvagia && CanSurviveHeatFor(48) &&
                                      ((CanUse(STICKS) && CanDoGlitch(GlitchType::QPA, GlitchDifficulty::NOVICE)) ||
                                       CanUse(MEGATON_HAMMER)) &&
                                      Bombs && CanDoGlitch(GlitchType::ISG, GlitchDifficulty::INTERMEDIATE);

--- a/source/location_access/locacc_fire_temple.cpp
+++ b/source/location_access/locacc_fire_temple.cpp
@@ -24,34 +24,35 @@ void AreaTable_Init_FireTemple() {
     |     VANILLA DUNGEON      |
     ---------------------------*/
     if (Dungeon::FireTemple.IsVanilla()) {
-        areaTable[FIRE_TEMPLE_FIRST_ROOM] = Area(
-            "Fire Temple First Room", "Fire Temple", FIRE_TEMPLE, NO_DAY_NIGHT_CYCLE,
-            {
-                // Events
-                EventAccess(&DekuBabaSticks, { [] { return DekuBabaSticks || CanGetDekuBabaSticks(4, 0, 0); } }),
-                EventAccess(&DekuBabaNuts, { [] { return DekuBabaNuts || CanGetDekuBabaNuts(4, 0, 0); } }),
-            },
-            {},
-            {
-                // Exits
-                Entrance(FIRE_TEMPLE_ENTRYWAY, { [] { return true; } }),
-                Entrance(FIRE_TEMPLE_NEAR_BOSS_ROOM, { [] { return CanSurviveHeatFor(24); } }),
-                Entrance(FIRE_TEMPLE_LOOP_ENEMIES, { [] {
-                                                        return Here(FIRE_TEMPLE_FIRST_ROOM,
-                                                                    [] { return CanUse(MEGATON_HAMMER); }) &&
-                                                               (SmallKeys(FIRE_TEMPLE, 8) || !IsKeysanity);
-                                                    },
-                                                     /*Glitched*/
-                                                     [] {
-                                                         return ((IsAdult && CanDoGlitch(GlitchType::TripleSlashClip,
-                                                                                         GlitchDifficulty::EXPERT)) ||
-                                                                 (GlitchFireGrunzClip && Bombs && IsAdult &&
-                                                                  CanUse(HOVER_BOOTS) && CanSurviveDamage)) &&
-                                                                (SmallKeys(FIRE_TEMPLE, 8) || !IsKeysanity);
-                                                     } }),
-                Entrance(FIRE_TEMPLE_LOOP_EXIT, { [] { return true; } }),
-                Entrance(FIRE_TEMPLE_BIG_LAVA_ROOM, { [] { return SmallKeys(FIRE_TEMPLE, 2) && CanSurviveHeatFor(24); } }),
-            });
+        areaTable[FIRE_TEMPLE_FIRST_ROOM] =
+            Area("Fire Temple First Room", "Fire Temple", FIRE_TEMPLE, NO_DAY_NIGHT_CYCLE,
+                 {
+                     // Events
+                     EventAccess(&DekuBabaSticks, { [] { return DekuBabaSticks || CanGetDekuBabaSticks(4, 0, 0); } }),
+                     EventAccess(&DekuBabaNuts, { [] { return DekuBabaNuts || CanGetDekuBabaNuts(4, 0, 0); } }),
+                 },
+                 {},
+                 {
+                     // Exits
+                     Entrance(FIRE_TEMPLE_ENTRYWAY, { [] { return true; } }),
+                     Entrance(FIRE_TEMPLE_NEAR_BOSS_ROOM, { [] { return CanSurviveHeatFor(24); } }),
+                     Entrance(FIRE_TEMPLE_LOOP_ENEMIES,
+                              { [] {
+                                   return Here(FIRE_TEMPLE_FIRST_ROOM, [] { return CanUse(MEGATON_HAMMER); }) &&
+                                          (SmallKeys(FIRE_TEMPLE, 8) || !IsKeysanity);
+                               },
+                                /*Glitched*/
+                                [] {
+                                    return ((IsAdult &&
+                                             CanDoGlitch(GlitchType::TripleSlashClip, GlitchDifficulty::EXPERT)) ||
+                                            (GlitchFireGrunzClip && Bombs && IsAdult && CanUse(HOVER_BOOTS) &&
+                                             CanSurviveDamage)) &&
+                                           (SmallKeys(FIRE_TEMPLE, 8) || !IsKeysanity);
+                                } }),
+                     Entrance(FIRE_TEMPLE_LOOP_EXIT, { [] { return true; } }),
+                     Entrance(FIRE_TEMPLE_BIG_LAVA_ROOM,
+                              { [] { return SmallKeys(FIRE_TEMPLE, 2) && CanSurviveHeatFor(24); } }),
+                 });
 
         areaTable[FIRE_TEMPLE_NEAR_BOSS_ROOM] =
             Area("Fire Temple Near Boss Room", "Fire Temple", FIRE_TEMPLE, NO_DAY_NIGHT_CYCLE,
@@ -251,19 +252,20 @@ void AreaTable_Init_FireTemple() {
                      Entrance(FIRE_TEMPLE_BIG_LAVA_ROOM, { [] { return true; } }),
                  });
 
-        areaTable[FIRE_TEMPLE_FIRE_PILLAR_ROOM] = Area(
-            "Fire Temple Fire Pillar Room", "Fire Temple", FIRE_TEMPLE, NO_DAY_NIGHT_CYCLE,
-            {
-                // Events
-                EventAccess(&DekuBabaSticks, { [] { return DekuBabaSticks || CanGetDekuBabaSticks(4, 0, 21); } }),
-                EventAccess(&DekuBabaNuts, { [] { return DekuBabaNuts || CanGetDekuBabaNuts(4, 0, 21); } }),
-            },
-            {},
-            {
-                // Exits
-                Entrance(FIRE_TEMPLE_BIG_LAVA_ROOM, { [] { return SmallKeys(FIRE_TEMPLE, 3); } }),
-                Entrance(FIRE_TEMPLE_SHORTCUT_ROOM, { [] { return CanSurviveHeatFor(56) && SmallKeys(FIRE_TEMPLE, 4); } }),
-            });
+        areaTable[FIRE_TEMPLE_FIRE_PILLAR_ROOM] =
+            Area("Fire Temple Fire Pillar Room", "Fire Temple", FIRE_TEMPLE, NO_DAY_NIGHT_CYCLE,
+                 {
+                     // Events
+                     EventAccess(&DekuBabaSticks, { [] { return DekuBabaSticks || CanGetDekuBabaSticks(4, 0, 21); } }),
+                     EventAccess(&DekuBabaNuts, { [] { return DekuBabaNuts || CanGetDekuBabaNuts(4, 0, 21); } }),
+                 },
+                 {},
+                 {
+                     // Exits
+                     Entrance(FIRE_TEMPLE_BIG_LAVA_ROOM, { [] { return SmallKeys(FIRE_TEMPLE, 3); } }),
+                     Entrance(FIRE_TEMPLE_SHORTCUT_ROOM,
+                              { [] { return CanSurviveHeatFor(56) && SmallKeys(FIRE_TEMPLE, 4); } }),
+                 });
 
         areaTable[FIRE_TEMPLE_SHORTCUT_ROOM] = Area(
             "Fire Temple Shortcut Room", "Fire Temple", FIRE_TEMPLE, NO_DAY_NIGHT_CYCLE,
@@ -674,7 +676,8 @@ void AreaTable_Init_FireTemple() {
                                           CanUse(DINS_FIRE);
                                } }),
                 LocationAccess(FIRE_TEMPLE_MQ_NEAR_BOSS_CHEST, { [] {
-                                   return IsAdult && CanSurviveHeatFor(24) && (CanUse(HOVER_BOOTS) || CanUse(HOOKSHOT)) &&
+                                   return IsAdult && CanSurviveHeatFor(24) &&
+                                          (CanUse(HOVER_BOOTS) || CanUse(HOOKSHOT)) &&
                                           (CanUse(FIRE_ARROWS) ||
                                            (CanUse(DINS_FIRE) &&
                                             ((DamageMultiplier.IsNot(DAMAGEMULTIPLIER_OHKO) &&
@@ -835,15 +838,16 @@ void AreaTable_Init_FireTemple() {
         "Fire Temple Boss Room", "Fire Temple", NONE, NO_DAY_NIGHT_CYCLE,
         {
             // Events
-            EventAccess(&FireTempleClear,
-                        { [] { return FireTempleClear || (SoulVolvagia && CanSurviveHeatFor(64) && CanUse(MEGATON_HAMMER)); },
-                          /*Glitched*/
-                          [] {
-                              return SoulVolvagia && CanSurviveHeatFor(48) &&
-                                     ((CanUse(STICKS) && CanDoGlitch(GlitchType::QPA, GlitchDifficulty::NOVICE)) ||
-                                      CanUse(MEGATON_HAMMER)) &&
-                                     Bombs && CanDoGlitch(GlitchType::ISG, GlitchDifficulty::INTERMEDIATE);
-                          } }),
+            EventAccess(
+                &FireTempleClear,
+                { [] { return FireTempleClear || (SoulVolvagia && CanSurviveHeatFor(64) && CanUse(MEGATON_HAMMER)); },
+                  /*Glitched*/
+                  [] {
+                      return SoulVolvagia && CanSurviveHeatFor(48) &&
+                             ((CanUse(STICKS) && CanDoGlitch(GlitchType::QPA, GlitchDifficulty::NOVICE)) ||
+                              CanUse(MEGATON_HAMMER)) &&
+                             Bombs && CanDoGlitch(GlitchType::ISG, GlitchDifficulty::INTERMEDIATE);
+                  } }),
         },
         {
             // Locations

--- a/source/location_access/locacc_gerudo_training_grounds.cpp
+++ b/source/location_access/locacc_gerudo_training_grounds.cpp
@@ -112,8 +112,8 @@ void AreaTable_Init_GerudoTrainingGrounds() {
             {
                 // Locations
                 LocationAccess(GERUDO_TRAINING_GROUNDS_UNDERWATER_SILVER_RUPEE_CHEST, { [] {
-                                   return CanUse(HOOKSHOT) && CanPlay(SongOfTime) && IronBoots && CanSurviveUnderwaterFor(24) &&
-                                          CanPassEnemies(11, 0, 9, { 5, 7 });
+                                   return CanUse(HOOKSHOT) && CanPlay(SongOfTime) && IronBoots &&
+                                          CanSurviveUnderwaterFor(24) && CanPassEnemies(11, 0, 9, { 5, 7 });
                                } }),
             },
             {
@@ -257,8 +257,8 @@ void AreaTable_Init_GerudoTrainingGrounds() {
                  {
                      // Locations
                      LocationAccess(GERUDO_TRAINING_GROUNDS_MQ_UNDERWATER_SILVER_RUPEE_CHEST, { [] {
-                                        return HasFireSource && IsAdult && CanUse(IRON_BOOTS) && CanSurviveUnderwaterFor(24) &&
-                                               CanTakeDamage;
+                                        return HasFireSource && IsAdult && CanUse(IRON_BOOTS) &&
+                                               CanSurviveUnderwaterFor(24) && CanTakeDamage;
                                     } }),
                  },
                  {});

--- a/source/location_access/locacc_gerudo_training_grounds.cpp
+++ b/source/location_access/locacc_gerudo_training_grounds.cpp
@@ -112,7 +112,7 @@ void AreaTable_Init_GerudoTrainingGrounds() {
             {
                 // Locations
                 LocationAccess(GERUDO_TRAINING_GROUNDS_UNDERWATER_SILVER_RUPEE_CHEST, { [] {
-                                   return CanUse(HOOKSHOT) && CanPlay(SongOfTime) && IronBoots && WaterTimer >= 24 &&
+                                   return CanUse(HOOKSHOT) && CanPlay(SongOfTime) && IronBoots && CanSurviveUnderwaterFor(24) &&
                                           CanPassEnemies(11, 0, 9, { 5, 7 });
                                } }),
             },
@@ -257,7 +257,7 @@ void AreaTable_Init_GerudoTrainingGrounds() {
                  {
                      // Locations
                      LocationAccess(GERUDO_TRAINING_GROUNDS_MQ_UNDERWATER_SILVER_RUPEE_CHEST, { [] {
-                                        return HasFireSource && IsAdult && CanUse(IRON_BOOTS) && WaterTimer >= 24 &&
+                                        return HasFireSource && IsAdult && CanUse(IRON_BOOTS) && CanSurviveUnderwaterFor(24) &&
                                                CanTakeDamage;
                                     } }),
                  },

--- a/source/location_access/locacc_water_temple.cpp
+++ b/source/location_access/locacc_water_temple.cpp
@@ -80,7 +80,7 @@ void AreaTable_Init_WaterTemple() {
                              return (WaterTempleLow || WaterTempleMiddle) && (HasFireSourceWithTorch || CanUse(BOW));
                          } }),
                 Entrance(WATER_TEMPLE_EAST_MIDDLE, { [] {
-                             return (WaterTempleLow || WaterTempleMiddle || (CanUse(IRON_BOOTS) && WaterTimer >= 16)) &&
+                             return (WaterTempleLow || WaterTempleMiddle || (CanUse(IRON_BOOTS) && CanSurviveUnderwaterFor(16))) &&
                                     CanUse(HOOKSHOT) && CanPassEnemies(5, 0, 4, {}, SpaceAroundEnemy::NARROW);
                          } }),
                 Entrance(WATER_TEMPLE_WEST_MIDDLE,
@@ -436,11 +436,11 @@ void AreaTable_Init_WaterTemple() {
                      Entrance(WATER_TEMPLE_LOBBY, { [] { return SmallKeys(WATER_TEMPLE, 5); } }),
                      Entrance(WATER_TEMPLE_CENTRAL_PILLAR_UPPER, { [] { return CanUse(HOOKSHOT); } }),
                      Entrance(WATER_TEMPLE_CENTRAL_PILLAR_BASEMENT,
-                              { [] { return WaterTempleMiddle && CanUse(IRON_BOOTS) && WaterTimer >= 40; },
+                              { [] { return WaterTempleMiddle && CanUse(IRON_BOOTS) && CanSurviveUnderwaterFor(40); },
                                 /*Glitched*/
                                 [] {
                                     return CanDoGlitch(GlitchType::LedgeClip, GlitchDifficulty::NOVICE) &&
-                                           CanUse(IRON_BOOTS) && WaterTimer >= 40;
+                                           CanUse(IRON_BOOTS) && CanSurviveUnderwaterFor(40);
                                 } }),
                  });
 
@@ -478,11 +478,11 @@ void AreaTable_Init_WaterTemple() {
             {
                 // Locations
                 LocationAccess(WATER_TEMPLE_CENTRAL_PILLAR_CHEST,
-                               { [] { return CanDefeatEnemies(5, 0, 2) && WaterTimer >= 40; } }),
+                               { [] { return CanDefeatEnemies(5, 0, 2) && CanSurviveUnderwaterFor(40); } }),
             },
             {
                 // Exits
-                Entrance(WATER_TEMPLE_CENTRAL_PILLAR_LOWER, { [] { return CanUse(IRON_BOOTS) && WaterTimer >= 16; } }),
+                Entrance(WATER_TEMPLE_CENTRAL_PILLAR_LOWER, { [] { return CanUse(IRON_BOOTS) && CanSurviveUnderwaterFor(16); } }),
             });
 
         areaTable[WATER_TEMPLE_EAST_MIDDLE] =
@@ -666,7 +666,7 @@ void AreaTable_Init_WaterTemple() {
             {
                 // Exits
                 Entrance(WATER_TEMPLE_ENTRYWAY, { [] { return true; } }),
-                Entrance(WATER_TEMPLE_MQ_DIVE, { [] { return IsAdult && WaterTimer >= 24 && CanUse(IRON_BOOTS); } }),
+                Entrance(WATER_TEMPLE_MQ_DIVE, { [] { return IsAdult && CanSurviveUnderwaterFor(24) && CanUse(IRON_BOOTS); } }),
                 Entrance(WATER_TEMPLE_MQ_DARK_LINK_REGION,
                          { [] { return SmallKeys(WATER_TEMPLE, 1) && IsAdult && CanUse(LONGSHOT) && CanJumpslash; } }),
                 Entrance(WATER_TEMPLE_BOSS_ENTRYWAY,
@@ -718,7 +718,7 @@ void AreaTable_Init_WaterTemple() {
             {
                 // Locations
                 LocationAccess(WATER_TEMPLE_MQ_BOSS_KEY_CHEST, { [] {
-                                   return IsAdult && WaterTimer >= 24 && CanUse(DINS_FIRE) &&
+                                   return IsAdult && CanSurviveUnderwaterFor(24) && CanUse(DINS_FIRE) &&
                                           (LogicWaterDragonJumpDive || CanDive || CanUse(IRON_BOOTS));
                                } }),
                 LocationAccess(WATER_TEMPLE_MQ_GS_RIVER, { [] { return true; } }),
@@ -726,7 +726,7 @@ void AreaTable_Init_WaterTemple() {
             {
                 // Exits
                 Entrance(WATER_TEMPLE_MQ_BASEMENT_GATED_AREAS,
-                         { [] { return IsAdult && WaterTimer >= 24 && CanUse(DINS_FIRE) && CanUse(IRON_BOOTS); } }),
+                         { [] { return IsAdult && CanSurviveUnderwaterFor(24) && CanUse(DINS_FIRE) && CanUse(IRON_BOOTS); } }),
             });
 
         areaTable[WATER_TEMPLE_MQ_BASEMENT_GATED_AREAS] = Area(

--- a/source/location_access/locacc_water_temple.cpp
+++ b/source/location_access/locacc_water_temple.cpp
@@ -80,7 +80,8 @@ void AreaTable_Init_WaterTemple() {
                              return (WaterTempleLow || WaterTempleMiddle) && (HasFireSourceWithTorch || CanUse(BOW));
                          } }),
                 Entrance(WATER_TEMPLE_EAST_MIDDLE, { [] {
-                             return (WaterTempleLow || WaterTempleMiddle || (CanUse(IRON_BOOTS) && CanSurviveUnderwaterFor(16))) &&
+                             return (WaterTempleLow || WaterTempleMiddle ||
+                                     (CanUse(IRON_BOOTS) && CanSurviveUnderwaterFor(16))) &&
                                     CanUse(HOOKSHOT) && CanPassEnemies(5, 0, 4, {}, SpaceAroundEnemy::NARROW);
                          } }),
                 Entrance(WATER_TEMPLE_WEST_MIDDLE,
@@ -473,17 +474,18 @@ void AreaTable_Init_WaterTemple() {
                      Entrance(WATER_TEMPLE_CENTRAL_PILLAR_LOWER, { [] { return true; } }),
                  });
 
-        areaTable[WATER_TEMPLE_CENTRAL_PILLAR_BASEMENT] = Area(
-            "Water Temple Central Pillar Basement", "Water Temple", WATER_TEMPLE, NO_DAY_NIGHT_CYCLE, {},
-            {
-                // Locations
-                LocationAccess(WATER_TEMPLE_CENTRAL_PILLAR_CHEST,
-                               { [] { return CanDefeatEnemies(5, 0, 2) && CanSurviveUnderwaterFor(40); } }),
-            },
-            {
-                // Exits
-                Entrance(WATER_TEMPLE_CENTRAL_PILLAR_LOWER, { [] { return CanUse(IRON_BOOTS) && CanSurviveUnderwaterFor(16); } }),
-            });
+        areaTable[WATER_TEMPLE_CENTRAL_PILLAR_BASEMENT] =
+            Area("Water Temple Central Pillar Basement", "Water Temple", WATER_TEMPLE, NO_DAY_NIGHT_CYCLE, {},
+                 {
+                     // Locations
+                     LocationAccess(WATER_TEMPLE_CENTRAL_PILLAR_CHEST,
+                                    { [] { return CanDefeatEnemies(5, 0, 2) && CanSurviveUnderwaterFor(40); } }),
+                 },
+                 {
+                     // Exits
+                     Entrance(WATER_TEMPLE_CENTRAL_PILLAR_LOWER,
+                              { [] { return CanUse(IRON_BOOTS) && CanSurviveUnderwaterFor(16); } }),
+                 });
 
         areaTable[WATER_TEMPLE_EAST_MIDDLE] =
             Area("Water Temple East Middle", "Water Temple", WATER_TEMPLE, NO_DAY_NIGHT_CYCLE,
@@ -666,7 +668,8 @@ void AreaTable_Init_WaterTemple() {
             {
                 // Exits
                 Entrance(WATER_TEMPLE_ENTRYWAY, { [] { return true; } }),
-                Entrance(WATER_TEMPLE_MQ_DIVE, { [] { return IsAdult && CanSurviveUnderwaterFor(24) && CanUse(IRON_BOOTS); } }),
+                Entrance(WATER_TEMPLE_MQ_DIVE,
+                         { [] { return IsAdult && CanSurviveUnderwaterFor(24) && CanUse(IRON_BOOTS); } }),
                 Entrance(WATER_TEMPLE_MQ_DARK_LINK_REGION,
                          { [] { return SmallKeys(WATER_TEMPLE, 1) && IsAdult && CanUse(LONGSHOT) && CanJumpslash; } }),
                 Entrance(WATER_TEMPLE_BOSS_ENTRYWAY,
@@ -725,8 +728,9 @@ void AreaTable_Init_WaterTemple() {
             },
             {
                 // Exits
-                Entrance(WATER_TEMPLE_MQ_BASEMENT_GATED_AREAS,
-                         { [] { return IsAdult && CanSurviveUnderwaterFor(24) && CanUse(DINS_FIRE) && CanUse(IRON_BOOTS); } }),
+                Entrance(WATER_TEMPLE_MQ_BASEMENT_GATED_AREAS, { [] {
+                             return IsAdult && CanSurviveUnderwaterFor(24) && CanUse(DINS_FIRE) && CanUse(IRON_BOOTS);
+                         } }),
             });
 
         areaTable[WATER_TEMPLE_MQ_BASEMENT_GATED_AREAS] = Area(

--- a/source/location_access/locacc_zoras_domain.cpp
+++ b/source/location_access/locacc_zoras_domain.cpp
@@ -352,7 +352,8 @@ void AreaTable_Init_ZorasDomain() {
         {
             // Locations
             LocationAccess(ZF_ICEBERG_FREESTANDING_POH, { [] { return IsAdult; } }),
-            LocationAccess(ZF_BOTTOM_FREESTANDING_POH, { [] { return IsAdult && IronBoots && CanSurviveUnderwaterFor(24); } }),
+            LocationAccess(ZF_BOTTOM_FREESTANDING_POH,
+                           { [] { return IsAdult && IronBoots && CanSurviveUnderwaterFor(24); } }),
             LocationAccess(ZF_FAIRY_GOSSIP_STONE, { [] { return true; } }),
             LocationAccess(ZF_JABU_GOSSIP_STONE, { [] { return true; } }),
         },

--- a/source/location_access/locacc_zoras_domain.cpp
+++ b/source/location_access/locacc_zoras_domain.cpp
@@ -352,7 +352,7 @@ void AreaTable_Init_ZorasDomain() {
         {
             // Locations
             LocationAccess(ZF_ICEBERG_FREESTANDING_POH, { [] { return IsAdult; } }),
-            LocationAccess(ZF_BOTTOM_FREESTANDING_POH, { [] { return IsAdult && IronBoots && WaterTimer >= 24; } }),
+            LocationAccess(ZF_BOTTOM_FREESTANDING_POH, { [] { return IsAdult && IronBoots && CanSurviveUnderwaterFor(24); } }),
             LocationAccess(ZF_FAIRY_GOSSIP_STONE, { [] { return true; } }),
             LocationAccess(ZF_JABU_GOSSIP_STONE, { [] { return true; } }),
         },

--- a/source/logic.cpp
+++ b/source/logic.cpp
@@ -1,6 +1,7 @@
 #include "logic.hpp"
 
 #include <3ds.h>
+#include <limits.h>
 #include <algorithm>
 #include <cstdio>
 #include <string>
@@ -347,8 +348,6 @@ u8 BaseHearts      = 0;
 u8 Hearts          = 0;
 u8 Multiplier      = 0;
 u8 EffectiveHealth = 0;
-u8 FireTimer       = 0;
-u8 WaterTimer      = 0;
 
 bool GuaranteeTradePath     = false;
 bool GuaranteeHint          = false;
@@ -844,8 +843,6 @@ void UpdateHelpers() {
     EffectiveHealth =
         ((Hearts << (2 + DoubleDefense)) >> Multiplier) + ((Hearts << (2 + DoubleDefense)) % (1 << Multiplier) >
                                                            0); // Number of half heart hits to die, ranges from 1 to 160
-    FireTimer          = CanUse(GORON_TUNIC) ? 255 : (LogicFewerTunicRequirements) ? (Hearts * 8) : 0;
-    WaterTimer         = CanUse(ZORA_TUNIC) ? 255 : (LogicFewerTunicRequirements) ? (Hearts * 8) : 0;
     NeedNayrusLove     = (EffectiveHealth <= 1);
     CanSurviveDamage   = !NeedNayrusLove || CanUse(NAYRUS_LOVE);
     CanTakeDamage      = Fairy || CanSurviveDamage;
@@ -976,6 +973,26 @@ bool SmallKeys(Key dungeon, u8 requiredAmountGlitchless, u8 requiredAmountGlitch
         default:
             return false;
     }
+}
+
+static bool CanSurviveHazardFor(s32 timeWithFTR, s32 timeWithoutFTR) {
+    if (timeWithoutFTR < 0) {
+        timeWithoutFTR = INT_MAX;
+    }
+    if (timeWithFTR < 0) {
+        timeWithFTR = timeWithoutFTR;
+    }
+    s32 survivableTime = Hearts * 8;
+    s32 requiredTime   = LogicFewerTunicRequirements ? timeWithFTR : timeWithoutFTR;
+    return survivableTime >= requiredTime;
+}
+
+bool CanSurviveHeatFor(s32 timeWithFTR, s32 timeWithoutFTR /*= -1*/) {
+    return CanUse(GORON_TUNIC) || CanSurviveHazardFor(timeWithFTR, timeWithoutFTR);
+}
+
+bool CanSurviveUnderwaterFor(s32 timeWithFTR, s32 timeWithoutFTR /*= -1*/) {
+    return CanUse(ZORA_TUNIC) || CanSurviveHazardFor(timeWithFTR, timeWithoutFTR);
 }
 
 // Reset All Logic to false
@@ -1306,8 +1323,6 @@ void LogicReset() {
     Hearts          = 0;
     Multiplier      = (DamageMultiplier.Value<u8>() < 6) ? DamageMultiplier.Value<u8>() : 10;
     EffectiveHealth = 0;
-    FireTimer       = 0;
-    WaterTimer      = 0;
 
     GuaranteeTradePath     = false;
     GuaranteeHint          = false;

--- a/source/logic.cpp
+++ b/source/logic.cpp
@@ -978,30 +978,6 @@ bool SmallKeys(Key dungeon, u8 requiredAmountGlitchless, u8 requiredAmountGlitch
     }
 }
 
-bool EventsUpdated() {
-
-    if (DekuTreeClearPast != DekuTreeClear || GoronRubyPast != GoronRuby || ZoraSapphirePast != ZoraSapphire ||
-        ForestTrialClearPast != ForestTrialClear || FireTrialClearPast != FireTrialClear ||
-        WaterTrialClearPast != WaterTrialClear || ShadowTrialClearPast != ShadowTrialClear ||
-        SpiritTrialClearPast != SpiritTrialClear || LightTrialClearPast != LightTrialClear ||
-        DrainWellPast != DrainWell || DampesWindmillAccessPast != DampesWindmillAccess ||
-        TimeTravelPast != TimeTravel) {
-        DekuTreeClearPast        = DekuTreeClear;
-        GoronRubyPast            = GoronRuby;
-        ZoraSapphirePast         = ZoraSapphire;
-        ForestTrialClearPast     = ForestTrialClear;
-        FireTrialClearPast       = FireTrialClear;
-        WaterTrialClearPast      = WaterTrialClear;
-        ShadowTrialClearPast     = ShadowTrialClear;
-        SpiritTrialClearPast     = SpiritTrialClear;
-        LightTrialClearPast      = LightTrialClear;
-        DrainWellPast            = DrainWell;
-        DampesWindmillAccessPast = DampesWindmillAccess;
-        return true;
-    }
-    return false;
-}
-
 // Reset All Logic to false
 void LogicReset() {
     // Settings-dependent variables

--- a/source/logic.hpp
+++ b/source/logic.hpp
@@ -337,8 +337,6 @@ extern u8 BaseHearts;
 extern u8 Hearts;
 extern u8 Multiplier;
 extern u8 EffectiveHealth;
-extern u8 FireTimer;
-extern u8 WaterTimer;
 
 extern bool GuaranteeTradePath;
 extern bool GuaranteeHint;
@@ -422,4 +420,6 @@ bool SmallKeys(Key dungeon, u8 requiredAmount);
 bool SmallKeys(Key dungeon, u8 requiredAmountGlitchless, u8 requiredAmountGlitched);
 bool CanDoGlitch(GlitchType glitch, GlitchDifficulty difficulty);
 void LogicReset();
+bool CanSurviveHeatFor(s32 timeWithFTR, s32 timeWithoutFTR = -1);
+bool CanSurviveUnderwaterFor(s32 timeWithFTR, s32 timeWithoutFTR = -1);
 } // namespace Logic

--- a/source/logic.hpp
+++ b/source/logic.hpp
@@ -421,6 +421,5 @@ bool HasProjectile(HasProjectileAge age);
 bool SmallKeys(Key dungeon, u8 requiredAmount);
 bool SmallKeys(Key dungeon, u8 requiredAmountGlitchless, u8 requiredAmountGlitched);
 bool CanDoGlitch(GlitchType glitch, GlitchDifficulty difficulty);
-bool EventsUpdated();
 void LogicReset();
 } // namespace Logic

--- a/source/menu.cpp
+++ b/source/menu.cpp
@@ -698,19 +698,9 @@ void PrintDescription(std::string_view description) {
 }
 
 static void RestoreOverrides() {
-    if (Settings::Racing) {
-        for (auto overridePair : Settings::racingOverrides) {
-            overridePair.first->RestoreDelayedOption();
-        }
-    }
-
-    if (Settings::Logic.Is(LOGIC_VANILLA)) {
-        for (auto overridePair : Settings::vanillaLogicOverrides) {
-            overridePair.first->RestoreDelayedOption();
-        }
-    }
-
-    // Reload Cosmetic settings because Random Choice options might have been changed during generation
+    // Reload cached settings to restore options that might have been changed during generation
+    // (e.g. racing/vanilla overrides, cosmetic random choices, ...)
+    LoadCachedSettings();
     LoadCachedCosmetics();
 }
 
@@ -745,13 +735,11 @@ void GenerateRandomizer() {
                    "successful.");
             PlacementLog_Msg("\nRANDOMIZATION FAILED COMPLETELY. PLZ FIX\n");
             PlacementLog_Write();
-            RestoreOverrides();
-            return;
         } else {
             printf("\n\nError %d with fill.\nPress Select to exit or B to go back to the menu.\n", ret);
-            RestoreOverrides();
-            return;
         }
+        RestoreOverrides();
+        return;
     }
 
     Music::DeleteOldArchive();

--- a/source/settings.cpp
+++ b/source/settings.cpp
@@ -3041,7 +3041,6 @@ void UpdateSettings() {
     // Override cosmetic options that can affect how fast a seed is beaten
     if (Racing) {
         for (auto overridePair : racingOverrides) {
-            overridePair.first->SetDelayedOption();
             overridePair.first->SetSelectedIndex(overridePair.second);
         }
     }
@@ -3049,7 +3048,6 @@ void UpdateSettings() {
     // If vanilla logic, we want to set all settings which unnecessarily modify vanilla behavior to off
     if (Logic.Is(LOGIC_VANILLA)) {
         for (auto overridePair : vanillaLogicOverrides) {
-            overridePair.first->SetDelayedOption();
             overridePair.first->SetSelectedIndex(overridePair.second);
         }
     }

--- a/source/settings.cpp
+++ b/source/settings.cpp
@@ -3052,6 +3052,12 @@ void UpdateSettings() {
         }
     }
 
+    if (GloomMode.IsNot(GLOOMMODE_OFF) && Logic.IsNot(LOGIC_NONE) && !(GoronTunicAsChild && AgeItemsInLogic)) {
+        for (LocationKey loc : childOnlyHotLocations) {
+            Location(loc)->GetExcludedOption()->SetSelectedIndex(EXCLUDE);
+        }
+    }
+
     RandomizeAllSettings(true); // now select any random options instead of just hiding them
 
     // shuffle the dungeons and then set MQ for as many as necessary

--- a/source/settings.hpp
+++ b/source/settings.hpp
@@ -154,15 +154,6 @@ class Option {
         }
     }
 
-    void SetDelayedOption() {
-        delayedOption = selectedOption;
-    }
-
-    void RestoreDelayedOption() {
-        selectedOption = delayedOption;
-        SetVariable();
-    }
-
     void SetSelectedIndex(size_t idx) {
         selectedOption = idx;
         if (selectedOption >= options.size()) {
@@ -252,7 +243,6 @@ class Option {
     std::vector<std::string> options;
     std::vector<std::string_view> optionDescriptions;
     u8 selectedOption = 0;
-    u8 delayedOption  = 0;
     bool locked       = false;
     bool hidden       = false;
     OptionCategory category;


### PR DESCRIPTION
This updates the logic related to hazard timers by having new functions `CanSurviveHeatFor` and `CanSurviveUnderwaterFor` to handle the checks on tunics, heart count and the FewerTunicRequirements trick, replacing the `FireTimer` and `WaterTimer` variables.

It also fixes an issue with Gloom Mode where child-only item locations in Death Mountain Crater would be logically unreachable due to the heat timer requiring hearts. Now, when the relevant settings are enabled, those locations will be forced excluded so that no important items are placed there, and the reachability search will consider them reachable even if they're not.

I've also removed the unused function `EventsUpdated`, and replaced the `delayedOption` system for the Option class with just reloading the cached settings after seed generation.