### PR TITLE
Fix flag overrides for randomized Poe Composers

### DIFF
--- a/code/src/actors/poe.c
+++ b/code/src/actors/poe.c
@@ -3,6 +3,8 @@
 
 #define EnPoh_Init ((ActorFunc)GAME_ADDR(0x18DF00))
 #define EnPoh_Update ((ActorFunc)GAME_ADDR(0x24D368))
+#define EnPoh_UpdateLiving ((ActorFunc)GAME_ADDR(0x1DD974))
+#define EnPoh_UpdateDead ((ActorFunc)GAME_ADDR(0x282E88))
 
 /**
  * Composer Brothers set some flags when they spawn and when the player talks to them.
@@ -10,13 +12,15 @@
  * these flags or moving them to the Graveyard scene.
  */
 static void Poe_CallActorFunc(ActorFunc actorFunc, Actor* thisx, GlobalContext* globalCtx) {
-    ActorFlags prevFlags;
+    u32 prevSwchFlags;
+    u32 prevTempSwchFlags;
     u8 isRandomizedComposerBrother = Enemizer_IsEnemyRandomized(ENEMY_POE) && (thisx->params & 0x0002) == 0x0002 &&
                                      globalCtx->sceneNum != SCENE_GRAVEYARD;
 
     if (isRandomizedComposerBrother) {
-        prevFlags                          = globalCtx->actorCtx.flags;
-        globalCtx->actorCtx.flags.swch     = gSaveContext.sceneFlags[83].swch;
+        prevSwchFlags                      = globalCtx->actorCtx.flags.swch;
+        prevTempSwchFlags                  = globalCtx->actorCtx.flags.tempSwch;
+        globalCtx->actorCtx.flags.swch     = gSaveContext.sceneFlags[SCENE_GRAVEYARD].swch;
         globalCtx->actorCtx.flags.tempSwch = 0;
         Flags_UnsetSwitch(globalCtx, 0x9); // This flag makes Composer Brothers stop spawning
     }
@@ -24,8 +28,9 @@ static void Poe_CallActorFunc(ActorFunc actorFunc, Actor* thisx, GlobalContext* 
     actorFunc(thisx, globalCtx);
 
     if (isRandomizedComposerBrother) {
-        gSaveContext.sceneFlags[83].swch = globalCtx->actorCtx.flags.swch;
-        globalCtx->actorCtx.flags        = prevFlags;
+        gSaveContext.sceneFlags[SCENE_GRAVEYARD].swch = globalCtx->actorCtx.flags.swch;
+        globalCtx->actorCtx.flags.swch                = prevSwchFlags;
+        globalCtx->actorCtx.flags.tempSwch            = prevTempSwchFlags;
     }
 }
 
@@ -33,6 +38,20 @@ void EnPoh_rInit(Actor* thisx, GlobalContext* globalCtx) {
     Poe_CallActorFunc(EnPoh_Init, thisx, globalCtx);
 }
 
+static void EnPoh_rUpdateDead(Actor* thisx, GlobalContext* globalCtx) {
+    Poe_CallActorFunc(EnPoh_UpdateDead, thisx, globalCtx);
+}
+
+static void EnPoh_rUpdateLiving(Actor* thisx, GlobalContext* globalCtx) {
+    Poe_CallActorFunc(EnPoh_UpdateLiving, thisx, globalCtx);
+    if (thisx->update == EnPoh_UpdateDead) {
+        thisx->update = EnPoh_rUpdateDead;
+    }
+}
+
 void EnPoh_rUpdate(Actor* thisx, GlobalContext* globalCtx) {
     Poe_CallActorFunc(EnPoh_Update, thisx, globalCtx);
+    if (thisx->update == EnPoh_UpdateLiving) {
+        thisx->update = EnPoh_rUpdateLiving;
+    }
 }


### PR DESCRIPTION
Randomized Poe Composers could wrongly set flags for the current scene, even though I had implemented a patch for this already, because their actor code overwrites the update function directly, disabling the patch.

Now all of their update functions are properly overridden.