### PR TITLE
Fixes spoiler item checks for Rupeesanity items when Rupeesanity is off.

### DIFF
--- a/source/spoiler_log.cpp
+++ b/source/spoiler_log.cpp
@@ -278,7 +278,8 @@ void WriteIngameSpoilerLog() {
             splrDatLoc->ItemLocations[spoilerItemIndex].RevealType  = REVEALTYPE_ALWAYS;
         }
         else if(loc->IsCategory(Category::cFreestandingRupee) && Settings::ShuffleRupees.Value<bool>() == false){
-            splrDatLoc->ItemLocations[spoilerItemIndex].CollectType = COLLECTTYPE_REPEATABLE;
+            
+            splrDatLoc->ItemLocations[spoilerItemIndex].CollectType = loc->GetFlag() >= 0x20 ? COLLECTTYPE_REPEATABLE : COLLECTTYPE_NORMAL;
             splrDatLoc->ItemLocations[spoilerItemIndex].RevealType  = REVEALTYPE_ALWAYS;
         }
 

--- a/source/spoiler_log.cpp
+++ b/source/spoiler_log.cpp
@@ -277,6 +277,10 @@ void WriteIngameSpoilerLog() {
             splrDatLoc->ItemLocations[spoilerItemIndex].CollectType = COLLECTTYPE_REPEATABLE;
             splrDatLoc->ItemLocations[spoilerItemIndex].RevealType  = REVEALTYPE_ALWAYS;
         }
+        else if(loc->IsCategory(Category::cFreestandingRupee) && Settings::ShuffleRupees.Value<bool>() == false){
+            splrDatLoc->ItemLocations[spoilerItemIndex].CollectType = COLLECTTYPE_REPEATABLE;
+            splrDatLoc->ItemLocations[spoilerItemIndex].RevealType  = REVEALTYPE_ALWAYS;
+        }
 
         auto checkGroup                                   = loc->GetCollectionCheckGroup();
         splrDatLoc->ItemLocations[spoilerItemIndex].Group = checkGroup;

--- a/source/spoiler_log.cpp
+++ b/source/spoiler_log.cpp
@@ -276,11 +276,11 @@ void WriteIngameSpoilerLog() {
                  Settings::Scrubsanity.Is(SCRUBSANITY_OFF)) {
             splrDatLoc->ItemLocations[spoilerItemIndex].CollectType = COLLECTTYPE_REPEATABLE;
             splrDatLoc->ItemLocations[spoilerItemIndex].RevealType  = REVEALTYPE_ALWAYS;
-        }
-        else if(loc->IsCategory(Category::cFreestandingRupee) && Settings::ShuffleRupees.Value<bool>() == false){
-            
-            splrDatLoc->ItemLocations[spoilerItemIndex].CollectType = loc->GetFlag() >= 0x20 ? COLLECTTYPE_REPEATABLE : COLLECTTYPE_NORMAL;
-            splrDatLoc->ItemLocations[spoilerItemIndex].RevealType  = REVEALTYPE_ALWAYS;
+        } else if (loc->IsCategory(Category::cFreestandingRupee) && Settings::ShuffleRupees.Value<bool>() == false) {
+
+            splrDatLoc->ItemLocations[spoilerItemIndex].CollectType =
+                loc->GetFlag() >= 0x20 ? COLLECTTYPE_REPEATABLE : COLLECTTYPE_NORMAL;
+            splrDatLoc->ItemLocations[spoilerItemIndex].RevealType = REVEALTYPE_ALWAYS;
         }
 
         auto checkGroup                                   = loc->GetCollectionCheckGroup();


### PR DESCRIPTION
Sets the spoiler checks of freestanding rupees to REVEALTYPE_ALWAYS if rupeesanity is off.

Clashes with #818
We should determine which one is preferrable