### PR TITLE
Update version string management

### DIFF
--- a/.github/workflows/checks.yml
+++ b/.github/workflows/checks.yml
@@ -30,4 +30,6 @@ jobs:
       uses: actions/checkout@v4.1.3
 
     - name: Compile Project
-      run: make -j
+      run: |
+        chmod +x write_version.sh
+        make -j

--- a/.github/workflows/create_build.yml
+++ b/.github/workflows/create_build.yml
@@ -49,13 +49,12 @@ jobs:
         uses: actions/checkout@v4.1.3
 
       - name: Run Build Script
+        env:
+          GITHUB_BUILD_TYPE: ${{ github.event.inputs.build_type }}
+          GITHUB_INPUT_VERSION: ${{ github.event.inputs.version }}
         run: |
-          chmod +x linux_build_rando.sh
+          chmod +x linux_build_rando.sh write_version.sh
           ./linux_build_rando.sh
-
-      - name: Get shorthand commit.
-        id: vars
-        run: echo "sha_short=$(echo ${{ github.sha }} | cut -c1-6)" >> $GITHUB_ENV
 
       - if: ${{ github.event.inputs.build_type == 'Nightly' }}
         name: Create Pre-release
@@ -65,18 +64,18 @@ jobs:
           artifacts: "OoT3D_Randomizer.cia,OoT3D_Randomizer.3dsx,cia.png,3dsx.png"
           prerelease: true
           commit: "${{ github.sha }}"
-          tag: "Nightly-${{ env.sha_short }}"
-          name: "Nightly-${{ env.sha_short }}"
+          tag: "${{ env.tag_name }}"
+          name: "${{ env.tag_name }}"
           body: |
             Please note that these are DEVELOPMENT builds and may not be entirely stable.
             When reporting issues, please mention the six character commit listed in the randomizer menu.
             You can use the FBI homebrew application to install the randomizer using either of these QR codes.
             CIA QR Code:
