### PR TITLE
Prevent randomized Iron Knuckles from respawning in cleared rooms

### DIFF
--- a/code/src/actors/iron_knuckle.c
+++ b/code/src/actors/iron_knuckle.c
@@ -20,6 +20,11 @@ void EnIk_rInit(Actor* thisx, GlobalContext* globalCtx) {
     EnIk_Init(thisx, globalCtx);
 
     if (Enemizer_IsEnemyRandomized(ENEMY_IRON_KNUCKLE)) {
+        if (Flags_GetClear(globalCtx, globalCtx->roomNum)) {
+            Actor_Kill(thisx);
+            return;
+        }
+
         // Wake up immediately
         this->skelAnime.playSpeed = 1.0f;
         // Override update here because it's also set in EnIk_Init


### PR DESCRIPTION
This fixes a bug with Enemy Randomizer where Iron Knukles could respawn in already cleared rooms due to their initial category being "Boss" instead of "Enemy" (and they would also be invisible).