### PR TITLE
Add playthrough stats to Zelda's final dialog

### DIFF
--- a/code/oot.ld
+++ b/code/oot.ld
@@ -100,6 +100,10 @@ SECTIONS
 		*(.patch_KingZoraDontStartTimer)
 	}
 
+	.patch_GanonFinalBlow 0x13B684 : {
+		*(.patch_GanonFinalBlow)
+	}
+
 	.patch_StalchildDespawn_13DB68 0x13DB68 : {
 		*(.patch_StalchildDespawn_13DB68)
 	}
@@ -1808,6 +1812,10 @@ SECTIONS
 
 	.patch_LHOwlEntranceOverride 0x492080 + region_offset : {
 		*(.patch_LHOwlEntranceOverride)
+	}
+
+	.patch_PlayerBonk 0x492CD0 + region_offset : {
+		*(.patch_PlayerBonk)
 	}
 
 	.patch_FairyUseHealAmount 0x4968B4 + region_offset : {

--- a/code/src/actors/player.c
+++ b/code/src/actors/player.c
@@ -12,6 +12,7 @@
 #include "colors.h"
 #include "common.h"
 #include "gloom.h"
+#include "savefile.h"
 
 #define PlayerActor_Init ((ActorFunc)GAME_ADDR(0x191844))
 
@@ -132,9 +133,13 @@ void PlayerActor_rUpdate(Actor* thisx, GlobalContext* globalCtx) {
         }
     }
 
