### PR TITLE
Fix QR code URLs

### DIFF
--- a/.github/workflows/create_build.yml
+++ b/.github/workflows/create_build.yml
@@ -65,6 +65,11 @@ jobs:
           chmod +x linux_build_rando.sh write_version.sh
           ./linux_build_rando.sh
 
+      - name: Create QR codes
+        run: |
+          qrencode -ocia.png https://github.com/$GITHUB_REPOSITORY/releases/download/${{ env.tag_name }}/OoT3D_Randomizer.cia
+          qrencode -o3dsx.png https://github.com/$GITHUB_REPOSITORY/releases/download/${{ env.tag_name }}/OoT3D_Randomizer.3dsx
+
       - if: ${{ github.event.inputs.build_type == 'Nightly' }}
         name: Create Pre-release
         uses: ncipollo/release-action@v1.21.0

--- a/linux_build_rando.sh
+++ b/linux_build_rando.sh
@@ -8,8 +8,6 @@ compile() {
   bannertoolexec makesmdh -s "Ocarina of Time 3D Randomizer" -l "A different Ocarina of Time experience" -p "Gamestabled & Gymnast86" -i icon.png -o ./icon.icn
   3dstool -cvtf romfs ./romfs.bin --romfs-dir ./romfs
   makerom -f cia -o OoT3D_Randomizer.cia -DAPP_ENCRYPTED=false -target t -exefslogo -elf ./OoT3D_Randomizer.elf -icon ./icon.icn -banner ./banner.bnr -rsf ./ootrando.rsf -romfs ./romfs.bin -major 1 -minor 1 -micro 1
-  qrencode -ocia.png https://github.com/$GITHUB_REPOSITORY/releases/download/$TAG_NAME/OoT3D_Randomizer.cia
-  qrencode -o3dsx.png https://github.com/$GITHUB_REPOSITORY/releases/download/$TAG_NAME/OoT3D_Randomizer.3dsx
   ls -la
 }
 


### PR DESCRIPTION
Move the creation of QR codes to a separate step in the GitHub action, as the `tag_name` environment variable is not readable from the same step it's created on.