### PR TITLE
Update handling of pending items in water

### DIFF
--- a/code/include/z3D/z3D.h
+++ b/code/include/z3D/z3D.h
@@ -734,7 +734,7 @@ void Flags_SetEnv(GlobalContext* globalCtx, s16 flag);
 void Actor_OfferGetItem(Actor* actor, GlobalContext* globalCtx, s32 getItemId, f32 xzRange, f32 yRange)
     __attribute__((pcs("aapcs-vfp")));
 void Message_CloseTextbox(GlobalContext* globalCtx);
-void SetupItemInWater(Player* player, GlobalContext* globalCtx);
+void Player_SetupGetItemOrHoldBehavior(Player* player, GlobalContext* globalCtx);
 void Health_ChangeBy(GlobalContext* arg1, u32 arg2);
 void Flags_SetSwitch(GlobalContext* globalCtx, u32 flag);
 void Flags_UnsetSwitch(GlobalContext* globalCtx, u32 flag);

--- a/code/include/z3D/z3Dactor.h
+++ b/code/include/z3D/z3Dactor.h
@@ -290,6 +290,16 @@ typedef struct DynaPolyActor {
     /* 0x1BA */ s16 unk_1BA;
 } DynaPolyActor; // size = 0x1BC
 
+typedef struct PlayerAgeProperties {
+    /* 0x000 */ f32 ceilingCheckHeight;
+    /* 0x004 */ char unk_004[0x02C];
+    /* 0x030 */ f32 idleDepthInWater;
+    /* 0x034 */ char unk_034[0x004];
+    /* 0x038 */ f32 wallCheckRadius;
+    /* 0x03C */ char unk_03C[0x0F8];
+} PlayerAgeProperties;
+_Static_assert(sizeof(PlayerAgeProperties) == 0x134, "PlayerAgeProperties size");
+
 struct Player;
 
 typedef void (*PlayerActionFunc)(struct Player*, struct GlobalContext*);
