### PR TITLE
Add Bonk Damage setting

### DIFF
--- a/code/oot.ld
+++ b/code/oot.ld
@@ -1810,6 +1810,10 @@ SECTIONS
 		*(.patch_LHOwlEntranceOverride)
 	}
 
+	.patch_PlayerBonk 0x492CD0 + region_offset : {
+		*(.patch_PlayerBonk)
+	}
+
 	.patch_FairyUseHealAmount 0x4968B4 + region_offset : {
 		*(.patch_FairyUseHealAmount)
 	}

--- a/code/src/actor.c
+++ b/code/src/actor.c
@@ -140,6 +140,8 @@ void Actor_Init() {
 
     gActorOverlayTable[0x25].initInfo->update = EnZf_rUpdate;
 
+    gActorOverlayTable[0x27].initInfo->update = BossDodongo_rUpdate;
+
     gActorOverlayTable[0x2E].initInfo->init   = DoorShutter_rInit;
     gActorOverlayTable[0x2E].initInfo->update = (ActorFunc)DoorShutter_rUpdate;
 

--- a/code/src/actors/dodongos.c
+++ b/code/src/actors/dodongos.c
@@ -1,11 +1,17 @@
 #include "z3D/z3D.h"
 #include "dodongos.h"
 #include "enemy_souls.h"
+#include "settings.h"
 
 #define EnDodongo_Idle ((EnDodongoActionFunc)GAME_ADDR(0x3E4FE8))
-#define EnDodojr_JumpAttackBounce ((EnDodojrActionFunc)GAME_ADDR(0x3D069C))
 
 #define EnDodojr_Init ((ActorFunc)GAME_ADDR(0x1F51E8))
+#define EnDodojr_JumpAttackBounce ((EnDodojrActionFunc)GAME_ADDR(0x3D069C))
+
+#define BossDodongo_Update ((ActorFunc)GAME_ADDR(0x27BE30))
+#define BossDodongo_DeathCutscene ((BossDodongoActionFunc)GAME_ADDR(0x3DA7AC))
+
+static s16 BossDodongo_PrevNumWallCollisions = 0;
 
 s32 Dodongos_AfterSwallowBomb_Normal(EnDodongo* this) {
     if (!EnemySouls_CheckSoulForActor(&this->base)) {
@@ -31,4 +37,26 @@ void EnDodojr_rInit(Actor* thisx, GlobalContext* globalCtx) {
 
     // Fix vanilla bug that causes dust to be consistently drawn at y=0 when the Baby Dodongo emerges from the ground.
     thisx->floorHeight = thisx->home.pos.y;
+}
+
+void BossDodongo_rUpdate(Actor* thisx, GlobalContext* globalCtx) {
+    BossDodongo* this = (BossDodongo*)thisx;
+    BossDodongo_Update(thisx, globalCtx);
+    if (this->numWallCollisions > BossDodongo_PrevNumWallCollisions && EnemySouls_CheckSoulForActor(thisx)) {
+        static const s8 bonkDamageValues[] = {
+            [BONKDAMAGE_NONE]    = 0,  //
+            [BONKDAMAGE_QUARTER] = 0,  //
+            [BONKDAMAGE_HALF]    = 0,  //
+            [BONKDAMAGE_ONE]     = 1,  //
+            [BONKDAMAGE_TWO]     = 2,  //
+            [BONKDAMAGE_FOUR]    = 4,  //
+            [BONKDAMAGE_OHKO]    = 12, //
+        };
+        this->health -= bonkDamageValues[gSettingsContext.bonkDamage];
+        if (this->health <= 0) {
+            this->health = 0;
+            thisx->world.rot.y += 0x4000; // To avoid the camera going out of bounds
+        }
+    }
+    BossDodongo_PrevNumWallCollisions = this->numWallCollisions;
 }

--- a/code/src/actors/dodongos.h
+++ b/code/src/actors/dodongos.h
@@ -5,9 +5,11 @@
 
 struct EnDodongo;
 struct EnDodojr;
+struct BossDodongo;
 
 typedef void (*EnDodongoActionFunc)(struct EnDodongo*, GlobalContext*);
 typedef void (*EnDodojrActionFunc)(struct EnDodojr*, GlobalContext*);
+typedef void (*BossDodongoActionFunc)(struct BossDodongo*, GlobalContext*);
 
 #define EnDodojr_DropItem ((EnDodojrActionFunc)GAME_ADDR(0x3B7C64))
 
@@ -34,6 +36,20 @@ typedef struct EnDodojr {
 } EnDodojr; // size = 0x520
 _Static_assert(sizeof(EnDodojr) == 0x520, "EnDodojr size");
 
+typedef struct BossDodongo {
+    /* 0x0000 */ Actor actor;
+    /* 0x01A4 */ SkelAnime skelAnime;
+    /* 0x0228 */ char unk_288[0x0538];
+    /* 0x0760 */ BossDodongoActionFunc actionFunc;
+    /* 0x0764 */ s16 health;
+    /* 0x0766 */ char unk_766[0x0012];
+    /* 0x0778 */ s16 numWallCollisions;
+    /* 0x077A */ char unk_77A[0x18F2];
+} BossDodongo;
+_Static_assert(sizeof(BossDodongo) == 0x206C, "BossDodongo size");
+
 void EnDodojr_rInit(Actor* thisx, GlobalContext* globalCtx);
+
+void BossDodongo_rUpdate(Actor* thisx, GlobalContext* globalCtx);
 
 #endif //_DODONGOS_H_

--- a/code/src/actors/player.c
+++ b/code/src/actors/player.c
@@ -250,3 +250,32 @@ void Player_OnHit(void) {
 
     sLastHitFrame = rGameplayFrames;
 }
+
+void Player_OnBonk(void) {
+    static const s8 bonkDamageValues[] = {
+        [BONKDAMAGE_NONE]    = 0x00, //
+        [BONKDAMAGE_QUARTER] = 0x04, //
+        [BONKDAMAGE_HALF]    = 0x08, //
+        [BONKDAMAGE_ONE]     = 0x10, //
+        [BONKDAMAGE_TWO]     = 0x20, //
+        [BONKDAMAGE_FOUR]    = 0x40, //
+    };
+
+    s16 damage;
+    if (gSaveContext.nayrusLoveTimer > 0) {
+        damage = 0;
+    } else if (gSettingsContext.bonkDamage == BONKDAMAGE_OHKO) {
+        damage = gSaveContext.health;
+    } else {
+        damage = bonkDamageValues[gSettingsContext.bonkDamage];
+
+        if (gSaveContext.doubleDefense) {
+            damage /= 2;
+        }
+    }
+
+    gSaveContext.health -= damage;
+    if (gSaveContext.health < 0) {
+        gSaveContext.health = 0;
+    }
+}

--- a/code/src/hooks.s
+++ b/code/src/hooks.s
@@ -2509,3 +2509,11 @@ hook_Item00GiveCollectedItemDrop:
     pop {r0-r12, lr}
     addne lr,lr,#0x8 @ Item overridden, skip Item_Give
     bx lr
+
+.global hook_PlayerBonk
+hook_PlayerBonk:
+    strh r8,[r7,#0x38]
+    push {r0-r12, lr}
+    bl Player_OnBonk
+    pop {r0-r12, lr}
+    bx lr

--- a/code/src/patches.s
+++ b/code/src/patches.s
@@ -2556,3 +2556,8 @@ Item00GiveAutomaticItemDrop_patch:
 .global Item00GiveCollectedItemDrop_patch
 Item00GiveCollectedItemDrop_patch:
     bl hook_Item00GiveCollectedItemDrop
+
+.section .patch_PlayerBonk
+.global PlayerBonk_patch
+PlayerBonk_patch:
+    bl hook_PlayerBonk

--- a/code/src/settings.h
+++ b/code/src/settings.h
@@ -346,6 +346,16 @@ typedef enum {
 } DamageMultiplierSetting;
 
 typedef enum {
+    BONKDAMAGE_NONE,
+    BONKDAMAGE_QUARTER,
+    BONKDAMAGE_HALF,
+    BONKDAMAGE_ONE,
+    BONKDAMAGE_TWO,
+    BONKDAMAGE_FOUR,
+    BONKDAMAGE_OHKO,
+} BonkDamageSetting;
+
+typedef enum {
     GLOOMMODE_OFF,
     GLOOMMODE_DEATH,
     GLOOMMODE_DAMAGE,
@@ -598,6 +608,7 @@ typedef struct {
     u8 fastBunnyHood;
 
     u8 damageMultiplier;
+    u8 bonkDamage;
     u8 permadeath;
     u8 gloomMode;
     u8 startingTime;

--- a/source/descriptions.cpp
+++ b/source/descriptions.cpp
@@ -921,6 +921,14 @@ string_view damageMultiDesc           = "Changes the amount of damage taken.\n" 
                                         "\n"                                               //
                                         "If set to OHKO, Link will die in one hit.";       //
 /*------------------------------                                                           //
+|          BONK DAMAGE         |                                                           //
+------------------------------*/                                                           //
+string_view bonkDamageDesc            = "Choose how many Hearts of damage you'll take when\n"
+                                        "hitting a wall or object during a roll.\n\n"      //
+                                        "Damage is unaffected by the damage multiplier\n"  //
+                                        "setting, but it will respect Nayru's Love and\n"  //
+                                        "Double Defense.";                                 //
+/*------------------------------                                                           //
 |          PERMADEATH          |                                                           //
 ------------------------------*/                                                           //
 string_view permadeathDesc            = "Dying deletes your save file and kicks you back\n"//

--- a/source/descriptions.hpp
+++ b/source/descriptions.hpp
@@ -298,6 +298,8 @@ extern string_view mapsShowDungeonModesDesc;
 
 extern string_view damageMultiDesc;
 
+extern string_view bonkDamageDesc;
+
 extern string_view permadeathDesc;
 
 extern string_view gloomModeOffDesc;

--- a/source/gold_skulltulas/gs_castle_town.cpp
+++ b/source/gold_skulltulas/gs_castle_town.cpp
@@ -99,7 +99,7 @@ void GsTable_Init_CastleTown() {
             HYRULE_CASTLE_GROUNDS,
             GsScene{ 0x5F },
             Room{ 0 },
-            { [] { return IsChild && CanChildAttack; } },
+            { [] { return IsChild && CanChildAttack && CanBreakCrate; } },
         },
         {
             // https://noclip.website/#oot3d/spot15;ShareData=AG_=,9kia&UsUwHUDPaKV|wj4Q7NK!UtL:J9h:d/V&},79p3+K96!ie9Ig-$WP
@@ -169,7 +169,7 @@ void GsTable_Init_CastleTown() {
             MARKET_GUARD_HOUSE,
             GsScene{ 0x4D },
             Room{ 0 },
-            { [] { return IsChild; } },
+            { [] { return IsChild && CanBreakCrate; } },
         },
         {
             // https://noclip.website/#oot3d/market_night;ShareData=AT$t@9S(U2UC0hzUhi]H+93No6YS(:UmOkH9N]H:V9cY792]kG8!,(59W|XYVS

--- a/source/gold_skulltulas/gs_death_mountain.cpp
+++ b/source/gold_skulltulas/gs_death_mountain.cpp
@@ -298,7 +298,7 @@ void GsTable_Init_DeathMountain() {
             DMC_UPPER_LOCAL,
             GsScene{ 0x61 },
             Room{ 1 },
-            { [] { return IsChild && CanSurviveHeatFor(8, 24) && CanChildAttack; } },
+            { [] { return IsChild && CanSurviveHeatFor(8, 24) && CanChildAttack && CanBreakCrate; } },
         },
         {
             // https://noclip.website/#oot3d/spot17;ShareData=AUFyuUi+-FUMXB)9MV(y=GY[ARBWLdUqoxlUYej?V|L=ZUNl?!9e:uhUh}L)V[

--- a/source/gold_skulltulas/gs_deku_tree.cpp
+++ b/source/gold_skulltulas/gs_deku_tree.cpp
@@ -262,7 +262,7 @@ void GsTable_Init_DekuTree() {
             DEKU_TREE_MQ_LOBBY,
             GsScene{ 0x0 },
             Room{ 0 },
-            { [] { return CanAdultAttack || CanChildAttack; } },
+            { [] { return CanBreakCrate && (CanAdultAttack || CanChildAttack); } },
         },
         {
             // https://noclip.website/#oot3d/ydan_dd;ShareData=AAgxKUvUc|9L&zZ9WSlu++SyvQ@A4YUhx_?95blPV{fV}USD2EUocYmUen6CVt

--- a/source/gold_skulltulas/gs_gerudo_valley.cpp
+++ b/source/gold_skulltulas/gs_gerudo_valley.cpp
@@ -39,7 +39,7 @@ void GsTable_Init_GerudoValley() {
                   { -765, 31, 155 },
                   { 0, 0, 0 },
               },
-              { [] { return IsChild && CanGetNightTimeGS && CanChildAttack; } } },
+              { [] { return IsChild && CanGetNightTimeGS && CanChildAttack && CanBreakCrate; } } },
             // https://noclip.website/#oot3d/spot09;ShareData=AVNR290gLQUEJICUdZ~p+5!r66Ure}Uk)RF9Q!3M+?Le291Vh_9fxud9i!xWV[
             { GV_CRATE_LEDGE,
               "On wall above the ledge.",
@@ -319,7 +319,8 @@ void GsTable_Init_GerudoValley() {
                   { 0, 0, 0 },
               },
               { [] {
-                  return IsAdult && CanGetNightTimeGS && (CanUse(SCARECROW) || CanUse(HOVER_BOOTS)) && CanUse(HOOKSHOT);
+                  return IsAdult && CanGetNightTimeGS && CanBreakCrate && (CanUse(SCARECROW) || CanUse(HOVER_BOOTS)) &&
+                         CanUse(HOOKSHOT);
               } } },
             // https://noclip.website/#oot3d/spot12;ShareData=AY9W19QF329Mf$DUhXRy=F~hMRr2F1Uk(JTUL)i^V$OQr9op,1T,Kau9gO3d=a
             { GERUDO_FORTRESS,
@@ -405,7 +406,7 @@ void GsTable_Init_GerudoValley() {
                   { -1530, 80, -970 },
                   { 0, 0, 0 },
               },
-              { [] { return CanGetNightTimeGS && (CanChildAttack || CanAdultAttack); } } },
+              { [] { return CanGetNightTimeGS && CanBreakCrate && (CanChildAttack || CanAdultAttack); } } },
             // https://noclip.website/#oot3d/spot13;ShareData=AXPkEUPe;_9T[Q|9ncqKWa@W~RVGa{Uo4X$9JKdN+};0;Ukz(CT27QDT{3F8WP
             { WASTELAND_NEAR_FORTRESS,
               "High up on left pole near beginning.",

--- a/source/gold_skulltulas/gs_hyrule_field.cpp
+++ b/source/gold_skulltulas/gs_hyrule_field.cpp
@@ -161,7 +161,10 @@ void GsTable_Init_HyruleField() {
                   { -370, -10, -103 },
                   { 0, 0, 0 },
               },
-              { [] { return IsChild && (CanUse(KOKIRI_SWORD) || CanUse(MASTER_SWORD) || CanUse(BIGGORON_SWORD)); } } },
+              { [] {
+                  return IsChild && CanBreakCrate &&
+                         (CanUse(KOKIRI_SWORD) || CanUse(MASTER_SWORD) || CanUse(BIGGORON_SWORD));
+              } } },
         });
 
     gsTable[LLR_GS_RAIN_SHED] = new GoldSkulltulaData( //
@@ -259,7 +262,7 @@ void GsTable_Init_HyruleField() {
             LON_LON_RANCH,
             GsScene{ 0x63 },
             Room{ 0 },
-            { [] { return IsChild; } },
+            { [] { return IsChild && CanBreakCrate; } },
         },
         {
             // https://noclip.website/#oot3d/spot20;ShareData=AHn)a95d3PS-;Xc8gn$yV(O+RRe(Z,UldSTUI!84V4*0rTVPLFUBi819g{4W+C
@@ -281,7 +284,7 @@ void GsTable_Init_HyruleField() {
                   { 1161, 0, -2370 },
                   { 0, 0, 0 },
               },
-              { [] { return IsChild && CanGetNightTimeGS; } } },
+              { [] { return IsChild && CanGetNightTimeGS && CanBreakCrate; } } },
             // https://noclip.website/#oot3d/spot20;ShareData=AFumC97I=DTM;qNTy8|G+8uj+Q)EBKUkrdx9Jx3[VZIC*85vv69KhgO9o6*g+^
             { LON_LON_RANCH,
               "Up on wooden gate to horse area.",
@@ -424,7 +427,7 @@ void GsTable_Init_HyruleField() {
             LH_LAB,
             GsScene{ 0x38 },
             Room{ 0 },
-            { [] { return CanUse(IRON_BOOTS) && CanUse(HOOKSHOT); },
+            { [] { return CanUse(IRON_BOOTS) && CanUse(HOOKSHOT) && CanBonk; },
               /*Glitched*/
               [] {
                   return (CanDoGlitch(GlitchType::RestrictedItems, GlitchDifficulty::NOVICE) && HasBombchus &&

--- a/source/gold_skulltulas/gs_kakariko.cpp
+++ b/source/gold_skulltulas/gs_kakariko.cpp
@@ -185,7 +185,7 @@ void GsTable_Init_Kakariko() {
                   { -620, 220, -502 },
                   { 0, 13000, 16383 },
               },
-              {} },
+              { [] { return CanBreakCrate; } } },
             // https://noclip.website/#oot3d/spot01;ShareData=AW6?kUHJeF9cH;bUf|e;WI5I4RHq*|UdC)RUP19JVwlh29tZr98!ID/US|5S+5
             { KAK_BACKYARD,
               "On back door to (adult) Potion Shop.",
@@ -224,7 +224,7 @@ void GsTable_Init_Kakariko() {
             KAKARIKO_VILLAGE,
             GsScene{ 0x52 },
             Room{ 0 },
-            { [] { return IsChild && CanGetNightTimeGS; } },
+            { [] { return IsChild && CanGetNightTimeGS && CanBreakCrate; } },
         },
         {
             // https://noclip.website/#oot3d/spot01;ShareData=AJ3g{9Cl:@9frO*Um9$MV*{nMQ]kghUvKz&UOTnmWH6v]9mSZsTrpTS8[)}DVt
@@ -256,7 +256,7 @@ void GsTable_Init_Kakariko() {
                   { -50, 0, -55 },
                   { 0, 0, 0 },
               },
-              {} },
+              { [] { return CanBreakCrate; } } },
             // https://noclip.website/#oot3d/kakusiana;ShareData=AR$j3UlUA/8MbZ}8(:/GWFuyCQ7n[3Ua?WJ9S$/bVYFKQT&^m(UARs;UpAFV+5
             { KAK_REDEAD_GROTTO,
               "High on wall between redeads.",

--- a/source/gold_skulltulas/gs_zoras_domain.cpp
+++ b/source/gold_skulltulas/gs_zoras_domain.cpp
@@ -68,7 +68,7 @@ void GsTable_Init_ZorasDomain() {
             ZR_FRONT,
             GsScene{ 0x54 },
             Room{ 0 },
-            { [] { return IsChild && CanChildAttack; } },
+            { [] { return IsChild && CanChildAttack && CanBreakCrate; } },
         },
         {
             // https://noclip.website/#oot3d/spot03;ShareData=ARBe?Uj}i6Ukk489wHzP=S6_05y:6^Ue=o$Ub?4^V~TB-Uov1S9WVdkUAsD^+d
@@ -350,7 +350,7 @@ void GsTable_Init_ZorasDomain() {
             ZORAS_FOUNTAIN,
             GsScene{ 0x59 },
             Room{ 0 },
-            { [] { return IsChild; } },
+            { [] { return IsChild && CanBreakCrate; } },
         },
         {
             // https://noclip.website/#oot3d/spot08;ShareData=AZh!$TssBD8-=aa9n;[}V]MzfRPo,JUla[88*eOVVkPoHUXUyIS,BO~TfYZ)Vt

--- a/source/location_access/locacc_dodongos_cavern.cpp
+++ b/source/location_access/locacc_dodongos_cavern.cpp
@@ -662,7 +662,9 @@ void AreaTable_Init_DodongosCavern() {
                                   return DodongosCavernClear ||
                                          (Here(DODONGOS_CAVERN_BOSS_ROOM,
                                                [] { return HasExplosives || (CanUse(MEGATON_HAMMER) && CanShield); }) &&
-                                          SoulDodongo && (Bombs || GoronBracelet) && CanJumpslash);
+                                          SoulDodongo &&
+                                          (((Bombs || GoronBracelet) && CanJumpslash) ||
+                                           BonkDamage.Value<u8>() >= BONKDAMAGE_ONE));
                               },
                                /*Glitched*/
                                [] {
@@ -671,7 +673,9 @@ void AreaTable_Init_DodongosCavern() {
                                                    return HasExplosives || (CanUse(MEGATON_HAMMER) && CanShield) ||
                                                           (GlitchBlueFireWall && BlueFire);
                                                }) &&
-                                          SoulDodongo && (HasExplosives || GoronBracelet) && CanJumpslash;
+                                          SoulDodongo &&
+                                          (((HasExplosives || GoronBracelet) && CanJumpslash) ||
+                                           BonkDamage.Value<u8>() >= BONKDAMAGE_ONE);
                                } }),
              },
              {

--- a/source/location_access/locacc_fire_temple.cpp
+++ b/source/location_access/locacc_fire_temple.cpp
@@ -677,7 +677,7 @@ void AreaTable_Init_FireTemple() {
                                } }),
                 LocationAccess(FIRE_TEMPLE_MQ_NEAR_BOSS_CHEST, { [] {
                                    return IsAdult && CanSurviveHeatFor(24) &&
-                                          (CanUse(HOVER_BOOTS) || CanUse(HOOKSHOT)) &&
+                                          (CanUse(HOVER_BOOTS) || CanUse(HOOKSHOT)) && CanBreakCrate &&
                                           (CanUse(FIRE_ARROWS) ||
                                            (CanUse(DINS_FIRE) &&
                                             ((DamageMultiplier.IsNot(DAMAGEMULTIPLIER_OHKO) &&

--- a/source/location_access/locacc_gerudo_valley.cpp
+++ b/source/location_access/locacc_gerudo_valley.cpp
@@ -88,7 +88,7 @@ void AreaTable_Init_GerudoValley() {
     areaTable[GV_CRATE_LEDGE] = Area("GV Crate Ledge", "Gerudo Valley", GERUDO_VALLEY, DAY_NIGHT_CYCLE, {},
                                      {
                                          // Locations
-                                         LocationAccess(GV_CRATE_FREESTANDING_POH, { [] { return true; } }),
+                                         LocationAccess(GV_CRATE_FREESTANDING_POH, { [] { return CanBreakCrate; } }),
                                      },
                                      {
                                          // Exits

--- a/source/location_access/locacc_kakariko.cpp
+++ b/source/location_access/locacc_kakariko.cpp
@@ -23,7 +23,8 @@ void AreaTable_Init_Kakariko() {
             // Locations
             LocationAccess(SHEIK_IN_KAKARIKO,
                            { [] { return IsAdult && ForestMedallion && FireMedallion && WaterMedallion; } }),
-            LocationAccess(KAK_ANJU_AS_CHILD, { [] { return IsChild && AtDay; } }),
+            LocationAccess(KAK_ANJU_AS_CHILD,
+                           { [] { return IsChild && AtDay && (CanBreakCrate || NumRequiredCuccos.Value<u8>() < 7); } }),
             LocationAccess(KAK_ANJU_AS_ADULT, { [] { return IsAdult && AtDay; } }),
             LocationAccess(KAK_TRADE_POCKET_CUCCO,
                            { [] { return IsAdult && AtDay && PocketEgg && WakeUpAdultTalon; } }),
@@ -358,7 +359,8 @@ void AreaTable_Init_Kakariko() {
             // Locations
             LocationAccess(GRAVEYARD_FREESTANDING_POH,
                            { [] {
-                                return (IsAdult && CanPlantBean(THE_GRAVEYARD)) || CanUse(LONGSHOT) ||
+                                return (CanBreakCrate &&
+                                        ((IsAdult && CanPlantBean(THE_GRAVEYARD)) || CanUse(LONGSHOT))) ||
                                        (LogicGraveyardPoH && CanUse(BOOMERANG));
                             },
                              /*Glitched*/

--- a/source/location_access/locacc_spirit_temple.cpp
+++ b/source/location_access/locacc_spirit_temple.cpp
@@ -425,8 +425,10 @@ void AreaTable_Init_SpiritTemple() {
                      // Locations
                      LocationAccess(SPIRIT_TEMPLE_MQ_CHILD_CLIMB_SOUTH_CHEST,
                                     { [] { return SmallKeys(SPIRIT_TEMPLE, 7); } }),
-                     LocationAccess(SPIRIT_TEMPLE_MQ_STATUE_ROOM_LULLABY_CHEST,
-                                    { [] { return CanPlay(ZeldasLullaby) && (CanJumpslash || CanUse(HOVER_BOOTS)); } }),
+                     LocationAccess(SPIRIT_TEMPLE_MQ_STATUE_ROOM_LULLABY_CHEST, { [] {
+                                        return CanPlay(ZeldasLullaby) && CanBreakCrate &&
+                                               (CanJumpslash || CanUse(HOVER_BOOTS));
+                                    } }),
                      LocationAccess(SPIRIT_TEMPLE_MQ_STATUE_ROOM_INVISIBLE_CHEST,
                                     { [] { return (LogicLensSpiritMQ || CanUse(LENS_OF_TRUTH)); } }),
                      LocationAccess(SPIRIT_TEMPLE_MQ_BEAMOS_ROOM_CHEST, { [] { return SmallKeys(SPIRIT_TEMPLE, 5); } }),

--- a/source/location_access/locacc_water_temple.cpp
+++ b/source/location_access/locacc_water_temple.cpp
@@ -733,23 +733,25 @@ void AreaTable_Init_WaterTemple() {
                          } }),
             });
 
-        areaTable[WATER_TEMPLE_MQ_BASEMENT_GATED_AREAS] = Area(
-            "Water Temple MQ Basement Gated Areas", "Water Temple", WATER_TEMPLE, NO_DAY_NIGHT_CYCLE, {},
-            {
-                // Locations
-                LocationAccess(WATER_TEMPLE_MQ_FREESTANDING_KEY,
-                               { [] { return HoverBoots || CanUse(SCARECROW) || LogicWaterNorthBasementLedgeJump; } }),
-                LocationAccess(WATER_TEMPLE_MQ_GS_TRIPLE_WALL_TORCH,
-                               { [] { return CanUse(FIRE_ARROWS) && (HoverBoots || CanUse(SCARECROW)); } }),
-                LocationAccess(WATER_TEMPLE_MQ_GS_FREESTANDING_KEY_AREA, { [] {
-                                   return SmallKeys(WATER_TEMPLE, 2) &&
-                                          (HoverBoots || CanUse(SCARECROW) || LogicWaterNorthBasementLedgeJump) &&
-                                          CanJumpslash;
-                               } }),
-                // Trick: LogicWaterMQLockedGS || (SmallKeys(WATER_TEMPLE, 2) && (HoverBoots || CanUse(SCARECROW) ||
-                // LogicWaterNorthBasementLedgeJump))
-            },
-            {});
+        areaTable[WATER_TEMPLE_MQ_BASEMENT_GATED_AREAS] =
+            Area("Water Temple MQ Basement Gated Areas", "Water Temple", WATER_TEMPLE, NO_DAY_NIGHT_CYCLE, {},
+                 {
+                     // Locations
+                     LocationAccess(WATER_TEMPLE_MQ_FREESTANDING_KEY, { [] {
+                                        return CanBreakCrate &&
+                                               (HoverBoots || CanUse(SCARECROW) || LogicWaterNorthBasementLedgeJump);
+                                    } }),
+                     LocationAccess(WATER_TEMPLE_MQ_GS_TRIPLE_WALL_TORCH,
+                                    { [] { return CanUse(FIRE_ARROWS) && (HoverBoots || CanUse(SCARECROW)); } }),
+                     LocationAccess(WATER_TEMPLE_MQ_GS_FREESTANDING_KEY_AREA, { [] {
+                                        return SmallKeys(WATER_TEMPLE, 2) &&
+                                               (HoverBoots || CanUse(SCARECROW) || LogicWaterNorthBasementLedgeJump) &&
+                                               CanJumpslash;
+                                    } }),
+                     // Trick: LogicWaterMQLockedGS || (SmallKeys(WATER_TEMPLE, 2) && (HoverBoots || CanUse(SCARECROW)
+                     // || LogicWaterNorthBasementLedgeJump))
+                 },
+                 {});
     }
 
     /*---------------------------

--- a/source/logic.cpp
+++ b/source/logic.cpp
@@ -338,6 +338,8 @@ bool NeedNayrusLove                  = false;
 bool CanSurviveDamage                = false;
 bool CanTakeDamage                   = false;
 bool CanTakeDamageTwice              = false;
+bool CanBonk                         = false;
+bool CanBreakCrate                   = false;
 // bool CanPlantBean        = false;
 bool CanOpenBombGrotto   = false;
 bool CanOpenStormGrotto  = false;
@@ -855,6 +857,26 @@ void UpdateHelpers() {
     CanTakeDamage      = Fairy || CanSurviveDamage;
     CanTakeDamageTwice = (Fairy && NumBottles >= 2) || ((EffectiveHealth == 2) && (CanUse(NAYRUS_LOVE) || Fairy)) ||
                          (EffectiveHealth > 2);
+    {
+        static const s32 bonkDamageRequiredHearts[] = {
+            [BONKDAMAGE_NONE]    = 0,    //
+            [BONKDAMAGE_QUARTER] = 1,    //
+            [BONKDAMAGE_HALF]    = 1,    //
+            [BONKDAMAGE_ONE]     = 2,    //
+            [BONKDAMAGE_TWO]     = 3,    //
+            [BONKDAMAGE_FOUR]    = 5,    //
+            [BONKDAMAGE_OHKO]    = 1000, //
+        };
+        s16 bonkRequiredHearts = bonkDamageRequiredHearts[BonkDamage.Value<u8>()];
+        if (DoubleDefense) {
+            // halve and round up
+            bonkRequiredHearts = (bonkRequiredHearts + 1) / 2;
+        }
+
+        CanBonk = Hearts > bonkRequiredHearts || (Fairy && Hearts > 0) || CanUse(NAYRUS_LOVE);
+    }
+    CanBreakCrate = CanBonk || CanBlastOrSmash;
+
     // CanPlantBean        = IsChild && (MagicBean || MagicBeanPack);
     CanOpenBombGrotto   = CanBlastOrSmash && (ShardOfAgony || LogicGrottosWithoutAgony);
     CanOpenStormGrotto  = CanPlay(SongOfStorms) && (ShardOfAgony || LogicGrottosWithoutAgony);
@@ -1324,6 +1346,12 @@ void LogicReset() {
     CanStunDeku                     = false;
     CanSummonGossipFairy            = false;
     CanSummonGossipFairyWithoutSuns = false;
+    NeedNayrusLove                  = false;
+    CanSurviveDamage                = false;
+    CanTakeDamage                   = false;
+    CanTakeDamageTwice              = false;
+    CanBonk                         = false;
+    CanBreakCrate                   = false;
     // CanPlantBean        = false;
     CanOpenBombGrotto   = false;
     CanOpenStormGrotto  = false;

--- a/source/logic.hpp
+++ b/source/logic.hpp
@@ -326,6 +326,8 @@ extern bool NeedNayrusLove;
 extern bool CanSurviveDamage;
 extern bool CanTakeDamage;
 extern bool CanTakeDamageTwice;
+extern bool CanBonk;
+extern bool CanBreakCrate;
 // extern bool CanPlantBean;
 extern bool CanOpenBombGrotto;
 extern bool CanOpenStormGrotto;

--- a/source/settings.cpp
+++ b/source/settings.cpp
@@ -463,6 +463,7 @@ std::vector<Option *> itemPoolOptions = {
 Option FastBunnyHood       = Option::Bool("Fast Bunny Hood",        {"Off", "On"},                                                          {fastBunnyHoodDesc});
 Option KeepFWWarpPoint     = Option::Bool("Keep FW Warp Point",     {"Off", "On"},                                                          {keepFWWarpPointDesc});
 Option DamageMultiplier    = Option::U8  ("Damage Multiplier",      {"x1/2", "x1", "x2", "x4", "x8", "x16", "OHKO"},                        {damageMultiDesc},                                                                                                OptionCategory::Setting,    DAMAGEMULTIPLIER_DEFAULT);
+Option BonkDamage          = Option::U8  ("Bonk Damage",            {"0", "1/4", "1/2", "1", "2", "4", "OHKO"},                             {bonkDamageDesc});
 Option Permadeath          = Option::Bool("Permadeath",             {"Off", "On"},                                                          {permadeathDesc});
 Option GloomMode           = Option::U8  ("Gloom Mode",             {"Off", "Death", "Damage", "Collision", "Empty"},                       {gloomModeOffDesc, gloomModeDeathDesc, gloomModeDamageDesc, gloomModeCollisionDesc, gloomModeEmptyDesc});
 Option RandomTrapDmg       = Option::U8  ("Random Trap Damage",     {"Off", "Basic", "Advanced"},                                           {randomTrapDmgDesc, basicTrapDmgDesc, advancedTrapDmgDesc},                                                       OptionCategory::Setting,    RANDOMTRAPS_BASIC);
@@ -483,6 +484,7 @@ std::vector<Option*> gameplayOptions = {
     &FastBunnyHood,
     &KeepFWWarpPoint,
     &DamageMultiplier,
+    &BonkDamage,
     &Permadeath,
     &GloomMode,
     &RandomTrapDmg,
@@ -1568,6 +1570,7 @@ SettingsContext FillContext() {
     ctx.compassesShowWotH   = CompassesShowWotH.Value<u8>();
     ctx.mapsShowDungeonMode = MapsShowDungeonMode.Value<u8>();
     ctx.damageMultiplier    = DamageMultiplier.Value<u8>();
+    ctx.bonkDamage          = BonkDamage.Value<u8>();
     ctx.permadeath          = (Permadeath) ? 1 : 0;
     ctx.gloomMode           = GloomMode.Value<u8>();
     ctx.startingTime        = StartingTime.Value<u8>();

--- a/source/settings.hpp
+++ b/source/settings.hpp
@@ -482,6 +482,7 @@ extern Option CompassesShowReward;
 extern Option CompassesShowWotH;
 extern Option MapsShowDungeonMode;
 extern Option DamageMultiplier;
+extern Option BonkDamage;
 extern Option Permadeath;
 extern Option GloomMode;
 extern Option StartingTime;


### PR DESCRIPTION
This adds a setting to make bonking inflict a configurable amount of damage, similar to the equivalent setting from OoTR.
King Dodongo will also take damage when bonking on the wall.
New logic checks are included for crates and trees. I mostly copied them from OoTR, hopefully I didn't miss any.