### PR TITLE
Fix Hyrule Field spawn from Zora River

### DIFF
--- a/code/src/entrance.c
+++ b/code/src/entrance.c
@@ -1059,4 +1059,10 @@ void Entrance_OverrideSpawnScene(void) {
         gGlobalContext->linkActorEntry->rot.y                            = 0;
         gGlobalContext->setupEntranceList[gGlobalContext->curSpawn].room = 11;
     }
+
+    //  Fix Hyrule Field spawn from Zora River (Land) to not be inside the loading zone
+    if (gGlobalContext->sceneNum == SCENE_HYRULE_FIELD && gGlobalContext->curSpawn == 2) {
+        gGlobalContext->linkActorEntry->pos.x = 0x173D;
+        gGlobalContext->linkActorEntry->pos.z = 0x0E96;
+    }
 }


### PR DESCRIPTION
This fixes a bug reported on Discord where the "Link's Pocket" item could be lost if the initial spawn is in Hyrule Field coming from Zora River, because the spawn point is normally inside the loading zone. Now it will be moved a bit forward to avoid this.