### PR TITLE
Fixed GF key logic in fast setting

### DIFF
--- a/source/item_pool.cpp
+++ b/source/item_pool.cpp
@@ -723,10 +723,11 @@ void GenerateItemPool() {
         Location(GF_SOUTH_F2_CARPENTER)->PlaceVanillaItem();
     } else if (GerudoKeys.IsNot(GERUDOKEYS_VANILLA)) {
         if (GerudoFortress.Is(GERUDOFORTRESS_FAST)) {
+            // Placing junk in other guards so logic doesn't see them as a viable alternative to the shuffled key
             AddItemToMainPool(GERUDO_FORTRESS_SMALL_KEY);
-            Location(GF_NORTH_F2_CARPENTER)->PlaceVanillaItem();
-            Location(GF_SOUTH_F1_CARPENTER)->PlaceVanillaItem();
-            Location(GF_SOUTH_F2_CARPENTER)->PlaceVanillaItem();
+            PlaceItemInLocation(GF_NORTH_F2_CARPENTER, RECOVERY_HEART);
+            PlaceItemInLocation(GF_SOUTH_F1_CARPENTER, RECOVERY_HEART);
+            PlaceItemInLocation(GF_SOUTH_F2_CARPENTER, RECOVERY_HEART);
         } else {
             // Only add key ring if 4 Fortress keys necessary
             if (RingFortress) {
@@ -748,10 +749,11 @@ void GenerateItemPool() {
         }
     } else {
         if (GerudoFortress.Is(GERUDOFORTRESS_FAST)) {
+            // Placing junk in other guards so logic doesn't see them as a viable alternative for enemizer
             Location(GF_NORTH_F1_CARPENTER)->PlaceVanillaItem();
-            Location(GF_NORTH_F2_CARPENTER)->PlaceVanillaItem();
-            Location(GF_SOUTH_F1_CARPENTER)->PlaceVanillaItem();
-            Location(GF_SOUTH_F2_CARPENTER)->PlaceVanillaItem();
+            PlaceItemInLocation(GF_NORTH_F2_CARPENTER, RECOVERY_HEART);
+            PlaceItemInLocation(GF_SOUTH_F1_CARPENTER, RECOVERY_HEART);
+            PlaceItemInLocation(GF_SOUTH_F2_CARPENTER, RECOVERY_HEART);
         } else {
             Location(GF_NORTH_F1_CARPENTER)->PlaceVanillaItem();
             Location(GF_NORTH_F2_CARPENTER)->PlaceVanillaItem();


### PR DESCRIPTION
Reverted skipped guards' items to recovery hearts as they were before #820
Did not revert the items for the open setting as is inconsequential