### PR TITLE
Add cosmetic option for Ganon/dorf's blood colour

### DIFF
--- a/code/oot.ld
+++ b/code/oot.ld
@@ -851,6 +851,8 @@ SECTIONS
 	gRandFloat = 0x50C0C8 + _LD_OFF;
 	NaviColorsArray = 0x50C998 + _LD_OFF;
 	gActorOverlayTable = 0x50CD84 + _LD_OFF;
+	gGanondorfBlood = 0x514F78 + _LD_OFF;
+	gGanonBlood = 0x515194 + _LD_OFF;
 	EnChanger_LoserGetItemIds = 0x521774 + _LD_OFF;
 	VanillaScrubTable = 0x522384 + _LD_OFF;
 	EnGirlA_ShopItemEntries = 0x524F50 + _LD_OFF;

--- a/code/src/effects.c
+++ b/code/src/effects.c
@@ -4,7 +4,10 @@
 #include "objects.h"
 
 void initGanonBloodColors(void) {
-    typedef struct { Color_RGBA8 primary; Color_RGBA8 environ; } BloodCol;
+    typedef struct {
+        Color_RGBA8 primary;
+        Color_RGBA8 environ;
+    } BloodCol;
     extern BloodCol gGanondorfBlood, gGanonBlood;
     Color_RGBA8 col = gSettingsContext.ganonBloodColor;
     gGanondorfBlood = gGanonBlood = (BloodCol){ col, col };

--- a/code/src/effects.c
+++ b/code/src/effects.c
@@ -3,6 +3,13 @@
 #include "colors.h"
 #include "objects.h"
 
+void initGanonBloodColors(void) {
+    typedef struct { Color_RGBA8 primary; Color_RGBA8 environ; } BloodCol;
+    extern BloodCol gGanondorfBlood, gGanonBlood;
+    Color_RGBA8 col = gSettingsContext.ganonBloodColor;
+    gGanondorfBlood = gGanonBlood = (BloodCol){ col, col };
+}
+
 // This function is called when a new effect element tries to spawn but there's no space left.
 // The vanilla game simply fails to spawn the new element, but with the randomizer extended duration setting,
 // it is best to clear the oldest element to make space instead.

--- a/code/src/effects.c
+++ b/code/src/effects.c
@@ -3,7 +3,8 @@
 #include "colors.h"
 #include "objects.h"
 
-void initGanonBloodColors(void) {
+void Effects_Init(void) {
+    // Blood effect color for Ganondorf and Ganon defeat cutscenes
     typedef struct {
         Color_RGBA8 primary;
         Color_RGBA8 environ;

--- a/code/src/effects.h
+++ b/code/src/effects.h
@@ -3,6 +3,7 @@
 
 #include "z3D/z3D.h"
 
+void initGanonBloodColors(void);
 void EffectSs_ClearAllWithMissingObject(void);
 
 #endif //_EFFECTS_H_

--- a/code/src/effects.h
+++ b/code/src/effects.h
@@ -3,7 +3,7 @@
 
 #include "z3D/z3D.h"
 
-void initGanonBloodColors(void);
+void Effects_Init(void);
 void EffectSs_ClearAllWithMissingObject(void);
 
 #endif //_EFFECTS_H_

--- a/code/src/main.c
+++ b/code/src/main.c
@@ -40,7 +40,7 @@ void Randomizer_Init() {
     IceTrap_Init();
     extDataInit();
     irrstInit();
-    initGanonBloodColors();
+    Effects_Init();
 
     s64 output = 0;
     svcGetSystemInfo(&output, 0x20000, 0);

--- a/code/src/main.c
+++ b/code/src/main.c
@@ -3,6 +3,7 @@
 #include "actor.h"
 #include "input.h"
 #include "models.h"
+#include "effects.h"
 #include "entrance.h"
 #include "settings.h"
 #include "title_screen.h"
@@ -39,6 +40,7 @@ void Randomizer_Init() {
     IceTrap_Init();
     extDataInit();
     irrstInit();
+    initGanonBloodColors();
 
     s64 output = 0;
     svcGetSystemInfo(&output, 0x20000, 0);

--- a/shared/s_settings.h
+++ b/shared/s_settings.h
@@ -490,6 +490,13 @@ typedef enum TrailDuration {
     TRAILDURATION_LIGHTSABER,
 } TrailDuration;
 
+typedef enum BloodColor {
+    BLOODCOLOR_VANILLA,
+    BLOODCOLOR_ORIGINAL,
+    BLOODCOLOR_RANDOM,
+    BLOODCOLOR_CUSTOM,
+} BloodColor;
+
 typedef enum MirrorWorld {
     MIRRORWORLD_OFF,
     MIRRORWORLD_ON,
@@ -713,6 +720,7 @@ typedef struct SettingsContext {
     u8 rainbowChuTrailInnerColor;
     u8 rainbowChuTrailOuterColor;
     u8 bombchuTrailDuration;
+    Color_RGBA8 ganonBloodColor;
 
     u8 coloredKeys;
     u8 coloredBossKeys;

--- a/shared/s_settings.h
+++ b/shared/s_settings.h
@@ -490,13 +490,6 @@ typedef enum TrailDuration {
     TRAILDURATION_LIGHTSABER,
 } TrailDuration;
 
-typedef enum BloodColor {
-    BLOODCOLOR_VANILLA,
-    BLOODCOLOR_ORIGINAL,
-    BLOODCOLOR_RANDOM,
-    BLOODCOLOR_CUSTOM,
-} BloodColor;
-
 typedef enum MirrorWorld {
     MIRRORWORLD_OFF,
     MIRRORWORLD_ON,

--- a/source/cosmetics.cpp
+++ b/source/cosmetics.cpp
@@ -144,6 +144,22 @@ const std::array<std::string_view, 13> weaponTrailColors = {
     "FF69B4", // Pink
     "FF0000", // Rainbow (starts at red)
 };
+const std::array<std::string_view, 14> ganonBloodColors = {
+    "007800", // Vanilla Green
+    "780000", // Original Red
+    "FFFFFF", // White
+    "000000", // Black
+    "FF0000", // Red
+    "00FF00", // Green
+    "0000FF", // Blue
+    "FFFF00", // Yellow
+    "00FFFF", // Cyan
+    "FF00FF", // Magenta
+    "FFA500", // Orange
+    "FFD700", // Gold
+    "800080", // Purple
+    "FF69B4", // Pink
+};
 
 // Generate random hex color
 std::string RandomColor() {

--- a/source/cosmetics.hpp
+++ b/source/cosmetics.hpp
@@ -28,6 +28,7 @@ extern const std::array<std::string_view, 29> tunicColors;
 extern const std::array<std::string_view, 20> naviInnerColors;
 extern const std::array<std::string_view, 20> naviOuterColors;
 extern const std::array<std::string_view, 13> weaponTrailColors;
+extern const std::array<std::string_view, 14> ganonBloodColors;
 
 bool ValidHexString(std::string_view hexStr);
 Color_RGBAf HexStrToColorRGBAf(const std::string& hexStr);

--- a/source/settings.cpp
+++ b/source/settings.cpp
@@ -3091,17 +3091,18 @@ static void UpdateCosmetics() {
     }
     // Ganon/dorf Blood
     switch (Settings::GanonBloodColor.Value<u8>()) {
-    case BLOODCOLOR_VANILLA:
-        finalGanonBloodColor = (Color_RGBA8){ 0, 120, 0, 255 };
-        break;
-    case BLOODCOLOR_ORIGINAL:
-        finalGanonBloodColor = (Color_RGBA8){ 120, 0, 0, 255 };
-        break;
-    case BLOODCOLOR_RANDOM:
-        finalGanonBloodColor = Cosmetics::HexStrToColorRGBA8(RandomColor());
-        break;
-    case BLOODCOLOR_CUSTOM:
-        finalGanonBloodColor = Cosmetics::HexStrToColorRGBA8(GetCustomColor(Settings::GanonBloodColor.GetSelectedOptionText()));
+        case BLOODCOLOR_VANILLA:
+            finalGanonBloodColor = (Color_RGBA8){ 0, 120, 0, 255 };
+            break;
+        case BLOODCOLOR_ORIGINAL:
+            finalGanonBloodColor = (Color_RGBA8){ 120, 0, 0, 255 };
+            break;
+        case BLOODCOLOR_RANDOM:
+            finalGanonBloodColor = Cosmetics::HexStrToColorRGBA8(RandomColor());
+            break;
+        case BLOODCOLOR_CUSTOM:
+            finalGanonBloodColor =
+                Cosmetics::HexStrToColorRGBA8(GetCustomColor(Settings::GanonBloodColor.GetSelectedOptionText()));
     }
 }
 

--- a/source/settings.cpp
+++ b/source/settings.cpp
@@ -1268,6 +1268,7 @@ Option BoomerangTrailDuration     = Option::U8  (2, "Boomerang (Duration)",  tra
 Option BombchuTrailInnerColor     = Option::U8  (2, "Bombchu (Inner Color)", weaponTrailInnerOptionNames,   {RANDOM_CHOICE_DESC, RANDOM_COLOR_DESC, CUSTOM_COLOR_DESC, "Select the color for the center of the\nbombchu trail."},                                             OptionCategory::Cosmetic,                      5); // Red
 Option BombchuTrailOuterColor     = Option::U8  (2, "Bombchu (Outer Color)", weaponTrailOuterOptionNames,   {RANDOM_CHOICE_DESC, RANDOM_COLOR_DESC, CUSTOM_COLOR_DESC, "Select the color for the sides of the\nbombchu trail."},                                              OptionCategory::Cosmetic,    SAME_AS_INNER_TRAIL);
 Option BombchuTrailDuration       = Option::U8  (2, "Bombchu (Duration)",    chuTrailDurationOptionNames,   {"Select the duration for bombchu trails."},                                                                                                                      OptionCategory::Cosmetic,                      2); // Vanilla
+Option GanonBloodColor            = Option::U8  ("Ganon/dorf Blood Color",   {"Vanilla Green", "Original Red", std::string(RANDOM_COLOR_STR), std::string(CUSTOM_COLOR_STR),}, {"Select the color of Ganondorf and Ganon's blood."},                                          OptionCategory::Cosmetic);
 std::string finalChildTunicColor      = ChildTunicColor.GetSelectedOptionText();
 std::string finalKokiriTunicColor     = KokiriTunicColor.GetSelectedOptionText();
 std::string finalGoronTunicColor      = GoronTunicColor.GetSelectedOptionText();
@@ -1288,6 +1289,7 @@ Color_RGBA8 finalBoomerangColor = {0};
 u8 boomerangTrailColorMode = 0;
 std::string finalChuTrailInnerColor   = BombchuTrailInnerColor.GetSelectedOptionText();
 std::string finalChuTrailOuterColor   = BombchuTrailOuterColor.GetSelectedOptionText();
+Color_RGBA8 finalGanonBloodColor = { 0, 120, 0, 255 };
 
 Option ColoredKeys         = Option::Bool("Colored Small Keys",     {"Off", "On"},                                {coloredKeysDesc},                                                                                                                                  OptionCategory::Cosmetic);
 Option ColoredBossKeys     = Option::Bool("Colored Boss Keys",      {"Off", "On"},                                {coloredBossKeysDesc},                                                                                                                              OptionCategory::Cosmetic);
@@ -1322,6 +1324,7 @@ std::vector<Option *> cosmeticOptions = {
     &BombchuTrailInnerColor,
     &BombchuTrailOuterColor,
     &BombchuTrailDuration,
+    &GanonBloodColor,
     &ColoredKeys,
     &ColoredBossKeys,
     &MirrorWorld,
@@ -1684,6 +1687,7 @@ SettingsContext FillContext() {
     ctx.rainbowChuTrailInnerColor   = (BombchuTrailInnerColor.Value<u8>() == RAINBOW_TRAIL) ? 1 : 0;
     ctx.rainbowChuTrailOuterColor   = (BombchuTrailOuterColor.Value<u8>() == RAINBOW_TRAIL) ? 1 : 0;
     ctx.bombchuTrailDuration        = BombchuTrailDuration.Value<u8>();
+    ctx.ganonBloodColor             = finalGanonBloodColor;
     ctx.mirrorWorld                 = MirrorWorld.Value<u8>();
     ctx.coloredKeys                 = (ColoredKeys) ? 1 : 0;
     ctx.coloredBossKeys             = (ColoredBossKeys) ? 1 : 0;
@@ -3084,6 +3088,20 @@ static void UpdateCosmetics() {
         finalChuTrailOuterColor = finalChuTrailInnerColor;
     } else {
         ChooseFinalColor(BombchuTrailOuterColor, finalChuTrailOuterColor, weaponTrailColors);
+    }
+    // Ganon/dorf Blood
+    switch (Settings::GanonBloodColor.Value<u8>()) {
+    case BLOODCOLOR_VANILLA:
+        finalGanonBloodColor = (Color_RGBA8){ 0, 120, 0, 255 };
+        break;
+    case BLOODCOLOR_ORIGINAL:
+        finalGanonBloodColor = (Color_RGBA8){ 120, 0, 0, 255 };
+        break;
+    case BLOODCOLOR_RANDOM:
+        finalGanonBloodColor = Cosmetics::HexStrToColorRGBA8(RandomColor());
+        break;
+    case BLOODCOLOR_CUSTOM:
+        finalGanonBloodColor = Cosmetics::HexStrToColorRGBA8(GetCustomColor(Settings::GanonBloodColor.GetSelectedOptionText()));
     }
 }
 

--- a/source/settings.cpp
+++ b/source/settings.cpp
@@ -1235,6 +1235,26 @@ static std::vector<std::string> chuTrailDurationOptionNames = {
     "Hero's Path",
 };
 
+static std::vector<std::string> ganonBloodOptionNames = {
+    std::string(RANDOM_CHOICE_STR),
+    std::string(RANDOM_COLOR_STR),
+    std::string(CUSTOM_COLOR_STR),
+    "Vanilla Green",
+    "Original Red",
+    "White",
+    "Black",
+    "Red",
+    "Green",
+    "Blue",
+    "Yellow",
+    "Cyan",
+    "Magenta",
+    "Orange",
+    "Gold",
+    "Purple",
+    "Pink",
+};
+
 static std::vector<std::string_view> cosmeticDescriptions = {
     RANDOM_CHOICE_DESC,
     RANDOM_COLOR_DESC,
@@ -1268,7 +1288,7 @@ Option BoomerangTrailDuration     = Option::U8  (2, "Boomerang (Duration)",  tra
 Option BombchuTrailInnerColor     = Option::U8  (2, "Bombchu (Inner Color)", weaponTrailInnerOptionNames,   {RANDOM_CHOICE_DESC, RANDOM_COLOR_DESC, CUSTOM_COLOR_DESC, "Select the color for the center of the\nbombchu trail."},                                             OptionCategory::Cosmetic,                      5); // Red
 Option BombchuTrailOuterColor     = Option::U8  (2, "Bombchu (Outer Color)", weaponTrailOuterOptionNames,   {RANDOM_CHOICE_DESC, RANDOM_COLOR_DESC, CUSTOM_COLOR_DESC, "Select the color for the sides of the\nbombchu trail."},                                              OptionCategory::Cosmetic,    SAME_AS_INNER_TRAIL);
 Option BombchuTrailDuration       = Option::U8  (2, "Bombchu (Duration)",    chuTrailDurationOptionNames,   {"Select the duration for bombchu trails."},                                                                                                                      OptionCategory::Cosmetic,                      2); // Vanilla
-Option GanonBloodColor            = Option::U8  ("Ganon/dorf Blood Color",   {"Vanilla Green", "Original Red", std::string(RANDOM_COLOR_STR), std::string(CUSTOM_COLOR_STR),}, {"Select the color of Ganondorf and Ganon's blood."},                                          OptionCategory::Cosmetic);
+Option GanonBloodColor            = Option::U8  ("Ganon/dorf Blood Color",   ganonBloodOptionNames,         {RANDOM_CHOICE_DESC, RANDOM_COLOR_DESC, CUSTOM_COLOR_DESC, "Select the color of Ganondorf and Ganon's blood."},                                                   OptionCategory::Cosmetic,                      3); // Vanilla Green
 std::string finalChildTunicColor      = ChildTunicColor.GetSelectedOptionText();
 std::string finalKokiriTunicColor     = KokiriTunicColor.GetSelectedOptionText();
 std::string finalGoronTunicColor      = GoronTunicColor.GetSelectedOptionText();
@@ -3090,20 +3110,8 @@ static void UpdateCosmetics() {
         ChooseFinalColor(BombchuTrailOuterColor, finalChuTrailOuterColor, weaponTrailColors);
     }
     // Ganon/dorf Blood
-    switch (Settings::GanonBloodColor.Value<u8>()) {
-        case BLOODCOLOR_VANILLA:
-            finalGanonBloodColor = (Color_RGBA8){ 0, 120, 0, 255 };
-            break;
-        case BLOODCOLOR_ORIGINAL:
-            finalGanonBloodColor = (Color_RGBA8){ 120, 0, 0, 255 };
-            break;
-        case BLOODCOLOR_RANDOM:
-            finalGanonBloodColor = Cosmetics::HexStrToColorRGBA8(RandomColor());
-            break;
-        case BLOODCOLOR_CUSTOM:
-            finalGanonBloodColor =
-                Cosmetics::HexStrToColorRGBA8(GetCustomColor(Settings::GanonBloodColor.GetSelectedOptionText()));
-    }
+    ChooseFinalColor(GanonBloodColor, tempString, ganonBloodColors);
+    finalGanonBloodColor = Cosmetics::HexStrToColorRGBA8(tempString);
 }
 
 // Function to set flags depending on settings


### PR DESCRIPTION
Options:
- Vanilla green (default)
- N64 1.0 red
- Random
- Custom