### PR TITLE
Fix equipment deletion patch

### DIFF
--- a/code/oot.ld
+++ b/code/oot.ld
@@ -507,7 +507,7 @@ SECTIONS
 	FaceAnim_Init = 0x35C358 + _LD_OFF;
 	.patch_Audio_PlayFanfare 0x35C528 + _LD_OFF : { *(.patch_Audio_PlayFanfare) }
 	Audio_PlayFanfare = 0x35C528 + _LD_OFF;
-	.patch_DeleteEquipment 0x35D1F8 + _LD_OFF : { *(.patch_DeleteEquipment) }
+	.patch_DeleteEquipment 0x35D1F4 + _LD_OFF : { *(.patch_DeleteEquipment) }
 	LinkDamage = 0x35D304 + _LD_OFF;
 	FireDamage = 0x35D8D8 + _LD_OFF;
 	Player_InBlockingCsMode = 0x35DB20 + _LD_OFF;

--- a/code/src/asm/hooks.s
+++ b/code/src/asm/hooks.s
@@ -1835,6 +1835,7 @@ HOOK DeleteEquipment
     cmp r0,#0x0
     pop {r0-r12, lr}
     strheq r2,[r12,#0xB6]
+    cmp r1,#0x2
     bx lr
 
 HOOK GetQuickItem

--- a/code/src/asm/patches.s
+++ b/code/src/asm/patches.s
@@ -1425,6 +1425,7 @@ PATCH TitleLinkObject
 
 PATCH DeleteEquipment
     bl hook_DeleteEquipment
+    nop
 
 PATCH GetQuickItem
     bl hook_GetQuickItem


### PR DESCRIPTION
Fix the patch added in #824 to override shield deletion, because it accidentally messed up condition flags for the following instructions, making the Master Sword stay equipped when Ganon knocks it out of the inventory.