### PR TITLE
Allow backtracking after Dampé's race

### DIFF
--- a/code/oot.ld
+++ b/code/oot.ld
@@ -284,6 +284,7 @@ SECTIONS
 	.patch_Item00GiveCollectedItemDrop 0x22B974 + _LD_OFF : { *(.patch_Item00GiveCollectedItemDrop) }
 	.patch_patch_ItemGiveBombchuDropTwo 0x22BAE4 + _LD_OFF : { *(.patch_ItemGiveBombchuDropTwo) }
 	.patch_GetObjectEntry_EnNutsballInit 0x22DEC4 + _LD_OFF : { *(.patch_GetObjectEntry_EnNutsballInit) }
+	EnPoRelay_Destroy = 0x22E438 + _LD_OFF;
 	EnShopnuts_Init = 0x22ED2C + _LD_OFF;
 	.patch_BusinessScrubCheckFlags 0x22EE64 + _LD_OFF : { *(.patch_BusinessScrubCheckFlags) }
 	EnTorch2_Update = 0x22F0C8 + _LD_OFF;

--- a/code/src/actor.c
+++ b/code/src/actor.c
@@ -245,6 +245,8 @@ void Actor_Init() {
 
     gActorOverlayTable[0x11D].initInfo->type = ACTORTYPE_ENEMY; // Flying Pot
 
+    gActorOverlayTable[0x122].initInfo->destroy = EnPoRelay_rDestroy;
+
     gActorOverlayTable[0x126].initInfo->init   = ObjBean_rInit;
     gActorOverlayTable[0x126].initInfo->update = ObjBean_rUpdate;
 

--- a/code/src/actors/dampe.c
+++ b/code/src/actors/dampe.c
@@ -1,5 +1,9 @@
 #include "dampe.h"
 
+/*-------------------------------
+|              EnTk             |
+-------------------------------*/
+
 void EnTk_Update(Actor* thisx, GlobalContext* globalCtx);
 
 void EnTk_rUpdate(Actor* thisx, GlobalContext* globalCtx) {
@@ -16,8 +20,31 @@ void EnTk_SetRewardFlag(EnTk* dampe) {
     dampe->currentReward = 4;
 }
 
+/*-------------------------------
+|           EnPoRelay           |
+-------------------------------*/
+
+void EnPoRelay_Destroy(Actor* thisx, GlobalContext* globalCtx);
+
+void EnPoRelay_rDestroy(Actor* thisx, GlobalContext* globalCtx) {
+    EnPoRelay_Destroy(thisx, globalCtx);
+
+    // Despawn previous doors when finishing the race with Dampé.
+    Actor* bgActor = globalCtx->actorCtx.actorList[ACTORTYPE_BG].first;
+    while (bgActor != NULL) {
+        if (bgActor->id == ACTOR_WINDMILL_OBJECTS && bgActor->world.pos.z < -1800.0) {
+            Actor_Kill(bgActor);
+        }
+        bgActor = bgActor->next;
+    }
+    // Set temp flags to enable loading triggers.
+    Flags_SetSwitch(globalCtx, 0x35);
+    Flags_SetSwitch(globalCtx, 0x36);
+    Flags_SetSwitch(globalCtx, 0x37);
+}
+
 // Checks the clear flag for the first race (chest spawned, not opened)
 // Replaces a check for hookshot in the inventory
 void EnPoRelay_CheckChestFlag(EnPoRelay* dampe) {
-    dampe->unk_B1C = ((gSaveContext.sceneFlags[0x48].clear & 0x00000010) != 0);
+    dampe->isSecondRace = ((gSaveContext.sceneFlags[0x48].clear & 0x00000010) != 0);
 }

--- a/code/src/actors/dampe.h
+++ b/code/src/actors/dampe.h
@@ -3,16 +3,30 @@
 
 #include "z3D/z3D.h"
 
-typedef struct {
-    /* 0x000 */ char unk_00[0xBA8];
-    /* 0xBA8 */ u32 currentReward;
-} EnTk;
+/*-------------------------------
+|              EnTk             |
+-------------------------------*/
 
-typedef struct {
-    /* 0x000 */ char unk_00[0xB1C];
-    /* 0xB1C */ u8 unk_B1C;
-} EnPoRelay;
+typedef struct EnTk {
+    /* 0x000 */ char unk_000[0xBA8];
+    /* 0xBA8 */ u32 currentReward;
+    /* 0xBAC */ char unk_BAC[0x654];
+} EnTk;
+_Static_assert(sizeof(EnTk) == 0x1200, "EnTk size");
 
 void EnTk_rUpdate(Actor* thisx, GlobalContext* globalCtx);
 
-#endif
+/*-------------------------------
+|           EnPoRelay           |
+-------------------------------*/
+
+typedef struct EnPoRelay {
+    /* 0x000 */ char unk_000[0xB1C];
+    /* 0xB1C */ u8 isSecondRace;
+    /* 0xB1D */ char unk_B1D[0x253];
+} EnPoRelay;
+_Static_assert(sizeof(EnPoRelay) == 0xD70, "EnPoRelay size");
+
+void EnPoRelay_rDestroy(Actor* thisx, GlobalContext* globalCtx);
+
+#endif //_DAMPE_H_

--- a/shared/s_actor_id.h
+++ b/shared/s_actor_id.h
@@ -55,6 +55,7 @@ enum ActorId {
     ACTOR_SKULL_KID          = 0x115,
     ACTOR_FLYING_POT         = 0x11D,
     ACTOR_FREEZARD           = 0x121,
+    ACTOR_WINDMILL_OBJECTS   = 0x123,
     ACTOR_BG_JYA_IRONOBJ     = 0x169,
     ACTOR_STINGER_WATER      = 0x18C,
     ACTOR_HINT_DEKU_SCRUB    = 0x192,


### PR DESCRIPTION
This PR makes Dampé's ghost open all doors in his grave's maze after finishing the race, allowing the player to backtrack without worrying about the timer (e.g. to collect randomized rupees).