### PR TITLE
Fix: center version string

### DIFF
--- a/source/menu.cpp
+++ b/source/menu.cpp
@@ -33,7 +33,8 @@ void PrintTopScreen() {
     consoleSelect(&topScreen);
     consoleClear();
     printf("\x1b[2;11H%sOcarina of Time 3D Randomizer%s", CYAN, RESET);
-    printf("\x1b[3;18H%s%s%s", CYAN, RandomizerVersion.c_str(), RESET);
+    int verCol = (50 - RandomizerVersion.length()) / 2 + 1;
+    printf("\x1b[3;%dH%s%s%s", verCol, CYAN, RandomizerVersion.c_str(), RESET);
     printf("\x1b[4;10HA/B/D-pad: Navigate Menu\n");
     printf("            Select: Exit to Homebrew Menu\n");
     printf("                 Y: New Random Seed\n");


### PR DESCRIPTION
I forgot to center the version string on the screen in #811. The position now needs to be computed dynamically because the string can be of different lengths.