### PR TITLE
Some logic fixes

### DIFF
--- a/source/item_location.cpp
+++ b/source/item_location.cpp
@@ -1651,6 +1651,14 @@ std::vector<LocationKey> childOnlyHotLocations = {
     DMC_DEKU_SCRUB,
     DMC_GS_CRATE,
     DMC_GS_BEAN_PATCH,
+    DMC_LOWER_RED_RUPEE_1,
+    DMC_LOWER_RED_RUPEE_2,
+    DMC_LOWER_BLUE_RUPEE_1,
+    DMC_LOWER_BLUE_RUPEE_2,
+    DMC_LOWER_BLUE_RUPEE_3,
+    DMC_LOWER_BLUE_RUPEE_4,
+    DMC_LOWER_BLUE_RUPEE_5,
+    DMC_LOWER_BLUE_RUPEE_6,
 };
 // clang-format on
 

--- a/source/logic.cpp
+++ b/source/logic.cpp
@@ -694,15 +694,16 @@ bool CanDoGlitch(GlitchType glitch, GlitchDifficulty difficulty) {
             if (!GlitchEnabled(GlitchHookshotJump_Bonk, difficulty)) {
                 return false;
             }
-            return IsAdult && Hookshot && CanBonk; // Child hookshot jumps are tiny so these stay as adult only until I check
+            // Child hookshot jumps are tiny so these stay as adult only.
+            return IsAdult && Hookshot && CanBonk;
 
         // Hookshot Jump: Boots
         case GlitchType::HookshotJump_Boots:
             if (!GlitchEnabled(GlitchHookshotJump_Boots, difficulty)) {
                 return false;
             }
-            return IsAdult && Hookshot &&
-                   HasBoots; // Child hookshot jumps are tiny so these stay as adult only until I check
+            // Child hookshot jumps are tiny so these stay as adult only.
+            return IsAdult && Hookshot && HasBoots;
 
         // Cutscene Dives
         case GlitchType::CutsceneDive:

--- a/source/logic.cpp
+++ b/source/logic.cpp
@@ -694,7 +694,7 @@ bool CanDoGlitch(GlitchType glitch, GlitchDifficulty difficulty) {
             if (!GlitchEnabled(GlitchHookshotJump_Bonk, difficulty)) {
                 return false;
             }
-            return IsAdult && Hookshot; // Child hookshot jumps are tiny so these stay as adult only until I check
+            return IsAdult && Hookshot && CanBonk; // Child hookshot jumps are tiny so these stay as adult only until I check
 
         // Hookshot Jump: Boots
         case GlitchType::HookshotJump_Boots:


### PR DESCRIPTION
- Add `CanBonk` check to `CanDoGlitch` for Bonk Hookshot Jump
- Add child-only DMC freestanding rupees to the special locations for Gloom mode, fixing seeds not being able to generate with both settings enabled.