-            ![CIA Download](https://github.com/${{ github.repository }}/releases/download/Nightly-${{ env.sha_short }}/cia.png)
+            ![CIA Download](https://github.com/${{ github.repository }}/releases/download/${{ env.tag_name }}/cia.png)
             3DSX QR Code:
-            ![CIA Download](https://github.com/${{ github.repository }}/releases/download/Nightly-${{ env.sha_short }}/3dsx.png)
+            ![3DSX Download](https://github.com/${{ github.repository }}/releases/download/${{ env.tag_name }}/3dsx.png)
 
-            Changes Since [${{ needs.get-changelog.outputs.last-nightly }}](https://github.com/${{ github.repository }}/releases/tag/${{ needs.get-changelog.outputs.last-nightly }}) 🛠:  
+            Changes Since [${{ needs.get-changelog.outputs.last-nightly }}](https://github.com/${{ github.repository }}/releases/tag/${{ needs.get-changelog.outputs.last-nightly }}) 🛠:
             ${{ needs.get-changelog.outputs.changelog }}
 
 
@@ -88,18 +87,18 @@ jobs:
           artifacts: "OoT3D_Randomizer.cia,OoT3D_Randomizer.3dsx,cia.png,3dsx.png"
           prerelease: false
           commit: "${{ github.sha }}"
-          tag: "v${{ github.event.inputs.version }}"
-          name: "v${{ github.event.inputs.version }}"
+          tag: "${{ env.tag_name }}"
+          name: "${{ env.tag_name }}"
           body: |
             ${{ github.event.inputs.version }} Changes:
             - Please check back later for a full list of changes.
-            
+
             When reporting issues, please mention the six character commit listed in the randomizer menu.
             You can use the FBI homebrew application to install the randomizer using either of these QR codes.
             CIA QR Code:
-            ![CIA Download](https://github.com/${{ github.repository }}/releases/download/Nightly-${{ env.sha_short }}/cia.png)
+            ![CIA Download](https://github.com/${{ github.repository }}/releases/download/${{ env.tag_name }}/cia.png)
             3DSX QR Code:
-            ![CIA Download](https://github.com/${{ github.repository }}/releases/download/Nightly-${{ env.sha_short }}/3dsx.png)
+            ![3DSX Download](https://github.com/${{ github.repository }}/releases/download/${{ env.tag_name }}/3dsx.png)
 
   deploy-gist:
     needs: build-cia-3dsx
@@ -407,7 +406,7 @@ jobs:
           sed -i "s#<REV_NUMBER>#$REVISION#g" OoT3DR.unistore
           LINES=$(cat ciaDownloads.txt)
           LINENUM=1
-          IFS=$'\n' 
+          IFS=$'\n'
           for LINE in $LINES
           do
               LINE=`sed -e 's/^"//' -e 's/"$//' <<<"$LINE"`

--- a/.gitignore
+++ b/.gitignore
@@ -19,4 +19,5 @@ build/*
 *.ips
 *.zar
 source/patch_symbols*
+version.hpp
 .DS_Store

--- a/Makefile
+++ b/Makefile
@@ -185,6 +185,7 @@ endif
 
 #---------------------------------------------------------------------------------
 app: create_basecode $(BUILD) $(GFXBUILD) $(DEPSDIR) $(ROMFS_T3XFILES) $(T3XHFILES)
+	@$(TOPDIR)/write_version.sh
 	@rm -fr $(TARGET).3dsx
 	@$(PYTHON) generate_patch_symbols.py
 	@$(MAKE) --no-print-directory -C $(BUILD) -f $(CURDIR)/Makefile

--- a/linux_build_rando.sh
+++ b/linux_build_rando.sh
@@ -1,16 +1,15 @@
 #!/bin/bash
 
+set -e
+
 compile() {
-  # If building manually just replace SHA with your own text.
-  export commitHashShort=$(echo ${GITHUB_SHA::6})
-  sed -i "s/develop/${commitHashShort:-develop}/" ./source/randomizer.hpp
   make -j
   bannertoolexec makebanner -i ./banner.png -a ./audio.wav -o ./banner.bnr
   bannertoolexec makesmdh -s "Ocarina of Time 3D Randomizer" -l "A different Ocarina of Time experience" -p "Gamestabled & Gymnast86" -i icon.png -o ./icon.icn
   3dstool -cvtf romfs ./romfs.bin --romfs-dir ./romfs
   makerom -f cia -o OoT3D_Randomizer.cia -DAPP_ENCRYPTED=false -target t -exefslogo -elf ./OoT3D_Randomizer.elf -icon ./icon.icn -banner ./banner.bnr -rsf ./ootrando.rsf -romfs ./romfs.bin -major 1 -minor 1 -micro 1
-  qrencode -ocia.png https://github.com/$GITHUB_REPOSITORY/releases/download/Nightly-$commitHashShort/OoT3D_Randomizer.cia
-  qrencode -o3dsx.png https://github.com/$GITHUB_REPOSITORY/releases/download/Nightly-$commitHashShort/OoT3D_Randomizer.3dsx
+  qrencode -ocia.png https://github.com/$GITHUB_REPOSITORY/releases/download/$TAG_NAME/OoT3D_Randomizer.cia
+  qrencode -o3dsx.png https://github.com/$GITHUB_REPOSITORY/releases/download/$TAG_NAME/OoT3D_Randomizer.3dsx
   ls -la
 }
 

--- a/source/globals.cpp
+++ b/source/globals.cpp
@@ -1,0 +1,4 @@
+#include <string>
+#include "version.hpp"
+
+std::string RandomizerVersion = RANDOMIZER_VERSION;

--- a/source/globals.hpp
+++ b/source/globals.hpp
@@ -1,0 +1,3 @@
+#include <string>
+
+extern std::string RandomizerVersion;

--- a/source/menu.cpp
+++ b/source/menu.cpp
@@ -11,8 +11,7 @@
 #include "menu.hpp"
 #include "patch.hpp"
 #include "preset.hpp"
-#include "randomizer.hpp"
-#include "settings.hpp"
+#include "globals.hpp"
 #include "spoiler_log.hpp"
 #include "location_access.hpp"
 #include "debug.hpp"
@@ -34,7 +33,7 @@ void PrintTopScreen() {
     consoleSelect(&topScreen);
     consoleClear();
     printf("\x1b[2;11H%sOcarina of Time 3D Randomizer%s", CYAN, RESET);
-    printf("\x1b[3;18H%s%s-%s%s", CYAN, RANDOMIZER_VERSION, COMMIT_NUMBER, RESET);
+    printf("\x1b[3;18H%s%s%s", CYAN, RandomizerVersion.c_str(), RESET);
     printf("\x1b[4;10HA/B/D-pad: Navigate Menu\n");
     printf("            Select: Exit to Homebrew Menu\n");
     printf("                 Y: New Random Seed\n");

--- a/source/randomizer.hpp
+++ b/source/randomizer.hpp
@@ -1,4 +1,0 @@
-#pragma once
-
-#define RANDOMIZER_VERSION "v4.0"
-#define COMMIT_NUMBER "develop"

--- a/source/settings.cpp
+++ b/source/settings.cpp
@@ -9,7 +9,7 @@
 #include "music.hpp"
 #include "sound_effects.hpp"
 #include "random.hpp"
-#include "randomizer.hpp"
+#include "globals.hpp"
 #include "descriptions.hpp"
 #include "trial.hpp"
 #include "keys.hpp"
@@ -27,7 +27,6 @@ using namespace SFX;
 
 namespace Settings {
 std::string seed;
-std::string version = RANDOMIZER_VERSION "-" COMMIT_NUMBER;
 std::array<u8, 5> hashIconIndexes;
 
 std::vector<std::string> NumOpts(int min, int max, int step = 1, std::string textBefore = {},

--- a/source/settings.hpp
+++ b/source/settings.hpp
@@ -356,7 +356,6 @@ bool ValidateSettings();
 std::string TitleId();
 
 extern std::string seed;
-extern std::string version;
 extern std::array<u8, 5> hashIconIndexes;
 
 extern Option OpenForest;

--- a/source/spoiler_log.cpp
+++ b/source/spoiler_log.cpp
@@ -13,6 +13,7 @@
 #include "gold_skulltulas.hpp"
 #include "enemizer.hpp"
 #include "ocarina_notes.hpp"
+#include "globals.hpp"
 
 #include <3ds.h>
 #include <cstdio>
@@ -848,7 +849,7 @@ bool SpoilerLog_Write() {
     auto rootNode = spoilerLog.NewElement("spoiler-log");
     spoilerLog.InsertEndChild(rootNode);
 
-    rootNode->SetAttribute("version", Settings::version.c_str());
+    rootNode->SetAttribute("version", RandomizerVersion.c_str());
     rootNode->SetAttribute("seed", Settings::seed.c_str());
     rootNode->SetAttribute("hash", GetRandomizerHashAsString().c_str());
     rootNode->SetAttribute("xmlns:h", "http://www.w3.org/1999/xhtml");
@@ -901,7 +902,7 @@ bool PlacementLog_Write() {
     auto rootNode = placementLog.NewElement("placement-log");
     placementLog.InsertEndChild(rootNode);
 
-    rootNode->SetAttribute("version", Settings::version.c_str());
+    rootNode->SetAttribute("version", RandomizerVersion.c_str());
     rootNode->SetAttribute("seed", Settings::seed.c_str());
     rootNode->SetAttribute("hash", GetRandomizerHashAsString().c_str());
 

--- a/write_version.sh
+++ b/write_version.sh
@@ -1,0 +1,38 @@
+#!/bin/bash
+
+# This script creates the name for the release git tag and the version string to show in the randomizer menu.
+# It generates a header file with a macro for the version string.
+
+VERSION_FILE="source/version.hpp"
+
+if [[ -n $GITHUB_ENV ]]
+then
+    # Building from GitHub Actions
+    # GITHUB_BUILD_TYPE and GITHUB_INPUT_VERSION are defined in `create_build.yml`
+
+    if [[ "$GITHUB_BUILD_TYPE" = "Release" ]]
+    then
+        VERSION="v$GITHUB_INPUT_VERSION"
+    else
+        VERSION="$GITHUB_BUILD_TYPE-${GITHUB_SHA::6}"
+    fi
+    echo "tag_name=$VERSION" >> $GITHUB_ENV
+else
+    # Building locally
+    VERSION=dev-$(git show --no-patch --format=format:"%h" --abbrev=6)
+
+    # If there are uncommitted changes, add a `*` to the version.
+    if [[ -n $(git status --porcelain) ]]
+    then
+        VERSION="${VERSION}*"
+    fi
+fi
+
+# If the version string doesn't change, don't rewrite the file to avoid useless rebuilds.
+NEW_CONTENT="#define RANDOMIZER_VERSION \"$VERSION\""
+OLD_CONTENT="$(cat "$VERSION_FILE" 2> /dev/null || true)"
+if [[ "$NEW_CONTENT" != "$OLD_CONTENT" ]]
+then
+    echo "$NEW_CONTENT" > "$VERSION_FILE"
+    echo "Wrote version string: $VERSION"
+fi


### PR DESCRIPTION
This changes how the version string displayed in the app is computed, making the process more automatic.

The new bash script `write_version.sh` generates a header file with a macro for the version string, handling both the GitHub Action inputs and the local build:
- for Release versions, the string will be like 'vX.Y', without the commit SHA which was previously included;
- for Nightly versions, it will be 'Nightly-xxxxxx' with the commit SHA (previously it was 'vX.Y-xxxxxx');
- for local builds, it will be 'dev-xxxxxx' with the commit SHA, instead of the previous hardcoded 'v4.0-develop'.

A couple of issues are also fixed:
- the `linux_build_rando.sh` script will now error out if a build step fails, so the Action will properly terminate.
- the descriptions for Release versions will show the correct QR codes images (previously the URL was mistakenly including the word 'Nightly')
