### PR TITLE
Fix void out with overworld spawn out of a grotto

### DIFF
--- a/code/src/grotto.c
+++ b/code/src/grotto.c
@@ -182,6 +182,10 @@ static s8 grottoId                     = 0xFF;
 static s8 lastEntranceType             = NOT_GROTTO;
 static u8 overridingNextEntrance       = FALSE;
 
+Bool Grotto_ReturnedFromGrotto() {
+    return lastEntranceType == GROTTO_RETURN;
+}
+
 // Initialize both lists so that each index refers to itself. An index referring
 // to itself means that the entrance is not shuffled. Indices will be overwritten
 // later in Entrance_Init() in entrance.c if entrance shuffle is enabled.
@@ -270,7 +274,7 @@ s16 Grotto_CheckSpecialEntrance(s16 nextEntranceIndex) {
         gSaveContext.respawn[RESPAWN_MODE_RETURN].data = grotto.content;
         nextEntranceIndex                              = grotto.entranceIndex;
 
-        lastEntranceType = NOT_GROTTO;
+        lastEntranceType = GROTTO_LOAD;
         // Otherwise just unset the current grotto ID
     } else {
         grottoId         = 0xFF;

--- a/code/src/grotto.h
+++ b/code/src/grotto.h
@@ -23,6 +23,7 @@ typedef struct {
     Vec3f pos;
 } GrottoReturnInfo;
 
+Bool Grotto_ReturnedFromGrotto();
 void Grotto_InitExitAndLoadLists(void);
 void Grotto_SetExitOverride(s16 originalIndex, s16 overrideIndex);
 void Grotto_SetLoadOverride(s16 originalIndex, s16 overrideIndex);

--- a/code/src/savefile.c
+++ b/code/src/savefile.c
@@ -11,6 +11,7 @@
 #include "permadeath.h"
 #include "gloom.h"
 #include "alert.h"
+#include "grotto.h"
 
 #include "savefile.h"
 
@@ -873,6 +874,11 @@ void SaveFile_AfterLoadGame(void) {
         (gSaveContext.dungeonItems[DUNGEON_GANONS_TOWER] & 1) == 0) {
 
         ItemOverride_PushHardcodedItem(GI_GANON_BOSS_KEY);
+    }
+    // If the randomized overworld spawn is a grotto return point, restore the entrance index
+    // in the void out respawn point because the game sets it to -1 when loading a file.
+    if (Grotto_ReturnedFromGrotto()) {
+        gSaveContext.respawn[RESPAWN_MODE_DOWN].entranceIndex = gSaveContext.entranceIndex;
     }
 }
 


### PR DESCRIPTION
This fixes the latest crash reported on Discord.

When coming out of a grotto, the game does not set the void out respawn point. Normally the Randomizer already handles it, so that when the grotto entrance is randomized, the respawn point is updated anyway.
But when loading a save file, the game sets the entrance index stored in the respawn data to -1, after the Randomizer code writes it: https://github.com/zeldaret/oot/blob/cbe814b25455f14a343a7457c4b1c92af40ede6a/src/overlays/gamestates/ovl_file_choose/z_file_choose.c#L1888
So if you load a file, spawn out of a grotto and then void out, the game will either go back to the Title Screen if the respawn point's room index is 0, or crash otherwise.

The easy fix implemented here is to reset the respawn point's entrance index after the file load completes.
