### PR TITLE
Update Multiplayer Full Sync

### DIFF
--- a/code/src/common.h
+++ b/code/src/common.h
@@ -10,6 +10,7 @@
 #define ABS(x) ((x) >= 0 ? (x) : -(x))
 #define MIN(x, y) (x < y ? x : y)
 #define MAX(x, y) (x > y ? x : y)
+#define TMP_ZERO_BUF(size) ((char[size]){ 0 })
 
 #define TICKS_PER_SEC 268123480
 #define SEQ_AUDIO_BLANK 0x1000142

--- a/code/src/common.h
+++ b/code/src/common.h
@@ -10,7 +10,7 @@
 #define ABS(x) ((x) >= 0 ? (x) : -(x))
 #define MIN(x, y) (x < y ? x : y)
 #define MAX(x, y) (x > y ? x : y)
-#define TMP_ZERO_BUF(size) ((char[size]){ 0 })
+#define TMP_ZEROED_BUFFER(size) ((char[size]){ 0 })
 
 #define TICKS_PER_SEC 268123480
 #define SEQ_AUDIO_BLANK 0x1000142

--- a/code/src/gfx.c
+++ b/code/src/gfx.c
@@ -1070,6 +1070,18 @@ static void Gfx_ShowMenu(void) {
 }
 
 static void Gfx_ShowMultiplayerSyncMenu(void) {
+    enum ResultStatus {
+        NONE,
+        SUCCESS,
+        NOT_FOUND,
+        FAIL,
+    };
+
+    static u8 syncUpdateAttempts = 0;
+    static PacketMask prevNeededPackets;
+    u8 offsetY;
+    u8 result = NONE;
+
     Draw_ClearFramebuffer();
     if (!playingOnCitra) {
         Draw_FlushFramebuffer();
@@ -1085,60 +1097,56 @@ static void Gfx_ShowMultiplayerSyncMenu(void) {
 
         Multiplayer_Update(0);
 
-        u8 offsetY              = 1;
+        offsetY                 = 1;
         const char* titleString = mp_foundSyncer ? "Syncing..." : "Looking for syncer...";
         Draw_DrawString(SCREEN_BOT_WIDTH / 2 - (strlen(titleString) / 2) * SPACING_X, 16 + SPACING_Y * offsetY++,
                         COLOR_WHITE, titleString);
 
         if (mp_foundSyncer) {
             offsetY++;
-            static const char* syncPacketNames[] = { "Base Sync",          "Save Scene Flags 1", "Save Scene Flags 2",
-                                                     "Save Scene Flags 3", "Save Scene Flags 4", "Entrance Data" };
+            static const char* syncPacketNames[] = { "Base Sync", "Entrance Data" };
             static const u8 squareSize           = 9;
-            for (size_t i = 0; i < ARRAY_SIZE(mp_completeSyncs); i++) {
+            for (size_t i = 0; i < FULLSYNC_MAX; i++) {
+                const char* name;
+                u8 partIdx;
+                if (i >= FULLSYNC_EXTINF_FIRST) {
+                    name    = "Extra Data %d";
+                    partIdx = i - FULLSYNC_EXTINF_FIRST + 1;
+                } else if (i >= FULLSYNC_FLAGS_FIRST && i <= FULLSYNC_FLAGS_LAST) {
+                    name    = "Save Scene Flags %d";
+                    partIdx = i - FULLSYNC_FLAGS_FIRST + 1;
+                } else {
+                    name = syncPacketNames[i];
+                }
+
                 Draw_DrawRect(10, 16 + SPACING_Y * offsetY, squareSize, squareSize, COLOR_WHITE);
                 Draw_DrawRect(11, 17 + SPACING_Y * offsetY, squareSize - 2, squareSize - 2,
                               mp_completeSyncs[i] ? COLOR_GREEN : COLOR_BLACK);
-                Draw_DrawString(10 + SPACING_X * 2, 16 + SPACING_Y * offsetY++, COLOR_WHITE, syncPacketNames[i]);
+                Draw_DrawFormattedString(10 + SPACING_X * 2, 16 + SPACING_Y * offsetY++, COLOR_WHITE, name, partIdx);
             }
-            if (Multiplayer_GetNeededPacketsMask() != 0) {
-                Multiplayer_Send_FullSyncRequest(Multiplayer_GetNeededPacketsMask());
+            PacketMask neededPackets = Multiplayer_GetNeededPacketsMask();
+            if (memcmp(&neededPackets, TMP_ZERO_BUF(sizeof(PacketMask)), sizeof(PacketMask)) != 0) {
+                if (syncUpdateAttempts > 10) {
+                    result = FAIL;
+                    break;
+                } else if (memcmp(&neededPackets, &prevNeededPackets, sizeof(PacketMask)) != 0) {
+                    syncUpdateAttempts = 0;
+                }
+
+                syncUpdateAttempts++;
+                prevNeededPackets = neededPackets;
+                Multiplayer_Send_FullSyncRequest(neededPackets);
             } else {
                 // Syncing is done!
-                offsetY++;
-                const char* msgString = "Done!";
-                Draw_DrawString(SCREEN_BOT_WIDTH / 2 - (strlen(msgString) / 2) * SPACING_X, 16 + SPACING_Y * offsetY,
-                                COLOR_WHITE, msgString);
-                Draw_CopyBackBuffer();
-                svcSleepThread(1000 * 1000 * 1000LL);
-
-                Draw_ClearBackbuffer();
-                Draw_CopyBackBuffer();
-                if (!playingOnCitra) {
-                    Draw_FlushFramebuffer();
-                }
-                mp_isSyncing     = false;
-                mSaveContextInit = true;
+                result = SUCCESS;
                 break;
             }
         } else {
-            Multiplayer_Send_FullSyncRequest(0); // Send 0 to only ask for ping, to reduce chance of packet loss
+            Multiplayer_Send_FullSyncProviderRequest();
             static u8 syncerSearchTimer = 0;
             // Look for a syncer for 5 seconds
             if (syncerSearchTimer >= 5) {
-                Draw_ClearBackbuffer();
-                const char* msgString = "No syncer found.";
-                Draw_DrawString(SCREEN_BOT_WIDTH / 2 - (strlen(msgString) / 2) * SPACING_X, 10 + SPACING_Y * offsetY,
-                                COLOR_WHITE, msgString);
-                Draw_CopyBackBuffer();
-                svcSleepThread(1000 * 1000 * 1000LL);
-
-                Draw_ClearBackbuffer();
-                Draw_CopyBackBuffer();
-                if (!playingOnCitra) {
-                    Draw_FlushFramebuffer();
-                }
-                mp_isSyncing = false;
+                result = NOT_FOUND;
                 break;
             }
             syncerSearchTimer++;
@@ -1152,6 +1160,39 @@ static void Gfx_ShowMultiplayerSyncMenu(void) {
         svcSleepThread(1000 * 1000 * 1000LL);
 
     } while (true);
+
+    char* msgString;
+    switch (result) {
+        case SUCCESS:
+            msgString        = "Done!";
+            mSaveContextInit = true;
+            mp_isSyncing     = false;
+            break;
+        case NOT_FOUND:
+            msgString    = "No syncer found.";
+            mp_isSyncing = false;
+            Draw_ClearBackbuffer();
+            break;
+        case FAIL:
+            msgString       = "Sync failed, will retry...";
+            mp_fullSyncerID = 0;
+            mp_foundSyncer  = false;
+            memset(&mp_completeSyncs, 0, FULLSYNC_MAX);
+            break;
+    }
+    syncUpdateAttempts = 0;
+    memset(&prevNeededPackets, 0, sizeof(PacketMask));
+
+    Draw_DrawString(SCREEN_BOT_WIDTH / 2 - (strlen(msgString) / 2) * SPACING_X, //
+                    16 + SPACING_Y * offsetY, COLOR_WHITE, msgString);
+    Draw_CopyBackBuffer();
+    svcSleepThread(1000 * 1000 * 1000LL);
+
+    Draw_ClearBackbuffer();
+    Draw_CopyBackBuffer();
+    if (!playingOnCitra) {
+        Draw_FlushFramebuffer();
+    }
 }
 
 void Gfx_Init(void) {

--- a/code/src/gfx.c
+++ b/code/src/gfx.c
@@ -1125,7 +1125,7 @@ static void Gfx_ShowMultiplayerSyncMenu(void) {
                 Draw_DrawFormattedString(10 + SPACING_X * 2, 16 + SPACING_Y * offsetY++, COLOR_WHITE, name, partIdx);
             }
             PacketMask neededPackets = Multiplayer_GetNeededPacketsMask();
-            if (memcmp(&neededPackets, TMP_ZERO_BUF(sizeof(PacketMask)), sizeof(PacketMask)) != 0) {
+            if (memcmp(&neededPackets, TMP_ZEROED_BUFFER(sizeof(PacketMask)), sizeof(PacketMask)) != 0) {
                 if (syncUpdateAttempts > 10) {
                     result = FAIL;
                     break;

--- a/code/src/multiplayer.c
+++ b/code/src/multiplayer.c
@@ -1344,7 +1344,7 @@ void Multiplayer_Send_FullExtInfSync(u16 targetID, u8 partIdx) {
         return;
     }
     memset(mBuffer, 0, mBufSize);
-    u8 memSpacer = PrepareSharedProgressPacket(PACKET_FULLEXTINFSYNC);
+    u16 memSpacer = PrepareSharedProgressPacket(PACKET_FULLEXTINFSYNC);
 
     mBuffer[memSpacer++] = partIdx;
     size_t partSize;
@@ -1355,7 +1355,7 @@ void Multiplayer_Send_FullExtInfSync(u16 targetID, u8 partIdx) {
     }
 
     memcpy(&mBuffer[memSpacer], mSaveContext.extInf + EXTINF_SYNC_PART_SIZE * partIdx, partSize);
-    memSpacer += partSize;
+    memSpacer += partSize / 4 + 1;
 
     Multiplayer_SendPacket(memSpacer, targetID);
 }
@@ -1364,7 +1364,7 @@ void Multiplayer_Receive_FullExtInfSync(u16 senderID) {
     if (!IsInSameSyncGroup() || gSettingsContext.mp_SharedProgress == OFF) {
         return;
     }
-    u8 memSpacer = GetSharedProgressMemSpacerOffset();
+    u16 memSpacer = GetSharedProgressMemSpacerOffset();
 
     u8 partIdx = mBuffer[memSpacer++];
 
@@ -1380,7 +1380,7 @@ void Multiplayer_Receive_FullExtInfSync(u16 senderID) {
     }
 
     memcpy(mSaveContext.extInf + EXTINF_SYNC_PART_SIZE * partIdx, &mBuffer[memSpacer], partSize);
-    memSpacer += partSize;
+    memSpacer += partSize / 4 + 1;
 
     mp_completeSyncs[FULLSYNC_EXTINF_FIRST + partIdx] = true;
 }

--- a/code/src/multiplayer.c
+++ b/code/src/multiplayer.c
@@ -1118,27 +1118,19 @@ void Multiplayer_Receive_FullSyncRequest(u16 senderID) {
     memcpy(&neededPackets, &mBuffer[memSpacer], sizeof(PacketMask));
     memSpacer += sizeof(neededPackets);
 
-    size_t maskSpacer = 0;
-    if (PacketMask_GetBit(&neededPackets, maskSpacer++)) {
+    if (PacketMask_GetBit(&neededPackets, FULLSYNC_BASE)) {
         Multiplayer_Send_BaseSync(senderID);
     }
-    if (PacketMask_GetBit(&neededPackets, maskSpacer++)) {
-        Multiplayer_Send_FullSceneFlagSync(senderID, 0);
-    }
-    if (PacketMask_GetBit(&neededPackets, maskSpacer++)) {
-        Multiplayer_Send_FullSceneFlagSync(senderID, 1);
-    }
-    if (PacketMask_GetBit(&neededPackets, maskSpacer++)) {
-        Multiplayer_Send_FullSceneFlagSync(senderID, 2);
-    }
-    if (PacketMask_GetBit(&neededPackets, maskSpacer++)) {
-        Multiplayer_Send_FullSceneFlagSync(senderID, 3);
-    }
-    if (PacketMask_GetBit(&neededPackets, maskSpacer++)) {
+    if (PacketMask_GetBit(&neededPackets, FULLSYNC_ENTRANCES)) {
         Multiplayer_Send_FullEntranceSync(senderID);
     }
+    for (size_t partIdx = 0; partIdx < 4; partIdx++) {
+        if (PacketMask_GetBit(&neededPackets, FULLSYNC_FLAGS_FIRST + partIdx)) {
+            Multiplayer_Send_FullSceneFlagSync(senderID, partIdx);
+        }
+    }
     for (size_t partIdx = 0; partIdx < EXTINF_SYNCS_COUNT; partIdx++) {
-        if (PacketMask_GetBit(&neededPackets, maskSpacer++)) {
+        if (PacketMask_GetBit(&neededPackets, FULLSYNC_EXTINF_FIRST + partIdx)) {
             Multiplayer_Send_FullExtInfSync(senderID, partIdx);
         }
     }

--- a/code/src/multiplayer.c
+++ b/code/src/multiplayer.c
@@ -29,10 +29,10 @@ bool mp_duplicateSendProtection = false;
 static s8 netStage              = 0;
 bool mp_isSyncing               = false;
 bool mp_foundSyncer             = false;
-bool mp_completeSyncs[6];
+bool mp_completeSyncs[FULLSYNC_MAX];
 bool mSaveContextInit = false;
 // Shared Progress: The ID that this client fullsyncs with
-static u16 fullSyncerID = 0;
+u16 mp_fullSyncerID = 0;
 
 // Network Vars
 u32* mBuffer;
@@ -273,18 +273,20 @@ u8 prevTriforcePieces;
 s16 prevHealth;
 s16 prevRupees;
 
-typedef enum {
+typedef enum PacketIdentifier {
     // Ghost Data
     PACKET_GHOSTPING,
     PACKET_GHOSTDATA,
     PACKET_GHOSTDATA_JOINTTABLE,
     PACKET_LINKSFX,
     // Shared Progress
+    PACKET_FULLSYNCPROVIDERREQUEST,
+    PACKET_FULLSYNCPROVIDEROFFER,
     PACKET_FULLSYNCREQUEST,
-    PACKET_FULLSYNCPING,
     PACKET_BASESYNC,
     PACKET_FULLSCENEFLAGSYNC,
     PACKET_FULLENTRANCESYNC,
+    PACKET_FULLEXTINFSYNC,
     PACKET_ITEM,
     PACKET_MAXHEALTH,
     PACKET_KOKIRISWORDEQUIP,
@@ -319,7 +321,9 @@ typedef enum {
     PACKET_HEALTHCHANGE,
     PACKET_RUPEESCHANGE,
     PACKET_AMMOCHANGE,
+    PACKET_MAX,
 } PacketIdentifier;
+_Static_assert(PACKET_MAX <= 255, "PacketIdentifier size");
 
 static u8 IsSendReceiveReady(void) {
     return gSettingsContext.mp_Enabled != OFF && netStage >= 3;
@@ -1042,27 +1046,66 @@ static bool IsInSameSyncGroup(void) {
     return true;
 }
 
-u8 Multiplayer_GetNeededPacketsMask(void) {
-    u8 neededPacketsMask = 0;
+PacketMask Multiplayer_GetNeededPacketsMask(void) {
+    PacketMask neededPackets = { 0 };
 
-    for (size_t i = 0; i < ARRAY_SIZE(mp_completeSyncs); i++) {
+    for (size_t i = 0; i < FULLSYNC_MAX; i++) {
         if (!mp_completeSyncs[i]) {
-            neededPacketsMask |= 1 << i;
+            PacketMask_SetBit(&neededPackets, i);
         }
     }
 
-    return neededPacketsMask;
+    return neededPackets;
 }
 
-void Multiplayer_Send_FullSyncRequest(u8 neededPacketsMask) {
+void Multiplayer_Send_FullSyncProviderRequest(void) {
+    if (!IsSendReceiveReady() || gSettingsContext.mp_SharedProgress == OFF) {
+        return;
+    }
+    memset(mBuffer, 0, mBufSize);
+    u8 memSpacer = PrepareSharedProgressPacket(PACKET_FULLSYNCPROVIDERREQUEST);
+
+    Multiplayer_SendPacket(memSpacer, UDS_BROADCAST_NETWORKNODEID);
+}
+
+void Multiplayer_Receive_FullSyncProviderRequest(u16 senderID) {
+    if (gSettingsContext.mp_SharedProgress == OFF || !IsInSameSyncGroup() || !mSaveContextInit) {
+        return;
+    }
+
+    Multiplayer_Send_FullSyncProviderOffer(senderID);
+}
+
+void Multiplayer_Send_FullSyncProviderOffer(u16 targetID) {
+    if (!IsSendReceiveReady() || gSettingsContext.mp_SharedProgress == OFF) {
+        return;
+    }
+    memset(mBuffer, 0, mBufSize);
+    u8 memSpacer = PrepareSharedProgressPacket(PACKET_FULLSYNCPROVIDEROFFER);
+
+    Multiplayer_SendPacket(memSpacer, targetID);
+}
+
+void Multiplayer_Receive_FullSyncProviderOffer(u16 senderID) {
+    if (gSettingsContext.mp_SharedProgress == OFF || !IsInSameSyncGroup() || mp_fullSyncerID != 0) {
+        return;
+    }
+
+    mp_fullSyncerID = senderID;
+    mp_foundSyncer  = true;
+}
+
+void Multiplayer_Send_FullSyncRequest(PacketMask neededPackets) {
     if (!IsSendReceiveReady() || gSettingsContext.mp_SharedProgress == OFF) {
         return;
     }
     memset(mBuffer, 0, mBufSize);
     u8 memSpacer = PrepareSharedProgressPacket(PACKET_FULLSYNCREQUEST);
 
-    mBuffer[memSpacer++] = neededPacketsMask;
-    Multiplayer_SendPacket(memSpacer, neededPacketsMask == 0 ? UDS_BROADCAST_NETWORKNODEID : fullSyncerID);
+    memcpy(&mBuffer[memSpacer], &neededPackets, sizeof(PacketMask));
+    memSpacer += sizeof(neededPackets);
+
+    Multiplayer_SendPacket(memSpacer, mp_fullSyncerID);
 }
 
 void Multiplayer_Receive_FullSyncRequest(u16 senderID) {
@@ -1071,51 +1114,34 @@ void Multiplayer_Receive_FullSyncRequest(u16 senderID) {
     }
     u8 memSpacer = GetSharedProgressMemSpacerOffset();
 
-    u8 neededPacketsMask = mBuffer[memSpacer++];
+    PacketMask neededPackets;
+    memcpy(&neededPackets, &mBuffer[memSpacer], sizeof(PacketMask));
+    memSpacer += sizeof(neededPackets);
 
-    if (neededPacketsMask == 0) {
-        Multiplayer_Send_FullSyncPing(senderID);
-        return;
-    }
-
-    u8 maskSpacer = 0;
-    if (neededPacketsMask & 1 << maskSpacer++) {
+    size_t maskSpacer = 0;
+    if (PacketMask_GetBit(&neededPackets, maskSpacer++)) {
         Multiplayer_Send_BaseSync(senderID);
     }
-    if (neededPacketsMask & 1 << maskSpacer++) {
+    if (PacketMask_GetBit(&neededPackets, maskSpacer++)) {
         Multiplayer_Send_FullSceneFlagSync(senderID, 0);
     }
-    if (neededPacketsMask & 1 << maskSpacer++) {
+    if (PacketMask_GetBit(&neededPackets, maskSpacer++)) {
         Multiplayer_Send_FullSceneFlagSync(senderID, 1);
     }
-    if (neededPacketsMask & 1 << maskSpacer++) {
+    if (PacketMask_GetBit(&neededPackets, maskSpacer++)) {
         Multiplayer_Send_FullSceneFlagSync(senderID, 2);
     }
-    if (neededPacketsMask & 1 << maskSpacer++) {
+    if (PacketMask_GetBit(&neededPackets, maskSpacer++)) {
         Multiplayer_Send_FullSceneFlagSync(senderID, 3);
     }
-    if (neededPacketsMask & 1 << maskSpacer++) {
+    if (PacketMask_GetBit(&neededPackets, maskSpacer++)) {
         Multiplayer_Send_FullEntranceSync(senderID);
     }
-}
-
-void Multiplayer_Send_FullSyncPing(u16 targetID) {
-    if (!IsSendReceiveReady() || gSettingsContext.mp_SharedProgress == OFF) {
-        return;
+    for (size_t partIdx = 0; partIdx < EXTINF_SYNCS_COUNT; partIdx++) {
+        if (PacketMask_GetBit(&neededPackets, maskSpacer++)) {
+            Multiplayer_Send_FullExtInfSync(senderID, partIdx);
+        }
     }
-    memset(mBuffer, 0, mBufSize);
-    u8 memSpacer = PrepareSharedProgressPacket(PACKET_FULLSYNCPING);
-
-    Multiplayer_SendPacket(memSpacer, targetID);
-}
-
-void Multiplayer_Receive_FullSyncPing(u16 senderID) {
-    if (gSettingsContext.mp_SharedProgress == OFF || !IsInSameSyncGroup() || fullSyncerID != 0) {
-        return;
-    }
-
-    fullSyncerID   = senderID;
-    mp_foundSyncer = true;
 }
 
 void Multiplayer_Send_BaseSync(u16 targetID) {
@@ -1167,9 +1193,6 @@ void Multiplayer_Send_BaseSync(u16 targetID) {
         mBuffer[memSpacer++] = mSaveContext.infTable[i];
     }
     mBuffer[memSpacer++] = mSaveContext.worldMapAreaData;
-    for (size_t i = 0; i < ARRAY_SIZE(mSaveContext.extInf); i++) {
-        mBuffer[memSpacer++] = mSaveContext.extInf[i];
-    }
     mBuffer[memSpacer++] = mSaveContext.triforcePieces;
     mBuffer[memSpacer++] = mSaveContext.health;
     mBuffer[memSpacer++] = mSaveContext.rupees;
@@ -1177,7 +1200,7 @@ void Multiplayer_Send_BaseSync(u16 targetID) {
 }
 
 void Multiplayer_Receive_BaseSync(u16 senderID) {
-    if (!IsInSameSyncGroup() || gSettingsContext.mp_SharedProgress == OFF || mp_completeSyncs[0]) {
+    if (!IsInSameSyncGroup() || gSettingsContext.mp_SharedProgress == OFF || mp_completeSyncs[FULLSYNC_BASE]) {
         return;
     }
     u8 memSpacer = GetSharedProgressMemSpacerOffset();
@@ -1225,10 +1248,7 @@ void Multiplayer_Receive_BaseSync(u16 senderID) {
         mSaveContext.infTable[i] = mBuffer[memSpacer++];
     }
     mSaveContext.worldMapAreaData = mBuffer[memSpacer++];
-    for (size_t i = 0; i < ARRAY_SIZE(mSaveContext.extInf); i++) {
-        mSaveContext.extInf[i] = mBuffer[memSpacer++];
-    }
-    mSaveContext.triforcePieces = mBuffer[memSpacer++];
+    mSaveContext.triforcePieces   = mBuffer[memSpacer++];
     if (gSettingsContext.mp_SharedHealth) {
         mSaveContext.health = mBuffer[memSpacer++];
     } else {
@@ -1243,18 +1263,18 @@ void Multiplayer_Receive_BaseSync(u16 senderID) {
         memSpacer++;
     }
 
-    mp_completeSyncs[0] = true;
+    mp_completeSyncs[FULLSYNC_BASE] = true;
 }
 
-void Multiplayer_Send_FullSceneFlagSync(u16 targetID, u8 part) {
+void Multiplayer_Send_FullSceneFlagSync(u16 targetID, u8 partIdx) {
     if (!IsSendReceiveReady() || gSettingsContext.mp_SharedProgress == OFF) {
         return;
     }
     memset(mBuffer, 0, mBufSize);
     u8 memSpacer = PrepareSharedProgressPacket(PACKET_FULLSCENEFLAGSYNC);
 
-    mBuffer[memSpacer++] = part;
-    u8 start             = 31 * part;
+    mBuffer[memSpacer++] = partIdx;
+    u8 start             = 31 * partIdx;
     u8 end               = start + 31;
     for (size_t i = start; i < end; i++) {
         mBuffer[memSpacer++] = mSaveContext.sceneFlags[i].chest;
@@ -1274,13 +1294,13 @@ void Multiplayer_Receive_FullSceneFlagSync(u16 senderID) {
     }
     u8 memSpacer = GetSharedProgressMemSpacerOffset();
 
-    u8 part = mBuffer[memSpacer++];
+    u8 partIdx = mBuffer[memSpacer++];
 
-    if (mp_completeSyncs[1 + part]) {
+    if (mp_completeSyncs[FULLSYNC_FLAGS_FIRST + partIdx]) {
         return;
     }
 
-    u8 start = 31 * part;
+    u8 start = 31 * partIdx;
     u8 end   = start + 31;
     for (size_t i = start; i < end; i++) {
         mSaveContext.sceneFlags[i].chest   = mBuffer[memSpacer++];
@@ -1292,7 +1312,7 @@ void Multiplayer_Receive_FullSceneFlagSync(u16 senderID) {
         mSaveContext.sceneFlags[i].rooms2  = mBuffer[memSpacer++];
     }
 
-    mp_completeSyncs[1 + part] = true;
+    mp_completeSyncs[FULLSYNC_FLAGS_FIRST + partIdx] = true;
 }
 
 void Multiplayer_Send_FullEntranceSync(u16 targetID) {
@@ -1312,7 +1332,7 @@ void Multiplayer_Send_FullEntranceSync(u16 targetID) {
 }
 
 void Multiplayer_Receive_FullEntranceSync(u16 senderID) {
-    if (!IsInSameSyncGroup() || gSettingsContext.mp_SharedProgress == OFF || mp_completeSyncs[5]) {
+    if (!IsInSameSyncGroup() || gSettingsContext.mp_SharedProgress == OFF || mp_completeSyncs[FULLSYNC_ENTRANCES]) {
         return;
     }
     u8 memSpacer = GetSharedProgressMemSpacerOffset();
@@ -1324,7 +1344,53 @@ void Multiplayer_Receive_FullEntranceSync(u16 senderID) {
         mSaveContext.entrancesDiscovered[i] = mBuffer[memSpacer++];
     }
 
-    mp_completeSyncs[5] = true;
+    mp_completeSyncs[FULLSYNC_ENTRANCES] = true;
+}
+
+void Multiplayer_Send_FullExtInfSync(u16 targetID, u8 partIdx) {
+    if (!IsSendReceiveReady() || gSettingsContext.mp_SharedProgress == OFF) {
+        return;
+    }
+    memset(mBuffer, 0, mBufSize);
+    u8 memSpacer = PrepareSharedProgressPacket(PACKET_FULLEXTINFSYNC);
+
+    mBuffer[memSpacer++] = partIdx;
+    size_t partSize;
+    if (partIdx < EXTINF_SYNCS_COUNT - 1) {
+        partSize = EXTINF_SYNC_PART_SIZE;
+    } else {
+        partSize = EXTINF_SIZE - EXTINF_SYNC_PART_SIZE * partIdx;
+    }
+
+    memcpy(&mBuffer[memSpacer], mSaveContext.extInf + EXTINF_SYNC_PART_SIZE * partIdx, partSize);
+    memSpacer += partSize;
+
+    Multiplayer_SendPacket(memSpacer, targetID);
+}
+
+void Multiplayer_Receive_FullExtInfSync(u16 senderID) {
+    if (!IsInSameSyncGroup() || gSettingsContext.mp_SharedProgress == OFF) {
+        return;
+    }
+    u8 memSpacer = GetSharedProgressMemSpacerOffset();
+
+    u8 partIdx = mBuffer[memSpacer++];
+
+    if (mp_completeSyncs[FULLSYNC_EXTINF_FIRST + partIdx]) {
+        return;
+    }
+
+    size_t partSize;
+    if (partIdx < EXTINF_SYNCS_COUNT - 1) {
+        partSize = EXTINF_SYNC_PART_SIZE;
+    } else {
+        partSize = EXTINF_SIZE - EXTINF_SYNC_PART_SIZE * partIdx;
+    }
+
+    memcpy(mSaveContext.extInf + EXTINF_SYNC_PART_SIZE * partIdx, &mBuffer[memSpacer], partSize);
+    memSpacer += partSize;
+
+    mp_completeSyncs[FULLSYNC_EXTINF_FIRST + partIdx] = true;
 }
 
 void Multiplayer_Send_Item(u8 slot, ItemID item) {
@@ -2716,11 +2782,13 @@ static void Multiplayer_UnpackPacket(u16 senderID) {
         Multiplayer_Receive_GhostData_JointTable,
         Multiplayer_Receive_LinkSFX,
         // Shared Progress
+        Multiplayer_Receive_FullSyncProviderRequest,
+        Multiplayer_Receive_FullSyncProviderOffer,
         Multiplayer_Receive_FullSyncRequest,
-        Multiplayer_Receive_FullSyncPing,
         Multiplayer_Receive_BaseSync,
         Multiplayer_Receive_FullSceneFlagSync,
         Multiplayer_Receive_FullEntranceSync,
+        Multiplayer_Receive_FullExtInfSync,
         Multiplayer_Receive_Item,
         Multiplayer_Receive_MaxHealth,
         Multiplayer_Receive_KokiriSwordEquip,

--- a/code/src/multiplayer.h
+++ b/code/src/multiplayer.h
@@ -3,13 +3,40 @@
 
 #include "3ds/types.h"
 #include "z3D/z3D.h"
+#include "savefile.h"
+
+#define EXTINF_SYNC_PART_SIZE 0x400
+// Count of parts that ExtInf will be split into for syncing
+#define EXTINF_SYNCS_COUNT (EXTINF_SIZE / EXTINF_SYNC_PART_SIZE + 1)
+
+enum FullSyncType {
+    FULLSYNC_BASE,
+    FULLSYNC_ENTRANCES,
+    FULLSYNC_FLAGS_FIRST,
+    FULLSYNC_FLAGS_LAST = FULLSYNC_FLAGS_FIRST + 3,
+    FULLSYNC_EXTINF_FIRST,
+    FULLSYNC_MAX = FULLSYNC_EXTINF_FIRST + EXTINF_SYNCS_COUNT,
+};
+
+typedef struct PacketMask {
+    // 1 bit for each needed sync part
+    u8 arr[FULLSYNC_MAX / 8 + 1];
+} PacketMask;
+
+static inline bool PacketMask_GetBit(PacketMask* mask, size_t bitIdx) {
+    return (mask->arr[bitIdx >> 3] & (1 << (bitIdx & 0b111))) != 0;
+}
+static inline void PacketMask_SetBit(PacketMask* mask, size_t bitIdx) {
+    mask->arr[bitIdx >> 3] |= (1 << (bitIdx & 0b111));
+}
 
 extern u32 mp_receivedPackets;
 extern bool mp_duplicateSendProtection;
 extern bool mp_isSyncing;
 extern bool mp_foundSyncer;
-extern bool mp_completeSyncs[6];
+extern bool mp_completeSyncs[FULLSYNC_MAX];
 extern bool mSaveContextInit;
+extern u16 mp_fullSyncerID;
 
 void Multiplayer_Run(void);
 void Multiplayer_Update(u8 fromGlobalContextUpdate);
@@ -24,9 +51,10 @@ void Multiplayer_Send_GhostData(void);
 void Multiplayer_Send_GhostData_JointTable(void);
 void Multiplayer_Send_LinkSFX(u32 sfxID);
 // Shared Progress
-u8 Multiplayer_GetNeededPacketsMask(void);
-void Multiplayer_Send_FullSyncRequest(u8 neededPacketsMask);
-void Multiplayer_Send_FullSyncPing(u16 targetID);
+PacketMask Multiplayer_GetNeededPacketsMask(void);
+void Multiplayer_Send_FullSyncProviderRequest(void);
+void Multiplayer_Send_FullSyncProviderOffer(u16 targetID);
+void Multiplayer_Send_FullSyncRequest(PacketMask neededPackets);
 void Multiplayer_Send_BaseSync(u16 targetID);
 void Multiplayer_Send_FullSceneFlagSync(u16 targetID, u8 part);
 void Multiplayer_Send_Item(u8 slot, ItemID item);
@@ -55,6 +83,7 @@ void Multiplayer_Send_WorldMapBit(u8 bit, u8 setOrUnset);
 void Multiplayer_Send_ExtInfBit(u16 index, u8 bit, u8 setOrUnset);
 void Multiplayer_Send_TriforcePieces(u32 piecesDiff);
 void Multiplayer_Send_FullEntranceSync(u16 targetID);
+void Multiplayer_Send_FullExtInfSync(u16 targetID, u8 partIdx);
 void Multiplayer_Send_DiscoveredScene(u32 index, u32 bit);
 void Multiplayer_Send_DiscoveredEntrance(u32 index, u32 bit);
 void Multiplayer_Send_UnlockedDoor(u32 flag);

--- a/code/src/savefile.c
+++ b/code/src/savefile.c
@@ -11,8 +11,9 @@
 #include "permadeath.h"
 #include "gloom.h"
 
-#define DECLARE_EXTSAVEDATA
 #include "savefile.h"
+
+ExtSaveData gExtSaveData;
 
 void SaveFile_Init(u32 fileBaseIndex) {
 #ifdef ENABLE_DEBUG

--- a/code/src/savefile.h
+++ b/code/src/savefile.h
@@ -85,14 +85,7 @@ typedef struct {
     s8 option_FreeCamControl;
 } ExtSaveData;
 
-#ifdef DECLARE_EXTSAVEDATA
-    #define EXTERN
-#else
-    #define EXTERN extern
-#endif
-
-EXTERN ExtSaveData gExtSaveData;
-
+extern ExtSaveData gExtSaveData;
 extern u32 gFinalPlaytimeSeconds;
 
 #endif //_SAVEFILE_H_


### PR DESCRIPTION
This changes the Multiplayer Full Sync to work correctly with any size of the `ExtInf` struct, by splitting it up into parts of at most 0x400 bits to be synced individually. The amount of parts isn't hardcoded, it will be dynamically computed at compile time. The `mp_completeSyncs` array is expanded to include all the ExtInf parts, and the type of the `neededPacketsMask` sent over the network is changed to a struct of the correct size to have at least 1 bit for each FullSync part.

On the current build there is only 1 ExtInf part, but I tested increasing the size to have more parts and it would look like this:

https://github.com/user-attachments/assets/335a67ba-f9b1-4220-8199-7ffaff00b58c

