### PR TITLE
Fix: Make new location for Triforce Hunt goal

### DIFF
--- a/source/item_location.cpp
+++ b/source/item_location.cpp
@@ -12,8 +12,11 @@
 static std::array<ItemLocation, KEY_ENUM_MAX> locationTable;
 
 void LocationTable_Init() {
+    // No area                                                                       scene flag  name                                    hint key (hint_list.cpp)               vanilla item               categories                                                                                                            collection check (if needed)                             collection check group
     locationTable[NONE]                                  = ItemLocation::Base       (0xFF, 0xFF, "Invalid Location",                     NONE,                                  NONE,                      {},                                                                                                                   SpoilerCollectionCheck::None());
-    // Kokiri Forest                                                                 scene  flag  name                                    hint key (hint_list.cpp)               vanilla item               categories                                                                                                            collection check (if needed)                             collection check group
+    locationTable[TRIFORCE_HUNT_GOAL]                    = ItemLocation::Base       (0xFF, 0xFF, "Triforce Hunt Goal",                   NONE,                                  TRIFORCE,                  {},                                                                                                                   SpoilerCollectionCheck::None());
+
+    // Kokiri Forest
     locationTable[KF_KOKIRI_SWORD_CHEST]                 = ItemLocation::Chest      (0x55, 0x00, "KF Kokiri Sword Chest",                KF_KOKIRI_SWORD_CHEST,                 KOKIRI_SWORD,              {Category::cKokiriForest, Category::cForest,},                                                                                                                                 SpoilerCollectionCheckGroup::GROUP_KOKIRI_FOREST);
     locationTable[KF_MIDOS_TOP_LEFT_CHEST]               = ItemLocation::Chest      (0x28, 0x00, "KF Mido Top Left Chest",               KF_MIDOS_TOP_LEFT_CHEST,               BLUE_RUPEE,                {Category::cKokiriForest, Category::cForest,},                                                                                                                                 SpoilerCollectionCheckGroup::GROUP_KOKIRI_FOREST);
     locationTable[KF_MIDOS_TOP_RIGHT_CHEST]              = ItemLocation::Chest      (0x28, 0x01, "KF Mido Top Right Chest",              KF_MIDOS_TOP_RIGHT_CHEST,              BLUE_RUPEE,                {Category::cKokiriForest, Category::cForest,},                                                                                                                                 SpoilerCollectionCheckGroup::GROUP_KOKIRI_FOREST);
@@ -1473,6 +1476,10 @@ void GenerateLocationPool() {
     allLocations.clear();
     AddLocation(LINKS_POCKET);
     AddLocations(overworldLocations);
+
+    if (Settings::TriforceHunt) {
+        AddLocation(TRIFORCE_HUNT_GOAL);
+    }
 
     for (auto dungeon : Dungeon::dungeonList) {
         AddLocations(dungeon->GetDungeonLocations());

--- a/source/item_pool.cpp
+++ b/source/item_pool.cpp
@@ -530,7 +530,14 @@ void GenerateItemPool() {
     }
 
     // Fixed item locations
-    PlaceItemInLocation(GANON, TRIFORCE); // The Triforce is only used to make sure Ganon is accessible
+    // The Triforce is used to mark the win condition
+    if (TriforceHunt) {
+        PlaceItemInLocation(GANON, GREEN_RUPEE, false, true);
+        PlaceItemInLocation(TRIFORCE_HUNT_GOAL, TRIFORCE);
+    } else {
+        PlaceItemInLocation(GANON, TRIFORCE);
+        PlaceItemInLocation(TRIFORCE_HUNT_GOAL, GREEN_RUPEE, false, true);
+    }
     PlaceItemInLocation(MARKET_BOMBCHU_BOWLING_BOMBCHUS, BOMBCHU_DROP);
 
     if (ShuffleKokiriSword) {

--- a/source/keys.hpp
+++ b/source/keys.hpp
@@ -300,6 +300,8 @@ typedef enum {
 
     // ITEMLOCATIONS
 
+    TRIFORCE_HUNT_GOAL,
+
     // DUNGEON REWARDS
     LINKS_POCKET,
     QUEEN_GOHMA,

--- a/source/location_access.cpp
+++ b/source/location_access.cpp
@@ -251,14 +251,14 @@ void AreaTable_Init() {
     areaTable.fill(Area("Invalid Area", "Invalid Area", NONE, NO_DAY_NIGHT_CYCLE, {}, {}, {}));
 
     // name, scene, hint text,                       events, locations, exits
-    areaTable[ROOT] =
-        Area("Root", "", LINKS_POCKET, NO_DAY_NIGHT_CYCLE, {},
-             { // Locations
-               LocationAccess(LINKS_POCKET, { [] { return true; } }),
-               LocationAccess(
-                   GANON, { [] { return TriforceHunt && TriforcePieces >= TriforcePiecesTotal.Value<u8>() + 1; } }) },
-             { // Exits
-               Entrance(ROOT_EXITS, { [] { return true; } }) });
+    areaTable[ROOT] = Area(
+        "Root", "", LINKS_POCKET, NO_DAY_NIGHT_CYCLE, {},
+        { // Locations
+          LocationAccess(LINKS_POCKET, { [] { return true; } }),
+          LocationAccess(TRIFORCE_HUNT_GOAL,
+                         { [] { return TriforceHunt && TriforcePieces >= TriforcePiecesTotal.Value<u8>() + 1; } }) },
+        { // Exits
+          Entrance(ROOT_EXITS, { [] { return true; } }) });
 
     areaTable[ROOT_EXITS] =
         Area("Root Exits", "", NONE, NO_DAY_NIGHT_CYCLE, {}, {},

--- a/source/logic.cpp
+++ b/source/logic.cpp
@@ -904,6 +904,10 @@ void UpdateHelpers() {
         (LACSCondition == LACSCONDITION_DUNGEONS && DungeonCount >= LACSDungeonCount.Value<u8>()) ||
         (LACSCondition == LACSCONDITION_TOKENS && GoldSkulltulaTokens >= LACSTokenCount.Value<u8>()) ||
         (LACSCondition == LACSCONDITION_HEARTS && Hearts >= LACSHeartCount.Value<u8>());
+
+    if (TriforceHunt) {
+        BossKeyGanonsCastle = TriforcePieces >= TriforcePiecesTotal.Value<u8>() + 1;
+    }
 }
 
 bool SmallKeys(Key dungeon, u8 requiredAmount) {

--- a/source/spoiler_log.cpp
+++ b/source/spoiler_log.cpp
@@ -158,6 +158,10 @@ void WriteIngameSpoilerLog() {
         if (loc->IsExcluded()) {
             continue;
         }
+        // Win conditions that don't apply
+        else if ((key == GANON || key == TRIFORCE_HUNT_GOAL) && loc->GetPlacedItemKey() != TRIFORCE) {
+            continue;
+        }
         // Cows
         else if (!Settings::ShuffleCows && loc->IsCategory(Category::cCow)) {
             continue;
@@ -230,7 +234,7 @@ void WriteIngameSpoilerLog() {
         splrDatLoc->ItemLocations[spoilerItemIndex].LocationFlag        = loc->GetCollectionCheck().flag;
 
         // Collect Type and Reveal Type
-        if (key == GANON) {
+        if (key == GANON || key == TRIFORCE_HUNT_GOAL) {
             splrDatLoc->ItemLocations[spoilerItemIndex].CollectType = COLLECTTYPE_NEVER;
             splrDatLoc->ItemLocations[spoilerItemIndex].RevealType  = REVEALTYPE_ALWAYS;
         } else if (key == TOT_LIGHT_ARROWS_CUTSCENE &&


### PR DESCRIPTION
This fixes a bug with the Triforce Hunt playthrough calculation that can cause it to include useless items.

Currently, the win condition for Triforce Hunt is implemented by having the Ganon location (which contains the placeholder Triforce item to represent game end) accessible from the `ROOT` Area when all the pieces have been collected. But the parent region for the Ganon location is still Ganon's Tower. This leads to the playthrough calculations not considering it reachable from the root Area even after collecting all Triforce Pieces because the age/time variables in the Ganon's Tower Area aren't updated yet, making `LocationAccess::ConditionsMet()` always return false.
The result is that the playthrough (and everything depending on it like the gossip stone hints with the Playthrough distribution) could end up with many more useless steps and spheres after the last Triforce Piece.
To fix this, I added another location for the Triforce Hunt win condition, which is correctly assigned exclusively to the `ROOT` parent region, and made the relevant adjustments where needed to make it work as the goal while keeping the Ganon location accessible.