### PR TITLE
Skipped the free standing rupees in the ingame spoiler log when rupeesanity is disabled

### DIFF
--- a/source/spoiler_log.cpp
+++ b/source/spoiler_log.cpp
@@ -192,7 +192,7 @@ void WriteIngameSpoilerLog() {
                  (Settings::GerudoFortress.Is(GERUDOFORTRESS_FAST) && loc->IsCategory(Category::cVanillaGFSmallKey) &&
                   loc->GetHintKey() != GF_NORTH_F1_CARPENTER)) {
             continue;
-        } else if (loc->IsCategory(Category::cFreestandingRupee) && Settings::ShuffleRupees.Value<bool>() == false) {
+        } else if (loc->IsCategory(Category::cFreestandingRupee) && !Settings::ShuffleRupees) {
             continue;
         }
 

--- a/source/spoiler_log.cpp
+++ b/source/spoiler_log.cpp
@@ -192,7 +192,9 @@ void WriteIngameSpoilerLog() {
                  (Settings::GerudoFortress.Is(GERUDOFORTRESS_FAST) && loc->IsCategory(Category::cVanillaGFSmallKey) &&
                   loc->GetHintKey() != GF_NORTH_F1_CARPENTER)) {
             continue;
-        } else if (loc->IsCategory(Category::cFreestandingRupee) && !Settings::ShuffleRupees) {
+        }
+        // Freestanding Rupees
+        else if (loc->IsCategory(Category::cFreestandingRupee) && !Settings::ShuffleRupees) {
             continue;
         }
 

--- a/source/spoiler_log.cpp
+++ b/source/spoiler_log.cpp
@@ -192,8 +192,7 @@ void WriteIngameSpoilerLog() {
                  (Settings::GerudoFortress.Is(GERUDOFORTRESS_FAST) && loc->IsCategory(Category::cVanillaGFSmallKey) &&
                   loc->GetHintKey() != GF_NORTH_F1_CARPENTER)) {
             continue;
-        }
-        else if(loc->IsCategory(Category::cFreestandingRupee) && Settings::ShuffleRupees.Value<bool>() == false){
+        } else if (loc->IsCategory(Category::cFreestandingRupee) && Settings::ShuffleRupees.Value<bool>() == false) {
             continue;
         }
 

--- a/source/spoiler_log.cpp
+++ b/source/spoiler_log.cpp
@@ -193,6 +193,9 @@ void WriteIngameSpoilerLog() {
                   loc->GetHintKey() != GF_NORTH_F1_CARPENTER)) {
             continue;
         }
+        else if(loc->IsCategory(Category::cFreestandingRupee) && Settings::ShuffleRupees.Value<bool>() == false){
+            continue;
+        }
 
         // Copy at most 51 chars from the name and location name to avoid issues with names that don't fit on screen
         // Only copy enough characters that can fit on the screen


### PR DESCRIPTION
Removes the ingame spoiler log locations for the freestanding rupees when rupeesanity is disabled.

Clashes with #817 
We should determine which one is preferrable.