@@ -340,7 +350,7 @@ typedef struct Player {
     /* 0x15E8 */ Collider unkMeleeWeaponCollider;
     /* 0x1600 */ char unk_1600[0x108];
     /* 0x1708 */ PlayerActionFunc actionFunc;
-    /* 0x170C */ char unk_170C[0x0004];
+    /* 0x170C */ PlayerAgeProperties* ageProperties;
     /* 0x1710 */ u32 stateFlags1;
     /* 0x1714 */ u32 stateFlags2;
     /* 0x1718 */ Actor* unk_1718;
@@ -376,6 +386,11 @@ typedef struct Player {
     /* 0x28CC */ char unk_28CC[0x180];
 } Player; // total size (from init vars): 2A4C
 _Static_assert(sizeof(Player) == 0x2A4C, "Player size");
+
+#define PLAYER_STATE1_GETTING_ITEM (1 << 10)
+#define PLAYER_STATE1_SUBMERGED (1 << 27)
+
+#define PLAYER_STATE2_UNDERWATER (1 << 10)
 
 extern s32 sFloorType;
 

--- a/code/include/z3D/z3Dequipment.h
+++ b/code/include/z3D/z3Dequipment.h
@@ -17,4 +17,12 @@ typedef enum EquipValueShield {
     EQUIP_VALUE_SHIELD_MAX,
 } EquipValueShield;
 
+typedef enum EquipValueBoots {
+    EQUIP_VALUE_BOOTS_NONE,
+    EQUIP_VALUE_BOOTS_KOKIRI,
+    EQUIP_VALUE_BOOTS_IRON,
+    EQUIP_VALUE_BOOTS_HOVER,
+    EQUIP_VALUE_BOOTS_MAX,
+} EquipValueBoots;
+
 #endif //_Z3DEQUIPMENT_H_

--- a/code/oot.ld
+++ b/code/oot.ld
@@ -493,7 +493,7 @@ SECTIONS
 	.patch_GetObjectEntry_353CE4 0x353CE4 + _LD_OFF : { *(.patch_GetObjectEntry_353CE4) }
 	Collider_SetCylinder = 0x353D24 + _LD_OFF;
 	Collider_InitCylinder = 0x353DD0 + _LD_OFF;
-	SetupItemInWater = 0x354894 + _LD_OFF;
+	Player_SetupGetItemOrHoldBehavior = 0x354894 + _LD_OFF;
 	.patch_GetQuickItem 0x354AB0 + _LD_OFF : { *(.patch_GetQuickItem) }
 	.patch_FastChests 0x354CD4 + _LD_OFF : { *(.patch_FastChests) }
 	.patch_AboutToPickUpActor 0x354DD8 + _LD_OFF : { *(.patch_AboutToPickUpActor) }
@@ -564,7 +564,7 @@ SECTIONS
 	SkeletonAnimationModel_Draw = 0x372170 + _LD_OFF;
 	SkeletonAnimationModel_MatrixCopy = 0x3721E0 + _LD_OFF;
 	Actor_OfferGetItem = 0x3724DC + _LD_OFF;
-	.patch_IncomingGetItemID 0x3725AC + _LD_OFF : { *(.patch_IncomingGetItemID) }
+	.patch_ActorGetItemOffer 0x3725AC + _LD_OFF : { *(.patch_ActorGetItemOffer) }
 	Message_CloseTextbox = 0x3725E0 + _LD_OFF;
 	Model_EnableMeshGroupByIndex = 0x37266C + _LD_OFF;
 	.patch_Model_EnableMeshGroupByIndex 0x372670 + _LD_OFF : { *(.patch_Model_EnableMeshGroupByIndex) }
@@ -728,7 +728,7 @@ SECTIONS
 	.patch_OcarinaNoteButtonsPress 0x41AAAC + _LD_OFF : { *(.patch_OcarinaNoteButtonsPress) }
 	.patch_CurseTrapDizzyStick 0x41AB24 + _LD_OFF : { *(.patch_CurseTrapDizzyStick) }
 	.patch_CurseTrapDizzyButtons 0x41ABD0 + _LD_OFF : { *(.patch_CurseTrapDizzyButtons) }
-	.patch_PermadeathSkipMenu 0x41C980 + _LD_OFF : { *(.patch_PermadeathSkipMenu) }
+	.patch_GameOverMenuSkip 0x41C980 + _LD_OFF : { *(.patch_GameOverMenuSkip) }
 	.patch_SaveMenuIgnoreOpen 0x42EC00 + _LD_OFF : { *(.patch_SaveMenuIgnoreOpen) }
 	.patch_ItemsMenuDraw 0x434C08 + _LD_OFF : { *(.patch_ItemsMenuDraw) }
 	.patch_PlayInit 0x4352F4 + _LD_OFF : { *(.patch_PlayInit) }
@@ -781,11 +781,10 @@ SECTIONS
 	.patch_GameOverDontSpoilTradeItems 0x458BE0 + _LD_OFF : { *(.patch_GameOverDontSpoilTradeItems) }
 	ret_GameOverDontSpoilTradeItems = 0x458CA0 + _LD_OFF;
 	.patch_DeathHandleBButton 0x458CA8 + _LD_OFF : { *(.patch_DeathHandleBButton) }
-	.patch_PermadeathForceQuit 0x458E20 + _LD_OFF : { *(.patch_PermadeathForceQuit) }
+	.patch_GameOverActionSelection 0x458E28 + _LD_OFF : { *(.patch_GameOverActionSelection) }
 	.patch_SetGameOverEntrance 0x458E3C + _LD_OFF : { *(.patch_SetGameOverEntrance) }
 	ret_SetGameOverEntrance = 0x458EC8 + _LD_OFF;
 	.patch_SetGameOverRespawnFlag 0x458EF0 + _LD_OFF : { *(.patch_SetGameOverRespawnFlag) }
-	ret_PermadeathForceQuit = 0x458FF4 + _LD_OFF;
 	.patch_InterfaceDrawDontSpoilTradeItems 0x45A17C + _LD_OFF : { *(.patch_InterfaceDrawDontSpoilTradeItems) }
 	ret_InterfaceDrawDontSpoilTradeItems = 0x45A210 + _LD_OFF;
 	.patch_TimerExpiration 0x45A948 + _LD_OFF : { *(.patch_TimerExpiration) }

--- a/code/src/asm/hooks.s
+++ b/code/src/asm/hooks.s
@@ -55,12 +55,12 @@ HOOK Gfx_AwakeCallback
     add r0,r0,#0x9C
     b 0x3FD440
 
-HOOK IncomingGetItemID
+HOOK ActorGetItemOffer
     push {r0-r12, lr}
     cpy r0,r5
     cpy r1,r6
     cpy r2,r7
-    bl ItemOverride_GetItem
+    bl ItemOverride_OfferGetItem
     pop {r0-r12, lr}
     bx lr
 
@@ -930,23 +930,23 @@ HOOK GameOverStart
     pop {r0-r12, lr}
     bx lr
 
-HOOK PermadeathSkipMenu
-    push {r0-r12, lr}
-    bl Permadeath_GetOption
+HOOK GameOverMenuSkip
+    push {r1-r12, lr}
+    bl GameOverMenu_ShouldSkip
     cmp r0,#0x0
-    pop {r0-r12, lr}
+    pop {r1-r12, lr}
     movne r0,#0x10
     moveq r0,#0x2
     bx lr
 
-HOOK PermadeathForceQuit
-    ldrbeq r8,[r11,#0x9]
+HOOK GameOverActionSelection
     bxne lr
-    push {r0-r12, lr}
-    bl Permadeath_GetOption
-    cmp r0,#0x0
-    pop {r0-r12, lr}
-    bne ret_PermadeathForceQuit
+    push {r0-r7, r9-r12, lr}
+    cpy r0,r8
+    bl GameOverMenu_OverrideAction
+    cpy r8,r0
+    pop {r0-r7, r9-r12, lr}
+    cmp r8,#0x1
     bx lr
 
 HOOK OverrideFogDuringGameplayInit

--- a/code/src/asm/patches.s
+++ b/code/src/asm/patches.s
@@ -18,9 +18,9 @@ PATCH after_GlobalContext_Update
 PATCH Gfx_Update
     b hook_Gfx_Update
 
-PATCH IncomingGetItemID
+PATCH ActorGetItemOffer
     str r5,[r4,#0x2B0]
-    bl hook_IncomingGetItemID
+    bl hook_ActorGetItemOffer
 
 PATCH SaveFile_Init
     bl hook_SaveFile_Init
@@ -1014,11 +1014,11 @@ PATCH SaveMenuIgnoreOpen
 PATCH GameOverStart
     bl hook_GameOverStart
 
-PATCH PermadeathSkipMenu
-    bl hook_PermadeathSkipMenu
+PATCH GameOverMenuSkip
+    bl hook_GameOverMenuSkip
 
-PATCH PermadeathForceQuit
-    bl hook_PermadeathForceQuit
+PATCH GameOverActionSelection
+    bl hook_GameOverActionSelection
 
 PATCH OverrideFogDuringGameplayInit
     bl hook_OverrideFogDuringGameplayInit

--- a/code/src/item_override.c
+++ b/code/src/item_override.c
@@ -19,8 +19,11 @@
 #include "z3D/actors/z_en_item00.h"
 #include "z3D/actors/z_obj_mure3.h"
 
-#define READY_ON_LAND 1
-#define READY_IN_WATER 2
+typedef enum Readiness {
+    NOT_READY,
+    READY_STANDING,
+    READY_SWIMMING,
+} Readiness;
 
 static ItemOverride rItemOverrides[640] = { 0 };
 static s32 rItemOverrides_Count         = 0;
@@ -34,9 +37,6 @@ ItemRow* rActiveItemRow                 = NULL;
 u8 isItemOverrideActive                 = FALSE;
 u8 rActiveItemChestType                 = 0;
 static u16 rActiveItemObjectId          = 0;
-
-static u8 rSatisfiedPendingFrames      = 0;
-static u8 rSatisfiedPendingFramesWater = 0;
 
 void ItemOverride_Init(void) {
     while (rItemOverrides[rItemOverrides_Count].key.all != 0) {
@@ -257,6 +257,11 @@ s32 ItemOverride_IsAPendingOverride(void) {
     return (rPendingOverrideQueue[0].key.all != 0);
 }
 
+Bool ItemOverride_IsPendingQueueFilled(void) {
+    u8 lastOvrIdx = ARR_SIZE(rPendingOverrideQueue) - 1;
+    return rPendingOverrideQueue[lastOvrIdx].key.all != 0;
+}
+
 void ItemOverride_PushDelayedOverride(u8 flag) {
     ItemOverride_Key key  = { .all = 0 };
     key.scene             = 0xFF;
@@ -331,15 +336,6 @@ static void ItemOverride_AfterKeyReceived(ItemOverride_Key key) {
     }
 }
 
-static void ItemOverride_PopIceTrap(void) {
-    ItemOverride* override = &rPendingOverrideQueue[0];
-    if (override->value.itemId == GI_ICE_TRAP) {
-        IceTrap_Push();
-        ItemOverride_PopPendingOverride();
-        ItemOverride_AfterKeyReceived(override->key);
-    }
-}
-
 void ItemOverride_AfterItemReceived(void) {
     ItemOverride_Key key = rActiveItemOverride.key;
     if (key.all == 0) {
@@ -348,74 +344,32 @@ void ItemOverride_AfterItemReceived(void) {
     ItemOverride_AfterKeyReceived(key);
 }
 
-static u32 ItemOverride_PlayerIsReadyOnLand(void) {
-    if ((PLAYER->stateFlags1 & 0xFCAC2485) == 0 && (PLAYER->actor.bgCheckFlags & 0x0001) &&
-        (PLAYER->stateFlags2 & 0x000C0000) == 0 && PLAYER->actor.draw != NULL &&
-        gGlobalContext->actorCtx.titleCtx.delayTimer == 0 && gGlobalContext->actorCtx.titleCtx.durationTimer == 0 &&
-        gGlobalContext->actorCtx.titleCtx.alpha == 0
-        // && (z64_event_state_1 & 0x20) == 0 //TODO
-        // && (z64_game.camera_2 == 0) //TODO
-    ) {
-        rSatisfiedPendingFrames++;
-    } else {
-        rSatisfiedPendingFrames = 0;
-    }
-    if (rSatisfiedPendingFrames >= 2) {
-        rSatisfiedPendingFrames = 0;
-        return 1;
-    }
-    return 0;
-}
+Readiness ItemOverride_CheckPlayerReadiness(void) {
+    // Check states that always prevent getting items
+    if ((PLAYER->stateFlags1 & 0xF4AC2485) == 0 && (PLAYER->stateFlags2 & 0x000C0000) == 0 &&
+        // prevent triggering traps while buying multiple items
+        (PLAYER->interactRangeActor == NULL || PLAYER->interactRangeActor->id != ACTOR_SHOPKEEPER) &&
+        PLAYER->actor.draw != NULL && gGlobalContext->actorCtx.titleCtx.delayTimer == 0 &&
+        gGlobalContext->actorCtx.titleCtx.durationTimer == 0 && gGlobalContext->actorCtx.titleCtx.alpha == 0 &&
+        gGlobalContext->sceneLoadFlag == 0) {
 
-static u32 ItemOverride_PlayerIsReadyInWater(void) {
-    if ((PLAYER->stateFlags1 & 0xF4AC2085) == 0 /*&& (PLAYER->actor.bgCheckFlags & 0x0001)*/ &&
-        (PLAYER->stateFlags2 & 0x000C0000) == 0 && PLAYER->actor.draw != NULL &&
-        gGlobalContext->actorCtx.titleCtx.delayTimer == 0 && gGlobalContext->actorCtx.titleCtx.durationTimer == 0 &&
-        gGlobalContext->actorCtx.titleCtx.alpha == 0 && (PLAYER->stateFlags1 & 0x08000000) != 0 && // Player is Swimming
-        (PLAYER->stateFlags1 & 0x400) == 0 && // Player is not already receiving an item when surfacing
-        gGlobalContext->sceneLoadFlag == 0 && // Another scene isn't about to be loaded
-        ItemOverride_IsAPendingOverride()
-        // && Multiworld is off
-        // && (z64_event_state_1 & 0x20) == 0 //TODO
-        // && (z64_game.camera_2 == 0) //TODO
-    ) {
-        rSatisfiedPendingFramesWater++;
-    } else {
-        rSatisfiedPendingFramesWater = 0;
-    }
-    if (rSatisfiedPendingFramesWater >= 2) {
-        rSatisfiedPendingFramesWater = 0;
-        return 1;
-    }
-    return 0;
-}
+        Bool isOnGround               = (PLAYER->actor.bgCheckFlags & BGCHECKFLAG_GROUND) != 0;
+        Bool isSubmerged              = (PLAYER->stateFlags1 & PLAYER_STATE1_SUBMERGED) != 0;
+        EquipValueBoots equippedBoots = gSaveContext.equips.equipment >> (EQUIP_TYPE_BOOTS * 4);
+        if (isOnGround && (!isSubmerged || equippedBoots == EQUIP_VALUE_BOOTS_IRON)) {
+            return READY_STANDING;
+        }
 
-static u32 ItemOverride_PlayerIsReady(void) {
-    if (ItemOverride_PlayerIsReadyOnLand()) {
-        return READY_ON_LAND;
-    }
-    if (ItemOverride_PlayerIsReadyInWater()) {
-        return READY_IN_WATER;
+        Bool isInWater = PLAYER->actor.depthInWater > 0.0;
+        Bool willResurfaceNextFrame =
+            PLAYER->actor.depthInWater - PLAYER->actor.velocity.y < PLAYER->ageProperties->idleDepthInWater;
+
+        if (isInWater && isSubmerged && (willResurfaceNextFrame || ItemOverride_IsPendingQueueFilled())) {
+            return READY_SWIMMING;
+        }
     }
 
-    return 0;
-}
-
-static void ItemOverride_TryPendingItem(void) {
-    ItemOverride override = rPendingOverrideQueue[0];
-
-    if (override.key.all == 0) {
-        return;
-    }
-
-    if (rDummyActor->parent == NULL) {
-        ItemOverride_Activate(override);
-        PLAYER->interactRangeActor = rDummyActor;
-        PLAYER->getItemId          = rActiveItemRow->baseItemId;
-    } else {
-        rDummyActor->parent = NULL;
-        ItemOverride_PopPendingOverride();
-    }
+    return NOT_READY;
 }
 
 void ItemOverride_Update(void) {
@@ -423,24 +377,47 @@ void ItemOverride_Update(void) {
     ItemOverride_CheckZeldasLetter();
     IceTrap_Update();
     CustomModel_Update();
-    u8 readyStatus = ItemOverride_PlayerIsReady();
-    if (readyStatus) {
-        IceTrap_UpdateOverride(&rPendingOverrideQueue[0], FALSE);
-        if (readyStatus == READY_ON_LAND) { // Ice traps effects only work on land
-            ItemOverride_PopIceTrap();
+
+    if (rDummyActor->parent != NULL) {
+        // A pending override was given on the previous frame and Player accepted it.
+        rDummyActor->parent = NULL;
+        ItemOverride_PopPendingOverride();
+    }
+
+    Readiness readiness = ItemOverride_CheckPlayerReadiness();
+    if (readiness != NOT_READY) {
+        ItemOverride* pendingOvr = &rPendingOverrideQueue[0];
+        IceTrap_UpdateOverride(pendingOvr, FALSE);
+        Bool trapGiven = FALSE;
+        // Some ice trap effects only work while standing normally on the ground, so we wait for that state to trigger
+        // them. A potential TODO for the future is to separate the effects that would work *swimmingly* even while
+        // swimming, like curses.
+        if (readiness == READY_STANDING) {
+            if (pendingOvr->value.itemId == GI_ICE_TRAP) {
+                IceTrap_Push();
+                ItemOverride_PopPendingOverride();
+                ItemOverride_AfterKeyReceived(pendingOvr->key);
+            }
+            if (IceTrap_IsPending()) {
+                IceTrap_Give();
+                trapGiven = TRUE;
+            }
         }
 
-        if (IceTrap_IsPending()) {
-            IceTrap_Give();
-        } else {
-            ItemOverride_TryPendingItem();
-            if (readyStatus == READY_IN_WATER) {
+        if (ItemOverride_IsAPendingOverride() && !trapGiven) {
+            ItemOverride_Activate(rPendingOverrideQueue[0]);
+
+            // Manually offer Get Item to player.
+            PLAYER->interactRangeActor = rDummyActor;
+            PLAYER->getItemId          = rActiveItemRow->baseItemId;
+
+            if (readiness == READY_SWIMMING) {
                 // Force underwater player flag in order to play the correct get-item
                 // animation even if Link is at the water's surface.
-                PLAYER->stateFlags2 |= 0x400;
-                SetupItemInWater(PLAYER, gGlobalContext);
-                rDummyActor->parent = NULL;
-                ItemOverride_PopPendingOverride();
+                PLAYER->stateFlags2 |= PLAYER_STATE2_UNDERWATER;
+                // The action handler for accepting get item offers is not normally called while
+                // swimming in the base game, so in this case we need to call it manually.
+                Player_SetupGetItemOrHoldBehavior(PLAYER, gGlobalContext);
             }
         }
     }
@@ -454,7 +431,8 @@ void ItemOverride_Update(void) {
     }
 }
 
-void ItemOverride_GetItem(Actor* fromActor, Player* player, s8 incomingItemId) {
+// Called from Actor_OfferGetItem
+void ItemOverride_OfferGetItem(Actor* fromActor, Player* player, s8 incomingItemId) {
     ItemOverride override = { 0 };
     s32 incomingNegative  = incomingItemId < 0;
 

--- a/code/src/menus.c
+++ b/code/src/menus.c
@@ -5,6 +5,7 @@
 #include "settings.h"
 #include "dungeon.h"
 #include "item_override.h"
+#include "permadeath.h"
 
 extern MenuSpriteManager* gItemsMenuSpritesManager;
 extern MenuSpriteManager* gBowMenuSpritesManager;
@@ -145,4 +146,20 @@ u16 SaveMenu_IgnoreOpen(void) {
     return ItemOverride_IsAPendingOverride() || // safety check to avoid missing pending overrides by save-warping
            (gSettingsContext.menuOpeningButton == 0 && rInputCtx.cur.sel) ||
            (gSettingsContext.menuOpeningButton == 1 && rInputCtx.cur.strt);
+}
+
+Bool GameOverMenu_ShouldSkip() {
+    return Permadeath_ShouldApply() || ItemOverride_IsAPendingOverride();
+}
+
+s32 GameOverMenu_OverrideAction(s32 originalAction) {
+    if (Permadeath_ShouldApply()) {
+        return 2; // pressed Quit button
+    }
+
+    if (ItemOverride_IsAPendingOverride()) {
+        return 1; // pressed Continue button
+    }
+
+    return originalAction;
 }

--- a/code/src/permadeath.c
+++ b/code/src/permadeath.c
@@ -2,7 +2,7 @@
 #include "settings.h"
 #include "savefile.h"
 
-u8 Permadeath_GetOption(void) {
+Bool Permadeath_ShouldApply(void) {
     // For safety, verify that the seed and save file was created with permadeath enabled
     // If Gloom is enabled and set to Death mode, only apply Permadeath when all hearts are gone.
     return gSettingsContext.permadeath && gExtSaveData.permadeath &&
@@ -12,7 +12,7 @@ u8 Permadeath_GetOption(void) {
 void SaveFile_Delete(u8 fileNum);
 
 void Permadeath_DeleteSave(void) {
-    if (!Permadeath_GetOption()) {
+    if (!Permadeath_ShouldApply()) {
         return;
     }
     SaveFile_Delete(gSaveContext.fileNum);

--- a/code/src/permadeath.h
+++ b/code/src/permadeath.h
@@ -1,6 +1,7 @@
 #ifndef _PERMADEATH_H_
 #define _PERMADEATH_H_
 
+Bool Permadeath_ShouldApply(void);
 void Permadeath_DeleteSave(void);
 
 #endif //_PERMADEATH_H_

--- a/shared/s_actor_id.h
+++ b/shared/s_actor_id.h
@@ -26,6 +26,7 @@ enum ActorId {
     ACTOR_SKULLTULA          = 0x037,
     ACTOR_TORCH_SLUG         = 0x038,
     ACTOR_STINGER_FLOOR      = 0x03A,
+    ACTOR_SHOPKEEPER         = 0x03D,
     ACTOR_MOBLIN             = 0x04B,
     ACTOR_PHANTOM_GANON      = 0x052,
     ACTOR_ARMOS              = 0x054,


### PR DESCRIPTION
This changes pending overrides to trigger the GetItem offer in water only when resurfacing. This allows getting multiple major items from underwater rupees with a single dive, and also allows controlling Link after the WaT blue warp if you spawn in water instead of just having to wait for him to float up (for example you could equip iron boots to receive the item faster).

I changed the Player readiness checks to look at the distance from the water surface before returning `READY_SWIMMING`. I chose to remove the wait for 2 consecutive frames of readiness, because it felt more natural with the added velocity check. I have played through a seed to test all uses of pending items and everything works (hopefully I didn't miss any).

I refactored the GameOver menu skip introduced for PermaDeath, to make it automatically choose "Continue" if the player dies while a pending override is queued.

I've also made some minor refactors to the rDummyActor code so the flow is clearer.