-    // Handle hit stuff
-    // Ignore single units of elemental damage
-    if (gSaveContext.health < sPrevHealth - 1) {
+    // Handle hit/damage counters
+    s16 lostHealth = sPrevHealth - gSaveContext.health;
+    if (lostHealth > 0) {
+        gExtSaveData.damageReceived += (sPrevHealth - gSaveContext.health);
+    }
+    // Don't count hits for single units of elemental damage
+    if (lostHealth > 1) {
         Player_OnHit();
     }
     sPrevHealth = gSaveContext.health;
@@ -245,8 +250,13 @@ void Player_UpdateRainbowTunic(void) {
 
 void Player_OnHit(void) {
     if (rGameplayFrames - sLastHitFrame > 5) {
+        gExtSaveData.hitCount++;
         Gloom_OnHit();
     }
 
     sLastHitFrame = rGameplayFrames;
+}
+
+void Player_OnBonk(void) {
+    gExtSaveData.bonkCount++;
 }

--- a/code/src/ganon.c
+++ b/code/src/ganon.c
@@ -21,3 +21,8 @@ void Ganon_GiveMSMidFight(void) {
         gSaveContext.equips.buttonItems[0] = 0x3C;
     }
 }
+
+void Ganon_OnFinalBlow(void) {
+    gFinalPlaytimeSeconds = gExtSaveData.playtimeSeconds;
+    SaveGame(gGlobalContext, FALSE);
+}

--- a/code/src/hooks.s
+++ b/code/src/hooks.s
@@ -2509,3 +2509,19 @@ hook_Item00GiveCollectedItemDrop:
     pop {r0-r12, lr}
     addne lr,lr,#0x8 @ Item overridden, skip Item_Give
     bx lr
+
+.global hook_GanonFinalBlow
+hook_GanonFinalBlow:
+    push {r0-r12, lr}
+    bl Ganon_OnFinalBlow
+    pop {r0-r12, lr}
+    mov r1,#0x1
+    bx lr
+
+.global hook_PlayerBonk
+hook_PlayerBonk:
+    strh r8,[r7,#0x38]
+    push {r0-r12, lr}
+    bl Player_OnBonk
+    pop {r0-r12, lr}
+    bx lr

--- a/code/src/message.c
+++ b/code/src/message.c
@@ -68,11 +68,11 @@ u32 Message_HandleTextControlCode(TextControlCode ctrl, void* textObj, UnkTextCo
                 break;
         }
         u16* utf16Str = sDynamicStringArray[sDynamicStringIdx++];
-        utf8_to_utf16(utf16Str, (u8*)str, strlen(str));
+        u32 utf16Len  = utf8_to_utf16(utf16Str, (u8*)str, MAX_DYNAMIC_STRING_SIZE);
         Message_UnkControlCodeHandler(textObj, &data);
         data->unk_05         = 0;
         data->stringToInsert = utf16Str;
-        data->stringLength   = strlen(str);
+        data->stringLength   = utf16Len;
         return 1;
     }
 

--- a/code/src/message.h
+++ b/code/src/message.h
@@ -93,6 +93,13 @@ typedef enum TextControlCode {
     // The following values are custom control codes added by the randomizer
 
     /* 0x30 */ TEXT_CTRL_TRIFORCE_PIECE_COUNT,
+    /* 0x31 */ TEXT_CTRL_FINAL_TIME,
+    /* 0x32 */ TEXT_CTRL_CHECK_PERCENTAGE,
+    /* 0x33 */ TEXT_CTRL_SAVE_COUNT,
+    /* 0x34 */ TEXT_CTRL_DEATH_COUNT,
+    /* 0x35 */ TEXT_CTRL_HIT_COUNT,
+    /* 0x36 */ TEXT_CTRL_DAMAGE_RECEIVED,
+    /* 0x37 */ TEXT_CTRL_BONK_COUNT,
 } TextControlCode;
 
 typedef struct UnkTextControlData {

--- a/code/src/patches.s
+++ b/code/src/patches.s
@@ -2556,3 +2556,13 @@ Item00GiveAutomaticItemDrop_patch:
 .global Item00GiveCollectedItemDrop_patch
 Item00GiveCollectedItemDrop_patch:
     bl hook_Item00GiveCollectedItemDrop
+
+.section .patch_GanonFinalBlow
+.global GanonFinalBlow_patch
+GanonFinalBlow_patch:
+    bl hook_GanonFinalBlow
+
+.section .patch_PlayerBonk
+.global PlayerBonk_patch
+PlayerBonk_patch:
+    bl hook_PlayerBonk

--- a/code/src/savefile.c
+++ b/code/src/savefile.c
@@ -858,6 +858,7 @@ void SaveFile_AfterLoadGame(void) {
 }
 
 void SaveFile_OnGameOver(void) {
+    gExtSaveData.deathCount++;
     Gloom_OnDeath();
     Permadeath_DeleteSave();
 }

--- a/code/src/savefile.h
+++ b/code/src/savefile.h
@@ -35,7 +35,7 @@ void SaveFile_SetRupeeSanityFlag(s16 sceneNum, u16 collectibleFlag);
 u8 SaveFile_GetRupeeSanityFlag(s16 sceneNum, u16 collectibleFlag);
 
 // Increment the version number whenever the ExtSaveData structure is changed
-#define EXTSAVEDATA_VERSION 17
+#define EXTSAVEDATA_VERSION 18
 
 typedef struct ExtInf {
     u32 rupeesanityFlags[SCENE_MAX];

--- a/code/src/savefile.h
+++ b/code/src/savefile.h
@@ -68,6 +68,10 @@ typedef struct {
     u32 playtimeSeconds;
     u32 scenesDiscovered[SAVEFILE_SCENES_DISCOVERED_IDX_COUNT];
     u32 entrancesDiscovered[SAVEFILE_ENTRANCES_DISCOVERED_IDX_COUNT];
+    s32 hitCount;
+    s32 damageReceived;
+    s32 deathCount;
+    s32 bonkCount;
     u8 hasTimeTraveled;
     u8 permadeath;
     u8 gloomedHeart;
@@ -88,5 +92,7 @@ typedef struct {
 #endif
 
 EXTERN ExtSaveData gExtSaveData;
+
+extern u32 gFinalPlaytimeSeconds;
 
 #endif //_SAVEFILE_H_

--- a/code/src/triforce.c
+++ b/code/src/triforce.c
@@ -1,6 +1,7 @@
 #include "triforce.h"
 #include "item_override.h"
 #include "common.h"
+#include "savefile.h"
 
 #define TEXT_STATE_DONE 6
 
@@ -13,6 +14,8 @@ void Triforce_HandleCreditsWarp(void) {
         (TriforceWarpStatus == TRIFORCEWARP_WHEN_PLAYER_READY && IsInGame() && !gIsBottomScreenDimmed &&
          PauseContext_GetState() == 0 && gGlobalContext->sceneLoadFlag == 0 && !isItemOverrideActive &&
          gGlobalContext->csCtx.state == 0 && !ItemOverride_IsAPendingOverride())) {
+        // Set final time for Zelda's text
+        gFinalPlaytimeSeconds = gExtSaveData.playtimeSeconds;
         // Save progress
         SaveGame(gGlobalContext, FALSE);
         // Warp to Ganon sealing cutscene

--- a/source/custom_messages.cpp
+++ b/source/custom_messages.cpp
@@ -1093,6 +1093,64 @@ void CreateAlwaysIncludedMessages() {
                   /*german */ "Das kannst du haben, wenn du einen Fisch für das Aquarium fängst." };
         CreateMessageFromTextObject(0x40AE, 0, 2, 3, AddColorsAndFormat(aquariumText, {}));
     }
+
+    // Zelda final dialog
+    {
+        Text happyMsg = Text{
+            // english
+            "Thank you, @...&I've been keeping watch over you all this time...^"
+            "...specifically, you took #11111111#&to bring down Ganondorf.^"
+            "You have discovered #222222# of all items scattered throughout Hyrule.^"
+            "You saved your progress #333# times.",
+            // french
+            "TO DO",
+            // spanish
+            "TO DO",
+            // italian
+            "Grazie, @...&Ti ho osservato tutto questo tempo...^"
+            "...per essere precisi, ci hai messo #11111111#&per sconfiggere Ganondorf.^"
+            "Hai scoperto il #222222# di tutti gli oggetti sparpagliati per Hyrule.^"
+            "Hai salvato i tuoi progressi #333# volte.",
+            // german
+            "TO DO",
+        };
+        happyMsg = AddColorsAndFormat(happyMsg, { QM_RED, QM_RED, QM_RED });
+        happyMsg.Replace("11111111", FINAL_TIME());
+        happyMsg.Replace("222222", CHECK_PERCENTAGE());
+        happyMsg.Replace("333", SAVE_COUNT());
+        CreateMessageFromTextObject(0x706F, 0, 2, 3, happyMsg);
+
+        Text sadMsg = Text{
+            // english
+            "You've also received #111# hits, for a total of #2222# hearts of damage, "
+            "and you've been knocked out #333# times.",
+            // french
+            "TO DO",
+            // spanish
+            "TO DO",
+            // italian
+            "Hai anche subito #111# colpi, per un totale di #2222# cuori di danno, "
+            "e sei stato messo al tappeto #333# volte.",
+            // german
+            "TO DO",
+        };
+        sadMsg = AddColorsAndFormat(sadMsg, { QM_RED, QM_RED, QM_RED });
+        sadMsg.Replace("111", HIT_COUNT());
+        sadMsg.Replace("2222", DAMAGE_RECEIVED());
+        sadMsg.Replace("333", DEATH_COUNT());
+        CreateMessageFromTextObject(0x7091, 0, 2, 3, sadMsg);
+
+        Text linkMsg = Text{
+            /*english*/ "...oh, and you've bonked #111# times.",
+            /*french */ "TO DO",
+            /*spanish*/ "TO DO",
+            /*italian*/ "...oh, e sei andato a sbattere #111# volte.",
+            /*german */ "TO DO",
+        };
+        linkMsg = AddColorsAndFormat(linkMsg, { QM_RED });
+        linkMsg.Replace("111", BONK_COUNT());
+        CreateMessageFromTextObject(0x7092, 0, 2, 3, linkMsg);
+    }
 }
 
 std::vector<Text> CreateBaseCompassTexts() {
@@ -1407,7 +1465,30 @@ std::string MQ_ELSE() {
 std::string MQ_END() {
     return "\x7F\x2B"s;
 }
+
+// Custom control codes
 std::string TRIFORCE_PIECE_COUNT() {
-    return "\x7F\x30"s;
+    return { '\x7F', static_cast<char>(TEXT_CTRL_TRIFORCE_PIECE_COUNT) };
+}
+std::string FINAL_TIME() {
+    return { '\x7F', static_cast<char>(TEXT_CTRL_FINAL_TIME) };
+}
+std::string CHECK_PERCENTAGE() {
+    return { '\x7F', static_cast<char>(TEXT_CTRL_CHECK_PERCENTAGE) };
+}
+std::string SAVE_COUNT() {
+    return { '\x7F', static_cast<char>(TEXT_CTRL_SAVE_COUNT) };
+}
+std::string DEATH_COUNT() {
+    return { '\x7F', static_cast<char>(TEXT_CTRL_DEATH_COUNT) };
+}
+std::string HIT_COUNT() {
+    return { '\x7F', static_cast<char>(TEXT_CTRL_HIT_COUNT) };
+}
+std::string DAMAGE_RECEIVED() {
+    return { '\x7F', static_cast<char>(TEXT_CTRL_DAMAGE_RECEIVED) };
+}
+std::string BONK_COUNT() {
+    return { '\x7F', static_cast<char>(TEXT_CTRL_BONK_COUNT) };
 }
 } // namespace CustomMessages

--- a/source/custom_messages.cpp
+++ b/source/custom_messages.cpp
@@ -1099,25 +1099,34 @@ void CreateAlwaysIncludedMessages() {
         Text happyMsg = Text{
             // english
             "Thank you, @...&I've been keeping watch over you all this time...^"
-            "...specifically, you took #11111111#&to bring down Ganondorf.^"
-            "You have discovered #222222# of all items scattered throughout Hyrule.^"
-            "You saved your progress #333# times.",
+            "...specifically, you took #hh:mm:ss#&to bring down Ganondorf.^"
+            "You have discovered #100.0p# of all items scattered throughout Hyrule.^"
+            "You saved your progress #999# times.",
             // french
-            "TO DO",
+            "Merci, @...&Je t'ai observé tout ce temps...^"
+            "...au total, tu as pris #hh:mm:ss#&pour vaincre Ganondorf.^"
+            "Tu as découvert #100.0p# des objets éparpillés dans Hyrule.^"
+            "Tu as sauvegardé ta progression #999# fois.",
             // spanish
-            "TO DO",
+            "Gracias, @...&He velado por ti durante todo este tiempo...^"
+            "...especificamente, tardaste #hh:mm:ss#&en derrotar a Ganondorf.^"
+            "Has descubierto el #100.0p# de todos los objetos dispersos por Hyrule.^"
+            "Has guardado partida #999# veces.",
             // italian
             "Grazie, @...&Ti ho osservato tutto questo tempo...^"
-            "...per essere precisi, ci hai messo #11111111#&per sconfiggere Ganondorf.^"
-            "Hai scoperto il #222222# di tutti gli oggetti sparpagliati per Hyrule.^"
-            "Hai salvato i tuoi progressi #333# volte.",
+            "...per essere precisi, ci hai messo #hh:mm:ss#&per sconfiggere Ganondorf.^"
+            "Hai scoperto il #100.0p# di tutti gli oggetti sparpagliati per Hyrule.^"
+            "Hai salvato i tuoi progressi #999# volte.",
             // german
-            "TO DO",
+            "Danke, @...&Ich habe dich die ganze Zeit über beobachtet...^"
+            "Du hast genau #hh:mm:ss# gebraucht,&um Ganondorf zu besiegen.^"
+            "Du hast #100.0p# aller Items entdeckt, die in Hyrule verteilt wurden.^"
+            "Du hast deinen Spielstand #999# mal gespeichert.",
         };
         happyMsg = AddColorsAndFormat(happyMsg, { QM_RED, QM_RED, QM_RED });
-        happyMsg.Replace("11111111", FINAL_TIME());
-        happyMsg.Replace("222222", CHECK_PERCENTAGE());
-        happyMsg.Replace("333", SAVE_COUNT());
+        happyMsg.Replace("hh:mm:ss", FINAL_TIME());
+        happyMsg.Replace("100.0p", CHECK_PERCENTAGE());
+        happyMsg.Replace("999", SAVE_COUNT());
         CreateMessageFromTextObject(0x706F, 0, 2, 3, happyMsg);
 
         Text sadMsg = Text{
@@ -1125,14 +1134,17 @@ void CreateAlwaysIncludedMessages() {
             "You've also received #111# hits, for a total of #2222# hearts of damage, "
             "and you've been knocked out #333# times.",
             // french
-            "TO DO",
+            "Tu as aussi été blessé #111# fois, pour un total de #2222# cœurs de dégâts, "
+            "et a été abattu #333# fois.",
             // spanish
-            "TO DO",
+            "También has recibido #111# golpes, por un total de #2222# corazones de daño, "
+            "y has sido noqueado #333# veces.",
             // italian
-            "Hai anche subito #111# colpi, per un totale di #2222# cuori di danno, "
+            "Sei anche stato colpito #111# volte, per un totale di #2222# cuori di danno, "
             "e sei stato messo al tappeto #333# volte.",
             // german
-            "TO DO",
+            "Außerdem hast du #111# mal Schaden genommen, zusammen #2222# Herzen an Schaden "
+            "und du wurdest #333# mal besiegt.",
         };
         sadMsg = AddColorsAndFormat(sadMsg, { QM_RED, QM_RED, QM_RED });
         sadMsg.Replace("111", HIT_COUNT());
@@ -1142,10 +1154,10 @@ void CreateAlwaysIncludedMessages() {
 
         Text linkMsg = Text{
             /*english*/ "...oh, and you've bonked #111# times.",
-            /*french */ "TO DO",
-            /*spanish*/ "TO DO",
+            /*french */ "...oh, et tu t'es cogné #111# fois.",
+            /*spanish*/ "...oh, mas has bonqueado #111# veces.",
             /*italian*/ "...oh, e sei andato a sbattere #111# volte.",
-            /*german */ "TO DO",
+            /*german */ "...oh, und du bist #111# mal gegen eine Wand gerollt.",
         };
         linkMsg = AddColorsAndFormat(linkMsg, { QM_RED });
         linkMsg.Replace("111", BONK_COUNT());

--- a/source/custom_messages.hpp
+++ b/source/custom_messages.hpp
@@ -56,5 +56,14 @@ std::string CENTER_TEXT();
 std::string IF_NOT_MQ();
 std::string MQ_ELSE();
 std::string MQ_END();
+
+// Custom control codes
 std::string TRIFORCE_PIECE_COUNT();
+std::string FINAL_TIME();
+std::string CHECK_PERCENTAGE();
+std::string SAVE_COUNT();
+std::string DEATH_COUNT();
+std::string HIT_COUNT();
+std::string DAMAGE_RECEIVED();
+std::string BONK_COUNT();
 } // namespace CustomMessages


### PR DESCRIPTION
This changes Zelda's dialog before the credits to report some stats about the playthrough.

https://github.com/user-attachments/assets/9465df06-0cce-413f-92e1-5800dcfc416f

Translations are still missing for French, Spanish and German.

Additionally, I've also included an auto-save when dealing the killing blow to Ganon.


