### PR TITLE
Improve GitHub Actions

### DIFF
--- a/.github/workflows/checks.yml
+++ b/.github/workflows/checks.yml
@@ -1,5 +1,12 @@
 name: OoT3DR Checks
 
+env:
+  # These are used automatically by git
+  GIT_AUTHOR_NAME: ${{ github.actor }}
+  GIT_AUTHOR_EMAIL: ${{ github.actor_id }}+${{ github.actor }}@users.noreply.github.com
+  GIT_COMMITTER_NAME: GitHub Actions
+  GIT_COMMITTER_EMAIL: 41898282+github-actions[bot]@users.noreply.github.com
+
 on:
   pull_request:
 
@@ -29,7 +36,25 @@ jobs:
     - name: Checkout Project
       uses: actions/checkout@v6.0.2
 
+    - name: Set Env Vars
+      shell: bash
+      run: |
+        pr_number=$(echo ${{ github.ref }} | cut -d / -f 3)
+        echo pr_number="$pr_number" | tee -a $GITHUB_ENV
+        short_sha=${GITHUB_SHA::6}
+        echo short_sha="$short_sha" | tee -a $GITHUB_ENV
+        echo artifact_name=OoT3D_Randomizer_PR"$pr_number"_"$short_sha" | tee -a $GITHUB_ENV
+
     - name: Compile Project
+      env:
+        GITHUB_BUILD_TYPE: "PR${{ env.pr_number }}"
       run: |
         chmod +x write_version.sh
         make -j
+        mv -v OoT3D_Randomizer.3dsx ${{ env.artifact_name }}.3dsx
+
+    - name: Upload Artifact
+      uses: actions/upload-artifact@v6
+      with:
+        name: ${{ env.artifact_name }}
+        path: ${{ env.artifact_name }}.3dsx

--- a/.github/workflows/checks.yml
+++ b/.github/workflows/checks.yml
@@ -10,7 +10,7 @@ jobs:
 
     steps:
     - name: Checkout Project
-      uses: actions/checkout@v4.1.3
+      uses: actions/checkout@v6.0.2
 
     - name: Format Project
       uses: DoozyX/clang-format-lint-action@v0.15
@@ -27,7 +27,7 @@ jobs:
 
     steps:
     - name: Checkout Project
-      uses: actions/checkout@v4.1.3
+      uses: actions/checkout@v6.0.2
 
     - name: Compile Project
       run: |

--- a/.github/workflows/clang_format_code.yml
+++ b/.github/workflows/clang_format_code.yml
@@ -1,5 +1,11 @@
-name: Code Linting On Push To Main and Development
+name: Code Linting
 
+env:
+  # These are used automatically by git
+  GIT_AUTHOR_NAME: ${{ github.actor }}
+  GIT_AUTHOR_EMAIL: ${{ github.actor_id }}+${{ github.actor }}@users.noreply.github.com
+  GIT_COMMITTER_NAME: GitHub Actions
+  GIT_COMMITTER_EMAIL: 41898282+github-actions[bot]@users.noreply.github.com
 
 on:
   workflow_dispatch:
@@ -9,8 +15,8 @@ on:
       - development
 
 jobs:
-  auto-formatter-on-main:
-    name: Auto Format Code and Commit If Any Changes
+  auto-formatter:
+    name: Auto Format Code
     runs-on: ubuntu-latest
 
     steps:
@@ -24,13 +30,10 @@ jobs:
         style: file
         inplace: True
 
-    - uses: EndBug/add-and-commit@v9.1.4
-      with:
-        committer_name: GitHub Actions
-        committer_email: 41898282+github-actions[bot]@users.noreply.github.com
-        message: |
-          Run automatic format script as code does not match clang format rules.
-
-          Developers please rebase to avoid merge conflicts!
-      env:
-        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+    - name: Add and commit
+      run: |
+        git add --all
+        if ! git diff --cached --quiet; then
+          git commit -m "Auto-format code to match clang rules"
+          git push
+        fi

--- a/.github/workflows/clang_format_code.yml
+++ b/.github/workflows/clang_format_code.yml
@@ -14,7 +14,7 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-    - uses: actions/checkout@v4.1.3
+    - uses: actions/checkout@v6.0.2
 
     - uses: DoozyX/clang-format-lint-action@v0.15
       with:

--- a/.github/workflows/create_build.yml
+++ b/.github/workflows/create_build.yml
@@ -20,7 +20,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout Project
-        uses: actions/checkout@v4.1.3
+        uses: actions/checkout@v6.0.2
         with:
           fetch-depth: 0
       - name: Get Last Nightly
@@ -29,7 +29,7 @@ jobs:
           echo "last_nightly=$(git describe --tags $(git rev-list --tags --max-count=1))" >> $GITHUB_ENV
       - name: Generate changelog
         id: changelog
