### PR TITLE
Fixed intermittent free camera crash

### DIFF
--- a/code/src/camera.c
+++ b/code/src/camera.c
@@ -255,6 +255,7 @@ void Camera_FreeCamUpdate(Vec3s* out, Camera* camera) {
             if (newSetting != camera->setting) {
                 camera->prevSetting = camera->setting;
                 camera->setting     = newSetting;
+                camera->mode        = 0; // Reset to CAM_MODE_NORMAL so won't read data OoB on switch back
             }
         }
     }


### PR DESCRIPTION
Different camera settings have a different number of modes so an edge case in which entering free cam with a high mode value and changing to a high setting value could read past the end of the mode table and lead to executing a null function pointer.