### PR TITLE
Skip having to trigger Zelda escape cutscene

### DIFF
--- a/code/oot.ld
+++ b/code/oot.ld
@@ -611,6 +611,7 @@ SECTIONS
 	.patch_AltHeadersCommand 0x379020 + _LD_OFF : { *(.patch_AltHeadersCommand) }
 	EnWonderTalk2_Update = 0x3794EC + _LD_OFF;
 	Actor_KillAllWithMissingObject = 0x379C3C + _LD_OFF;
+	BgSpot00Hanebasi_Destroy = 0x37B324 + _LD_OFF;
 	.patch_EnFrSetupFrogSongTimerMultiplier 0x381204 + _LD_OFF : { *(.patch_EnFrSetupFrogSongTimerMultiplier) }
 	BgSpot02Objects_Update = 0x3831AC + _LD_OFF;
 	BgSpot06Objects_Update = 0x3833F8 + _LD_OFF;

--- a/code/src/actor.c
+++ b/code/src/actor.c
@@ -168,7 +168,8 @@ void Actor_Init() {
 
     gActorOverlayTable[0x3E].initInfo->init = BgTreemouth_rInit;
 
-    gActorOverlayTable[0x4A].initInfo->update = BgSpot00Hanebasi_rUpdate;
+    gActorOverlayTable[0x4A].initInfo->update  = BgSpot00Hanebasi_rUpdate;
+    gActorOverlayTable[0x4A].initInfo->destroy = BgSpot00Hanebasi_rDestroy;
 
     gActorOverlayTable[0x4B].initInfo->init   = EnMb_rInit;
     gActorOverlayTable[0x4B].initInfo->update = EnMb_rUpdate;

--- a/code/src/actors/drawbridge.c
+++ b/code/src/actors/drawbridge.c
@@ -2,6 +2,7 @@
 #include "drawbridge.h"
 
 void BgSpot00Hanebasi_Update(Actor* thisx, GlobalContext* globalCtx);
+void BgSpot00Hanebasi_Destroy(Actor* thisx, GlobalContext* globalCtx);
 
 void BgSpot00Hanebasi_rUpdate(Actor* thisx, GlobalContext* globalCtx) {
 
@@ -10,4 +11,14 @@ void BgSpot00Hanebasi_rUpdate(Actor* thisx, GlobalContext* globalCtx) {
         gSaveContext.nextCutsceneIndex = 0;
     }
     BgSpot00Hanebasi_Update(thisx, globalCtx);
+}
+
+void BgSpot00Hanebasi_rDestroy(Actor* thisx, GlobalContext* globalCtx) {
+    BgSpot00Hanebasi_Destroy(thisx, globalCtx);
+
+    u8 hasAllStones = (gSaveContext.questItems >> 18 & 0b111) == 0b111;
+    if (hasAllStones) {
+        // Set flag for zelda escape cutscene in case the last stone was obtained in Hyrule Field.
+        gSaveContext.eventChkInf[8] |= 0x0001;
+    }
 }

--- a/code/src/actors/drawbridge.h
+++ b/code/src/actors/drawbridge.h
@@ -4,5 +4,6 @@
 #include "z3D/z3D.h"
 
 void BgSpot00Hanebasi_rUpdate(Actor* thisx, GlobalContext* globalCtx);
+void BgSpot00Hanebasi_rDestroy(Actor* thisx, GlobalContext* globalCtx);
 
 #endif //_DRAWBRIDGE_H_

--- a/code/src/item_effect.c
+++ b/code/src/item_effect.c
@@ -398,6 +398,10 @@ void ItemEffect_Shield(SaveContext* saveCtx, s16 shieldEquipValue, s16 arg2) {
 void ItemEffect_GiveStone(SaveContext* saveCtx, s16 mask, s16 arg2) {
     s32 trueMask = mask << 16;
     saveCtx->questItems |= trueMask;
+    u8 hasAllStones = (saveCtx->questItems >> 18 & 0b111) == 0b111;
+    if (hasAllStones && (gGlobalContext->sceneNum != SCENE_HYRULE_FIELD || gSaveContext.linkAge == AGE_ADULT)) {
+        gSaveContext.eventChkInf[8] |= 0x0001; // watched zelda escape cutscene
+    }
 }
 
 void ItemEffect_GiveMedallion(SaveContext* saveCtx, s16 mask, s16 arg2) {


### PR DESCRIPTION
Mark the Zelda escape cutscene as watched when obtaining the 3rd spiritual stone, so that the next time the player visits Hyrule Field, the ocarina will already be in the moat.

More specifically:
- if the 3rd stone is obtained outside HF or as adult, the cutscene will immediately be set as watched;
- if the 3rd stone is obtained in HF as child, the drawbridge will wait for the player to approach (this is unchanged behavior), then
  - if the player approaches, the behavior is unchanged, so the cutscene triggers and the area reloads in the "ocarina in moat" layer;
  - if the player leaves HF, the cutscene will be set as watched by the bridge destroy function;
  - if the player savewarps, the behavior is unchanged, the cutscene will still need to be triggered.