-        uses: metcalfc/changelog-generator@v4.3.1
+        uses: metcalfc/changelog-generator@v4.7.0
         with:
           myToken: ${{ secrets.GITHUB_TOKEN }}
           base-ref: ${{ env.last_nightly }}
@@ -41,12 +41,14 @@ jobs:
     needs: get-changelog
     name: Build CIA and 3DSX Files
     runs-on: ubuntu-latest
+    permissions:
+      contents: write
     container:
       image: ghcr.io/z3dr/randotools:latest
 
     steps:
       - name: Checkout Project
-        uses: actions/checkout@v4.1.3
+        uses: actions/checkout@v6.0.2
 
       - name: Run Build Script
         env:
@@ -58,7 +60,7 @@ jobs:
 
       - if: ${{ github.event.inputs.build_type == 'Nightly' }}
         name: Create Pre-release
-        uses: ncipollo/release-action@v1.14.0
+        uses: ncipollo/release-action@v1.21.0
         with:
           token: "${{ secrets.GITHUB_TOKEN }}"
           artifacts: "OoT3D_Randomizer.cia,OoT3D_Randomizer.3dsx,cia.png,3dsx.png"
@@ -81,7 +83,7 @@ jobs:
 
       - if: ${{ github.event.inputs.build_type == 'Release' }}
         name: Create Release
-        uses: ncipollo/release-action@v1.14.0
+        uses: ncipollo/release-action@v1.21.0
         with:
           token: "${{ secrets.GITHUB_TOKEN }}"
           artifacts: "OoT3D_Randomizer.cia,OoT3D_Randomizer.3dsx,cia.png,3dsx.png"

--- a/.github/workflows/create_build.yml
+++ b/.github/workflows/create_build.yml
@@ -1,5 +1,12 @@
 name: OoT3DR Builds
 
+env:
+  # These are used automatically by git
+  GIT_AUTHOR_NAME: ${{ github.actor }}
+  GIT_AUTHOR_EMAIL: ${{ github.actor_id }}+${{ github.actor }}@users.noreply.github.com
+  GIT_COMMITTER_NAME: GitHub Actions
+  GIT_COMMITTER_EMAIL: 41898282+github-actions[bot]@users.noreply.github.com
+
 on:
   workflow_dispatch:
     inputs:
@@ -103,6 +110,7 @@ jobs:
             ![3DSX Download](https://github.com/${{ github.repository }}/releases/download/${{ env.tag_name }}/3dsx.png)
 
   deploy-gist:
+    if: ${{ github.repository == 'gamestabled/OoT3D_Randomizer' }}
     needs: build-cia-3dsx
     runs-on: ubuntu-latest
     steps:
@@ -433,9 +441,16 @@ jobs:
           done
 
       - name: Deploy to Gist
-        uses: exuanbo/actions-deploy-gist@v1.1.4
-        with:
-          token: ${{ secrets.TOKEN }}
-          gist_id: fa5ea9b42b99377c63bede1cf8ddfdad
-          gist_file_name: OoT3DR.unistore
-          file_path: ./OoT3DR.unistore
+        env:
+          GIST_ID: fa5ea9b42b99377c63bede1cf8ddfdad
+          GIST_FILE_NAME: OoT3DR.unistore
+          GIST_ACCESS_TOKEN: ${{ secrets.TOKEN }}
+        run: |
+          git clone https://$GIST_ACCESS_TOKEN@gist.github.com/$GIST_ID.git gist
+          cp ./$GIST_FILE_NAME ./gist/
+          cd gist
+          git add --all
+          if ! git diff --cached --quiet; then
+            git commit -m "Update UniStore"
+            git push
+          fi


### PR DESCRIPTION
- Update dependencies to latest version to run on Node.js 24, fixing warnings about deprecation of Node.js 20 actions
  - `actions/checkout@v6.0.2`,
  - `metcalfc/changelog-generator@v4.7.0`,
  - `ncipollo/release-action@v1.21.0` (now requires explicit `contents: write` permission)
- Drop dependencies on `exuanbo/actions-deploy-gist` and `EndBug/add-and-commit` as those operations are easy to implement with simple shell commands, and the first one doesn't run on Node.js 24 on its latest version.
- Make the `deploy-gist` job run only on the main repo, so that making a Release from a fork won't show this step as failed.
- Change the message for the formatting commit to be shorter ("Auto-format code to match clang rules"); I think this is better considering it should essentially never appear on the main branch with the PR checks currently in place.
- Add a step to the `Confirm Compilable` job to upload the artifact built during the PR check, so it can be downloaded from the Checks tab on the PR page.