### PR TITLE
Fixes for Vanilla Logic

### DIFF
--- a/source/fill.cpp
+++ b/source/fill.cpp
@@ -971,6 +971,7 @@ void VanillaFill() {
     CreateItemOverrides();
     CreateEntranceOverrides();
     CreateAlwaysIncludedMessages();
+    CreateMiscHints();
 }
 
 void ClearProgress() {

--- a/source/fill.cpp
+++ b/source/fill.cpp
@@ -959,6 +959,7 @@ void VanillaFill() {
         Location(loc)->PlaceVanillaItem();
     }
     // If necessary, handle ER stuff
+    playthroughEntrances.clear();
     if (ShuffleEntrances) {
         printf("\x1b[7;10HShuffling Entrances...");
         ShuffleAllEntrances();


### PR DESCRIPTION
- Fix app crashing when generating 2 seeds in a row with Vanilla Logic and Entrance Randomizer enabled.
- Generate Miscellaneous Hints even for Vanilla Logic, to avoid their custom text saying "What's that?" when they're enabled.