### PR TITLE
Logic updates for Enemy Randomizer

### DIFF
--- a/source/enemizer_list.cpp
+++ b/source/enemizer_list.cpp
@@ -716,8 +716,8 @@ void InitEnemyLocations(void) {
         enemyLocations[7][0][4][2]       = EnemyLocation(ENEMY_DEAD_HAND_HAND,     LocType::ABOVE_GROUND);
         enemyLocations[7][0][4][3]       = EnemyLocation(ENEMY_DEAD_HAND_HAND,     LocType::ABOVE_GROUND);
         enemyLocations[7][0][4][4]       = EnemyLocation(ENEMY_DEAD_HAND_HAND,     LocType::ABOVE_GROUND);
-        // Leave Dead Hand and one of its hands to lure it out.
-        // enemyLocations[7][0][4][5]    = EnemyLocation(ENEMY_DEAD_HAND_HAND,     LocType::ABOVE_GROUND);
+        enemyLocations[7][0][4][5]       = EnemyLocation(ENEMY_DEAD_HAND_HAND,     LocType::ABOVE_GROUND);
+        // Don't randomize Dead Hand.
         // enemyLocations[7][0][4][6]    = EnemyLocation(ENEMY_DEAD_HAND,          LocType::ABOVE_GROUND);
         enemyLocations[7][0][5][0]       = EnemyLocation(ENEMY_BEAMOS,             LocType::ABOVE_GROUND);
         enemyLocations[7][0][7][0]       = EnemyLocation(ENEMY_GIBDO,              LocType::ABOVE_GROUND);
@@ -773,8 +773,8 @@ void InitEnemyLocations(void) {
         enemyLocations[8][0][4][0]       = EnemyLocation(ENEMY_DEAD_HAND_HAND,     LocType::ABOVE_GROUND);
         enemyLocations[8][0][4][1]       = EnemyLocation(ENEMY_DEAD_HAND_HAND,     LocType::ABOVE_GROUND);
         enemyLocations[8][0][4][2]       = EnemyLocation(ENEMY_DEAD_HAND_HAND,     LocType::ABOVE_GROUND);
-        // Leave Dead Hand and one of its hands to lure it out.
-        // enemyLocations[8][0][4][3]    = EnemyLocation(ENEMY_DEAD_HAND_HAND,     LocType::ABOVE_GROUND);
+        enemyLocations[8][0][4][3]       = EnemyLocation(ENEMY_DEAD_HAND_HAND,     LocType::ABOVE_GROUND);
+        // Don't randomize Dead Hand.
         // enemyLocations[8][0][4][4]    = EnemyLocation(ENEMY_DEAD_HAND,          LocType::ABOVE_GROUND);
         enemyLocations[8][0][5][0]       = EnemyLocation(ENEMY_KEESE_NORMAL,       LocType::ABOVE_GROUND);
         enemyLocations[8][0][5][1]       = EnemyLocation(ENEMY_KEESE_NORMAL,       LocType::ABOVE_GROUND);
@@ -1209,8 +1209,8 @@ void InitEnemyLocations(void) {
         enemyLocations[7][0][4][2]       = EnemyLocation(ENEMY_DEAD_HAND_HAND,     LocType::ABOVE_GROUND);
         enemyLocations[7][0][4][3]       = EnemyLocation(ENEMY_DEAD_HAND_HAND,     LocType::ABOVE_GROUND);
         enemyLocations[7][0][4][4]       = EnemyLocation(ENEMY_DEAD_HAND_HAND,     LocType::ABOVE_GROUND);
-        // Leave Dead Hand and one of its hands to lure it out.
-        // enemyLocations[7][0][4][5]    = EnemyLocation(ENEMY_DEAD_HAND_HAND,     LocType::ABOVE_GROUND);
+        enemyLocations[7][0][4][5]       = EnemyLocation(ENEMY_DEAD_HAND_HAND,     LocType::ABOVE_GROUND);
+        // Don't randomize Dead Hand.
         // enemyLocations[7][0][4][6]    = EnemyLocation(ENEMY_DEAD_HAND,          LocType::ABOVE_GROUND);
         enemyLocations[7][0][5][0]       = EnemyLocation(ENEMY_BEAMOS,             LocType::ABOVE_GROUND);
         enemyLocations[7][0][6][0]       = EnemyLocation(ENEMY_SKULLTULA,          LocType::ABOVE_GROUND);
@@ -1281,8 +1281,8 @@ void InitEnemyLocations(void) {
         enemyLocations[8][0][4][4]       = EnemyLocation(ENEMY_DEAD_HAND_HAND,     LocType::ABOVE_GROUND);
         enemyLocations[8][0][4][5]       = EnemyLocation(ENEMY_DEAD_HAND_HAND,     LocType::ABOVE_GROUND);
         enemyLocations[8][0][4][6]       = EnemyLocation(ENEMY_DEAD_HAND_HAND,     LocType::ABOVE_GROUND);
-        // Leave Dead Hand and one of its hands to lure it out.
-        // enemyLocations[8][0][4][7]    = EnemyLocation(ENEMY_DEAD_HAND_HAND,     LocType::ABOVE_GROUND);
+        enemyLocations[8][0][4][7]       = EnemyLocation(ENEMY_DEAD_HAND_HAND,     LocType::ABOVE_GROUND);
+        // Don't randomize Dead Hand.
         // enemyLocations[8][0][4][8]    = EnemyLocation(ENEMY_DEAD_HAND,          LocType::ABOVE_GROUND);
         enemyLocations[8][0][6][0]       = EnemyLocation(ENEMY_KEESE_NORMAL,       LocType::ABOVE_GROUND);
         enemyLocations[8][0][6][1]       = EnemyLocation(ENEMY_KEESE_NORMAL,       LocType::ABOVE_GROUND);

--- a/source/enemizer_logic.cpp
+++ b/source/enemizer_logic.cpp
@@ -11,8 +11,7 @@ using EnemyConditionFn = std::function<bool(Enemizer::EnemyLocation&)>;
 
 namespace Logic {
 
-static bool AllEnemiesSatisfy(EnemyConditionFn conditionFn, u8 scene, u8 layer, u8 room,
-                              std::vector<u8> actorEntries /*= {}*/) {
+static bool AllEnemiesSatisfy(EnemyConditionFn conditionFn, u8 scene, u8 layer, u8 room, std::vector<u8> actorEntries) {
     auto& roomMap = enemyLocations[scene][layer][room];
     if (actorEntries.empty()) {
         for (auto& entry : roomMap) {
@@ -30,14 +29,18 @@ static bool AllEnemiesSatisfy(EnemyConditionFn conditionFn, u8 scene, u8 layer, 
     return true;
 }
 
-static bool AnyEnemySatisfies(EnemyConditionFn conditionFn, u8 scene, u8 layer, u8 room,
-                              std::vector<u8> actorEntries /*= {}*/) {
+static bool AnyEnemySatisfies(EnemyConditionFn conditionFn, u8 scene, u8 layer, u8 room, std::vector<u8> actorEntries) {
     auto flippedConditionFn = [&conditionFn](EnemyLocation& loc) { return !conditionFn(loc); };
     return !AllEnemiesSatisfy(flippedConditionFn, scene, layer, room, actorEntries);
 }
 
 bool IsWallmaster(u8 scene, u8 layer, u8 room, u8 actorEntry) {
     return enemyLocations[scene][layer][room][actorEntry].GetEnemyId() == ENEMY_WALLMASTER;
+}
+
+bool CanDeadHandGrab(u8 scene, u8 layer, u8 room) {
+    return AnyEnemySatisfies([](EnemyLocation& loc) { return loc.GetEnemyId() == ENEMY_DEAD_HAND_HAND; }, scene, layer,
+                             room, {});
 }
 
 bool CanDefeatEnemy(u16 enemyId) {

--- a/source/enemizer_logic.cpp
+++ b/source/enemizer_logic.cpp
@@ -78,9 +78,10 @@ bool CanDefeatEnemy(u16 enemyId) {
             return CanUse(KOKIRI_SWORD) || CanUse(MASTER_SWORD) || CanUse(BIGGORON_SWORD) || CanUse(STICKS) ||
                    CanUse(MEGATON_HAMMER) || CanUse(BOW) || CanUse(HOOKSHOT) || CanUse(SLINGSHOT) || HasExplosives;
         case ENEMY_PEAHAT:
-            return AtDay && (CanUse(KOKIRI_SWORD) || CanUse(MASTER_SWORD) || CanUse(BIGGORON_SWORD) || CanUse(STICKS) ||
-                             CanUse(MEGATON_HAMMER) || CanUse(BOW) || CanUse(HOOKSHOT) || CanUse(SLINGSHOT) ||
-                             CanUse(DINS_FIRE) || HasExplosives);
+            return (AtDay && (CanUse(KOKIRI_SWORD) || CanUse(MASTER_SWORD) || CanUse(BIGGORON_SWORD) ||
+                              CanUse(STICKS) || CanUse(MEGATON_HAMMER) || CanUse(BOW) || CanUse(HOOKSHOT) ||
+                              CanUse(SLINGSHOT) || CanUse(DINS_FIRE))) ||
+                   HasExplosives;
         case ENEMY_PEAHAT_LARVA:
             return true;
         case ENEMY_LIZALFOS:
@@ -144,7 +145,8 @@ bool CanDefeatEnemy(u16 enemyId) {
                     ((CanUse(KOKIRI_SWORD) || CanUse(MASTER_SWORD) || CanUse(BIGGORON_SWORD) || CanUse(STICKS) ||
                       CanUse(SLINGSHOT))));
         case ENEMY_BUBBLE_FIRE:
-            return CanUse(MASTER_SWORD) || CanUse(BIGGORON_SWORD) || CanUse(BOW);
+            return CanUse(MASTER_SWORD) || CanUse(BIGGORON_SWORD) || CanUse(BOW) ||
+                   ((CanUse(HYLIAN_SHIELD) || CanUse(MIRROR_SHIELD)) && CanUse(KOKIRI_SWORD));
         case ENEMY_BUBBLE_WHITE:
             return CanUse(KOKIRI_SWORD) || CanUse(MASTER_SWORD) || CanUse(BIGGORON_SWORD) || CanUse(STICKS) ||
                    CanUse(MEGATON_HAMMER) || CanUse(BOW) || CanUse(SLINGSHOT) || CanUse(DINS_FIRE) || HasExplosives;

--- a/source/enemizer_logic.hpp
+++ b/source/enemizer_logic.hpp
@@ -12,6 +12,7 @@ enum class SpaceAroundEnemy {
 #define ENEMY_ON_LEDGE true
 
 bool IsWallmaster(u8 scene, u8 layer, u8 room, u8 actorEntry);
+bool CanDeadHandGrab(u8 scene, u8 layer, u8 room);
 bool CanDefeatEnemy(u16 enemyId);
 bool CanDefeatEnemy(u8 scene, u8 layer, u8 room, u8 actorEntry);
 bool CanDefeatEnemies(u8 scene, u8 layer, u8 room, std::vector<u8> actorEntries = {});

--- a/source/fill.cpp
+++ b/source/fill.cpp
@@ -958,6 +958,7 @@ void VanillaFill() {
     for (LocationKey loc : allLocations) {
         Location(loc)->PlaceVanillaItem();
     }
+    Enemizer::RandomizeEnemies();
     // If necessary, handle ER stuff
     if (ShuffleEntrances) {
         printf("\x1b[7;10HShuffling Entrances...");

--- a/source/fill.cpp
+++ b/source/fill.cpp
@@ -996,11 +996,18 @@ int Fill() {
         GenerateStartingInventory();
         RemoveStartingItemsFromPool();
         FillExcludedLocations();
-        Enemizer::RandomizeEnemies();
 
         // Temporarily add shop items to the ItemPool so that entrance randomization
         // can validate the world using deku/hylian shields
         AddElementsToPool(ItemPool, GetMinVanillaShopItems(32)); // assume worst case shopsanity 4
+        Enemizer::RandomizeEnemies();
+        Logic::LogicReset();
+        GetAccessibleLocations({}, SearchMode::ValidateWorld, "", false, false);
+        if (!allLocationsReachable) {
+            retries++;
+            ClearProgress();
+            continue;
+        }
         if (ShuffleEntrances) {
             printf("\x1b[7;10HShuffling Entrances");
             if (ShuffleAllEntrances() == ENTRANCE_SHUFFLE_FAILURE) {

--- a/source/location_access/locacc_bottom_of_the_well.cpp
+++ b/source/location_access/locacc_bottom_of_the_well.cpp
@@ -84,8 +84,9 @@ void AreaTable_Init_BottomOfTheWell() {
                                { [] { return (LogicLensBotw || CanUse(LENS_OF_TRUTH)) && HasExplosives; } }),
                 LocationAccess(BOTTOM_OF_THE_WELL_FREESTANDING_KEY, { [] { return Sticks || CanUse(DINS_FIRE); } }),
                 LocationAccess(BOTTOM_OF_THE_WELL_LENS_OF_TRUTH_CHEST, { [] {
-                                   return SoulDeadHand && CanDefeatEnemies(8, 0, 4) && CanPlay(ZeldasLullaby) &&
-                                          (KokiriSword || (Sticks && LogicChildDeadhand));
+                                   return SoulDeadHand && CanDefeatEnemies(8, 0, 4) &&
+                                          (CanDeadHandGrab(8, 0, 4) || (CanUse(LENS_OF_TRUTH) && HasExplosives)) &&
+                                          CanPlay(ZeldasLullaby) && (KokiriSword || (Sticks && LogicChildDeadhand));
                                } }),
                 LocationAccess(BOTTOM_OF_THE_WELL_INVISIBLE_CHEST,
                                { [] { return CanPlay(ZeldasLullaby) && (LogicLensBotw || CanUse(LENS_OF_TRUTH)); } }),

--- a/source/location_access/locacc_shadow_temple.cpp
+++ b/source/location_access/locacc_shadow_temple.cpp
@@ -54,7 +54,9 @@ void AreaTable_Init_ShadowTemple() {
                 // Locations
                 LocationAccess(SHADOW_TEMPLE_MAP_CHEST, { [] { return CanDefeatEnemies(7, 0, 1); } }),
                 LocationAccess(SHADOW_TEMPLE_HOVER_BOOTS_CHEST, { [] {
-                                   return CanDefeatEnemies(7, 0, 4) && SoulDeadHand &&
+                                   return CanDefeatEnemies(7, 0, 4) &&
+                                          (CanDeadHandGrab(7, 0, 4) || (CanUse(LENS_OF_TRUTH) && HasExplosives)) &&
+                                          SoulDeadHand &&
                                           (CanUse(KOKIRI_SWORD) || CanUse(MASTER_SWORD) || CanUse(BIGGORON_SWORD));
                                } }),
             },

--- a/source/settings.cpp
+++ b/source/settings.cpp
@@ -2809,7 +2809,6 @@ std::vector<std::pair<Option*, u8>> racingOverrides = {
 // Options that should be overridden and then restored after generating when vanilla logic is enabled
 std::vector<std::pair<Option*, u8>> vanillaLogicOverrides = {
     { &TriforceHunt, OFF },
-    { &Enemizer, OFF },
     { &LinksPocketItem, LINKSPOCKETITEM_DUNGEON_REWARD },
     { &ShuffleRewards, REWARDSHUFFLE_END_OF_DUNGEON },
     { &ShuffleSongs, SONGSHUFFLE_SONG_LOCATIONS },


### PR DESCRIPTION
- Update defeat logic for Peahat and Fire Bubble: Peahats can be defeated with explosives even when dormant, and Fire Bubbles can be defeated with Kokiri Sword jumpslash after stunning them with a shield.
- Randomize all of Dead Hand's hands, and logically expect Lens and explosives only if no hands will appear in the room. This was suggested by ScAr_wlvrne months ago, before I implemented the logic for Enemy Randomizer, but now I realized it was easy to implement.
- Allow playing a Vanilla Logic game with randomized enemies, similarly to what's done for Entrance Randomizer.
