### PR TITLE
Fix trap fanfare for randomized music

### DIFF
--- a/code/src/bgm.c
+++ b/code/src/bgm.c
@@ -44,5 +44,7 @@ void Bgm_ApplyFanfareMod(void) {
     }
 
     // Linearly decrease pitch
-    gUnkSequencePlayerData[SEQ_PLAYER_FANFARE]->freq -= 0.009;
+    if (gUnkSequencePlayerData[SEQ_PLAYER_FANFARE]->freq > 0.28) {
+        gUnkSequencePlayerData[SEQ_PLAYER_FANFARE]->freq -= 0.009;
+    }
 }


### PR DESCRIPTION
This adds a lower bound to the pitch decrease for trap fanfares introduced in #813.

When I added that feature I didn't consider randomized music: if the random fanfare lasts much longer than the normal one, the pitch can reach negative values, which causes glitches with the sound volume and frequency. The new limit of 0.28 is the minimum value reached by the normal fanfare.