### PR TITLE
Add Forest Temple Stalfos to Enemy Randomizer

### DIFF
--- a/code/include/z3D/z3D.h
+++ b/code/include/z3D/z3D.h
@@ -529,6 +529,30 @@ typedef struct GameState {
 } GameState;
 _Static_assert(sizeof(GameState) == 0x104, "GameState size");
 
+typedef struct Room {
+    /* 0x000 */ s8 num;
+    /* 0x001 */ u8 unk_01;
+    /* 0x002 */ u8 environmentType;
+    /* 0x003 */ u8 type;
+    /* 0x004 */ s8 echo;
+    /* 0x005 */ u8 lensMode;
+    /* 0x006 */ u8 isDrawn;      // new in 3D
+    /* 0x007 */ u8 visuallyHot;  // new in 3D
+    /* 0x008 */ void* roomShape; // maybe?
+    /* 0x00C */ void* segment;   // maybe?
+    /* 0x010 */ char unk_010[0x3CC];
+} Room;
+_Static_assert(sizeof(Room) == 0x3DC, "Room size");
+
+typedef struct RoomContext {
+    /* 0x000 */ Room curRoom;
+    /* 0x3DC */ Room prevRoom;
+    /* 0x7B8 */ char unk_7B8[0x19];
+    /* 0x7D1 */ s8 status;
+    /* 0x7D2 */ char unk_7D2[0x786];
+} RoomContext;
+_Static_assert(sizeof(RoomContext) == 0xF58, "RoomContext size");
+
 // Global Context (ram start: 0871E840)
 typedef struct GlobalContext {
     /* 0x0000 */ GameState state;
@@ -574,8 +598,11 @@ typedef struct GlobalContext {
     /* 0x3234 */ char unk_3234[0x0824];
     /* 0x3A58 */ ObjectContext objectCtx;
     /* 0x43DC */ char unk_43DC[0x0854];
-    /* 0x4C30 */ s8 roomNum;
-    /* 0x4C31 */ char unk_4C31[0x0FCB];
+    /* 0x4C30 */ union {
+        RoomContext roomCtx;
+        s8 roomNum; // shorthand for roomCtx.curRoom.num
+    };
+    /* 0x5B88 */ char unk_5B88[0x0074];
     /* 0x5BFC */ u32 gameplayFrames;
     /* 0x5C00 */ u8 linkAgeOnLoad;
     /* 0x5C01 */ u8 unk_5C01;

--- a/code/include/z3D/z3Dbgcheck.h
+++ b/code/include/z3D/z3Dbgcheck.h
@@ -160,5 +160,6 @@ f32 BgCheck_RaycastDown1(CollisionContext* colCtx, CollisionPoly* outGroundPoly,
     __attribute__((pcs("aapcs-vfp")));
 s32 BgCheck_EntityLineTest1(CollisionContext* colCtx, Vec3f* posA, Vec3f* posB, Vec3f* posResult,
                             CollisionPoly** outPoly, s32 chkWall, s32 chkFloor, s32 chkCeil, s32 chkOneFace, s32* bgId);
+void DynaPoly_UpdateContext(struct GlobalContext* global_ctx, DynaCollisionContext* dyna);
 
 #endif //_Z3DBGCHECK_H

--- a/code/oot.ld
+++ b/code/oot.ld
@@ -379,6 +379,7 @@ SECTIONS
 	.patch_PierreSoftlockFixTwo 0x288914 + _LD_OFF : { *(.patch_PierreSoftlockFixTwo) }
 	.patch_PierreSoftlockFixThree 0x2889D4 + _LD_OFF : { *(.patch_PierreSoftlockFixThree) }
 	.patch_KakarikoGateCheck 0x28A678 + _LD_OFF : { *(.patch_KakarikoGateCheck) }
+	BgMoriBigst_Update = 0x28C274 + _LD_OFF;
 	.patch_BombchuBowlingAlwaysFirstPrize 0x291924 + _LD_OFF : { *(.patch_BombchuBowlingAlwaysFirstPrize) }
 	ItemEtcetera_Update = 0x298D88 + _LD_OFF;
 	.patch_LostWoodsShootingGameTwo 0x2990E8 + _LD_OFF : { *(.patch_LostWoodsShootingGameTwo) }
@@ -817,6 +818,7 @@ SECTIONS
 	.patch_CriticalHealthCheckTwo 0x4716D4 + _LD_OFF : { *(.patch_CriticalHealthCheckTwo) }
 	.patch_EnableFW 0x476D1C + _LD_OFF : { *(.patch_EnableFW) }
 	.patch_OcarinaNoteSound_Npc 0x477C08 + _LD_OFF : { *(.patch_OcarinaNoteSound_Npc) }
+	DynaPoly_UpdateContext = 0x477E24 + _LD_OFF;
 	Quake_Update = 0x4787C8 + _LD_OFF;
 	TitleCard_Update = 0x47953C + _LD_OFF;
 	.patch_StoreTargetActorType 0x479984 + _LD_OFF : { *(.patch_StoreTargetActorType) }

--- a/code/src/actor.c
+++ b/code/src/actor.c
@@ -88,6 +88,7 @@
 #include "obj_mure3.h"
 #include "armos.h"
 #include "poe_collector.h"
+#include "forest_temple_objects.h"
 
 Actor* gRunningActor;
 #define MAX_RUNNING_ACTORS 5
@@ -194,6 +195,8 @@ void Actor_Init() {
     gActorOverlayTable[0x6B].initInfo->instanceSize = sizeof(EnYukabyun);
 
     gActorOverlayTable[0x85].initInfo->update = EnTk_rUpdate;
+
+    gActorOverlayTable[0x86].initInfo->update = BgMoriBigst_rUpdate;
 
     gActorOverlayTable[0x8B].initInfo->init    = DemoEffect_rInit;
     gActorOverlayTable[0x8B].initInfo->destroy = DemoEffect_rDestroy;
@@ -581,8 +584,14 @@ void Actor_rUpdate(Actor* actor, GlobalContext* globalCtx) {
         globalCtx->actorCtx.hammerQuakeFlag = 0;
     }
 
+    Bool updatedForestStalfosFight = ForestStalfosFight_BeforeActorUpdate(actor);
+
     actor->update(actor, globalCtx);
     HyperActors_Main(actor, globalCtx);
+
+    if (updatedForestStalfosFight) {
+        ForestStalfosFight_AfterActorUpdate(actor);
+    }
 
     if (tempHammerQuakeFlag != 0) {
         globalCtx->actorCtx.hammerQuakeFlag = tempHammerQuakeFlag;

--- a/code/src/actors/forest_temple_objects.c
+++ b/code/src/actors/forest_temple_objects.c
@@ -1,0 +1,120 @@
+#include "forest_temple_objects.h"
+#include "settings.h"
+#include "enemizer.h"
+
+/*-------------------------------
+|          BgMoriBigst          |
+-------------------------------*/
+
+// The 3 Stalfos are represented by entries 0xFD, 0xFE, 0xFF
+#define DYNAMIC_ENTRY(x) (0xFD + x)
+
+static s32 sRealClearFlags;
+
+static void ForestStalfosFight_ReplaceSpawnedEnemy(BgMoriBigst* this, Actor* stalfos, s32 stalfosIdx);
+static void ForestStalfosFight_OverrideDynapoly(void);
+
+void BgMoriBigst_Update(Actor* thisx, GlobalContext* globalCtx);
+
+void BgMoriBigst_rUpdate(Actor* thisx, GlobalContext* globalCtx) {
+    BgMoriBigst* this     = (BgMoriBigst*)thisx;
+    Actor* prevFirstEnemy = globalCtx->actorCtx.actorList[ACTORTYPE_ENEMY].first;
+
+    BgMoriBigst_Update(thisx, globalCtx);
+
+    Actor* curFirstEnemy = globalCtx->actorCtx.actorList[ACTORTYPE_ENEMY].first;
+
+    if (gSettingsContext.enemizer) {
+        if (curFirstEnemy != prevFirstEnemy) {
+            if (this->activeStalfosCount == 1) {
+                // spawned first stalfos
+                ForestStalfosFight_OverrideDynapoly();
+                ForestStalfosFight_ReplaceSpawnedEnemy(this, curFirstEnemy, 0);
+            } else if (this->activeStalfosCount == 2) {
+                // spawned stalfos pair
+                ForestStalfosFight_ReplaceSpawnedEnemy(this, curFirstEnemy->next, 1);
+                ForestStalfosFight_ReplaceSpawnedEnemy(this, curFirstEnemy, 2);
+            }
+        }
+
+        // Advance phase when there are no more enemies left
+        if (gGlobalContext->actorCtx.actorList[ACTORTYPE_ENEMY].first == NULL) {
+            this->activeStalfosCount = 0;
+        }
+    }
+}
+
+Bool ForestStalfosFight_BeforeActorUpdate(Actor* actor) {
+    if ( // is fighting randomized upper Stalfos in Forest Temple...
+        gSettingsContext.enemizer && gGlobalContext->sceneNum == SCENE_FOREST_TEMPLE && gGlobalContext->roomNum == 6 &&
+        gSaveContext.respawn[RESPAWN_MODE_DOWN].pos.y > 700.0f &&
+        // ...and this actor is for an enemy.
+        (actor->type == ACTORTYPE_ENEMY || actor->id == ACTOR_ANUBIS_SPAWNER || actor->id == ACTOR_HINT_DEKU_SCRUB)) {
+
+        // Prevent randomized enemies from falling down the hole.
+        ForestStalfosFight_OverrideDynapoly();
+        // Override clear flag to allow spawning enemies (e.g. Biri from Bari).
+        sRealClearFlags                      = gGlobalContext->actorCtx.flags.clear;
+        gGlobalContext->actorCtx.flags.clear = 0;
+        return TRUE;
+    }
+    return FALSE;
+}
+
+void ForestStalfosFight_AfterActorUpdate(Actor* actor) {
+    // Restore dynapoly.
+    DynaPoly_UpdateContext(gGlobalContext, &gGlobalContext->colCtx.dyna);
+    // Restore clear flag.
+    gGlobalContext->actorCtx.flags.clear = sRealClearFlags;
+}
+
+static void ForestStalfosFight_ReplaceSpawnedEnemy(BgMoriBigst* this, Actor* stalfos, s32 stalfosIdx) {
+    EnemyOverride enemyOverride = Enemizer_FindOverride(SCENE_FOREST_TEMPLE, 0, 6, DYNAMIC_ENTRY(stalfosIdx));
+
+    if (enemyOverride.enemyId != ENEMY_INVALID) {
+        // Remove spawned stalfos to replace it.
+        Actor_Kill(stalfos);
+
+        ActorEntry tempActorEntry = {
+            .id = gEnemyTable[enemyOverride.enemyId].actorId,
+            .pos = {
+                .x = stalfos->world.pos.x,
+                .y = stalfos->world.pos.y,
+                .z = stalfos->world.pos.z,
+            },
+            .rot = {
+                .x = 0,
+                .y = stalfos->yawTowardsPlayer,
+                .z = 0,
+            },
+            .params = gEnemyTable[enemyOverride.enemyId].possibleParams[enemyOverride.paramsIdx],
+        };
+
+        // Apply position updates depending on the specific enemy.
+        Enemizer_MoveSpecificEnemies(&tempActorEntry);
+
+        // Override clear flag to spawn enemy.
+        s32 realClearFlags                   = gGlobalContext->actorCtx.flags.clear;
+        gGlobalContext->actorCtx.flags.clear = 0;
+        Actor_Spawn(&gGlobalContext->actorCtx, gGlobalContext, tempActorEntry.id, tempActorEntry.pos.x,
+                    tempActorEntry.pos.y, tempActorEntry.pos.z, tempActorEntry.rot.x, tempActorEntry.rot.y,
+                    tempActorEntry.rot.z, tempActorEntry.params, TRUE);
+        gGlobalContext->actorCtx.flags.clear = realClearFlags;
+    }
+}
+
+// Override dynapoly to cover the central hole in the floor, so randomized enemies won't fall down.
+static void ForestStalfosFight_OverrideDynapoly(void) {
+    BgMoriBigst* this = (BgMoriBigst*)Actor_Find(&gGlobalContext->actorCtx, ACTOR_FOREST_BIG_STONE, ACTORTYPE_BG);
+    if (this == NULL || this->dyna.actor.world.pos.y < 900) {
+        // Do nothing if the platform is already lowered.
+        return;
+    }
+    DynaCollisionContext* dynaCtx = &gGlobalContext->colCtx.dyna;
+    s32 bgId                      = this->dyna.bgId;
+    f32 realPosY                  = this->dyna.actor.world.pos.y;
+    this->dyna.actor.world.pos.y  = this->dyna.actor.home.pos.y;
+    DynaPoly_UpdateContext(gGlobalContext, &gGlobalContext->colCtx.dyna);
+    dynaCtx->bgActors[bgId].prevTransform = dynaCtx->bgActors[bgId].curTransform;
+    this->dyna.actor.world.pos.y          = realPosY;
+}

--- a/code/src/actors/forest_temple_objects.h
+++ b/code/src/actors/forest_temple_objects.h
@@ -1,0 +1,26 @@
+#ifndef _FOREST_TEMPLE_OBJECTS_H_
+#define _FOREST_TEMPLE_OBJECTS_H_
+
+#include "z3D/z3D.h"
+
+struct BgMoriBigst;
+
+typedef void (*BgMoriBigstActionFunc)(struct BgMoriBigst*, GlobalContext*);
+
+typedef struct BgMoriBigst {
+    /* 0x0000 */ DynaPolyActor dyna;
+    /* 0x01BC */ BgMoriBigstActionFunc actionFunc;
+    /* 0x01C0 */ s16 waitTimer;
+    /* 0x01C2 */ s8 moriTexObjectSlot;
+    /* 0x01C4 */ SkeletonAnimationModel* saModel;
+} BgMoriBigst;
+_Static_assert(sizeof(BgMoriBigst) == 0x1C8, "BgMoriBigst size");
+
+#define activeStalfosCount dyna.actor.home.rot.z
+
+void BgMoriBigst_rUpdate(Actor* thisx, GlobalContext* globalCtx);
+
+Bool ForestStalfosFight_BeforeActorUpdate(Actor* actor);
+void ForestStalfosFight_AfterActorUpdate(Actor* actor);
+
+#endif //_FOREST_TEMPLE_OBJECTS_H_

--- a/code/src/actors/stalfos.c
+++ b/code/src/actors/stalfos.c
@@ -6,9 +6,16 @@
 void EnTest_Update(Actor* thisx, GlobalContext* globalCtx);
 
 void EnTest_rUpdate(Actor* thisx, GlobalContext* globalCtx) {
+    const Bool isRandomized = Enemizer_IsEnemyRandomized(ENEMY_STALFOS);
+    if (isRandomized && thisx->params == 0x0003 && thisx->floorPoly == PLAYER->actor.floorPoly) {
+        // For Stalfos that drop from above when approached, bypass the y distance check if the player
+        // is standing on the floor below the enemy.
+        thisx->yDistToPlayer = 0;
+    }
+
     EnTest_Update(thisx, globalCtx);
 
-    if (Enemizer_IsEnemyRandomized(ENEMY_STALFOS)) {
+    if (isRandomized) {
         // Change wallCheckHeight from 75 to 50.
         // This fixes the Stalfos falling out of bounds in the DC miniboss room.
         Actor_UpdateBgCheckInfo(globalCtx, thisx, 50.0f, 30.0f, 30.0f,

--- a/code/src/camera.c
+++ b/code/src/camera.c
@@ -137,8 +137,7 @@ void Camera_UpdateDistortion(Camera* camera) {
 
 s32 Camera_UpdateHotRoom(Camera* camera) {
     camera->distortionFlags &= 0xFFFE;
-    // Parts of RoomContext, bool value seems new to 3D
-    if (camera->globalCtx->unk_4C31[1] == 3 || camera->globalCtx->unk_4C31[6]) {
+    if (camera->globalCtx->roomCtx.curRoom.environmentType == 3 || camera->globalCtx->roomCtx.curRoom.visuallyHot) {
         camera->distortionFlags |= 1;
     }
     return 1;

--- a/code/src/enemizer.c
+++ b/code/src/enemizer.c
@@ -15,6 +15,8 @@
 #define SKIP_ACTOR_ENTRY TRUE
 #define KEEP_ACTOR_ENTRY FALSE
 
+#define MAX_DYNAMIC_ENEMIES_PER_ROOM 3 // Forest Temple Stalfos
+
 EnemyOverride rEnemyOverrides[ENEMY_OVERRIDES_MAX];
 s32 rEnemyOverrides_Count  = 0;
 static u8 sRoomLoadSignal  = FALSE;
@@ -26,8 +28,6 @@ EnemizerLocationFlags gEnemizerLocationFlags;
     [_enemyId] = { .name = _name, .actorId = _actorId, .possibleParams = _possibleParams },
 EnemyData gEnemyTable[ENEMY_MAX] = { ENEMY_TABLE };
 #undef X
-
-static EnemyOverride Enemizer_FindOverride(u8 scene, u8 layer, u8 room, u8 actorEntry);
 
 u8 Enemizer_IsEnemyRandomized(EnemyId enemyId) {
     return gSettingsContext.enemizer == ON && gSettingsContext.enemizerList[enemyId] == ENEMYMODE_RANDOMIZED;
@@ -54,7 +54,7 @@ void Enemizer_Init(void) {
             .enemyId != ENEMY_INVALID;
 }
 
-static EnemyOverride Enemizer_FindOverride(u8 scene, u8 layer, u8 room, u8 actorEntry) {
+s32 Enemizer_FindOverrideIndex(u8 scene, u8 layer, u8 room, u8 actorEntry) {
     s32 key   = (scene << 24) | (layer << 16) | (room << 8) | actorEntry;
     s32 start = 0;
     s32 end   = rEnemyOverrides_Count - 1;
@@ -66,8 +66,16 @@ static EnemyOverride Enemizer_FindOverride(u8 scene, u8 layer, u8 room, u8 actor
         } else if (key > midOvr.key) {
             start = midIdx + 1;
         } else {
-            return midOvr;
+            return midIdx;
         }
+    }
+    return -1;
+}
+
+EnemyOverride Enemizer_FindOverride(u8 scene, u8 layer, u8 room, u8 actorEntry) {
+    s32 idx = Enemizer_FindOverrideIndex(scene, layer, room, actorEntry);
+    if (idx >= 0) {
+        return rEnemyOverrides[idx];
     }
     return (EnemyOverride){ 0 };
 }
@@ -540,11 +548,16 @@ void Enemizer_AfterActorSetup(void) {
         return;
     }
 
-    EnemyOverride enemySpawnerOvr = Enemizer_GetSpawnerOverride();
-    if (enemySpawnerOvr.enemyId != ENEMY_INVALID) {
-        s16 actorId = gEnemyTable[enemySpawnerOvr.enemyId].actorId;
-        s16 params  = gEnemyTable[enemySpawnerOvr.enemyId].possibleParams[enemySpawnerOvr.paramsIdx];
+    s32 spawnerOverrideIdx =
+        Enemizer_FindOverrideIndex(gGlobalContext->sceneNum, rSceneLayer, gGlobalContext->roomNum, 0xFF);
+    while (spawnerOverrideIdx >= 0 &&
+           rEnemyOverrides[spawnerOverrideIdx].actorEntry >= 0x100 - MAX_DYNAMIC_ENEMIES_PER_ROOM) {
+        u8 enemyId   = rEnemyOverrides[spawnerOverrideIdx].enemyId;
+        u8 paramsIdx = rEnemyOverrides[spawnerOverrideIdx].paramsIdx;
+        s16 actorId  = gEnemyTable[enemyId].actorId;
+        s16 params   = gEnemyTable[enemyId].possibleParams[paramsIdx];
         Enemizer_SpawnObjectsForActor(actorId, params);
+        spawnerOverrideIdx--;
     }
 
     sSFMWolfos       = NULL;

--- a/code/src/enemizer.h
+++ b/code/src/enemizer.h
@@ -29,6 +29,8 @@ extern EnemizerLocationFlags gEnemizerLocationFlags;
 u8 Enemizer_IsEnemyRandomized(EnemyId enemyId);
 void Enemizer_Init(void);
 void Enemizer_Update(void);
+s32 Enemizer_FindOverrideIndex(u8 scene, u8 layer, u8 room, u8 actorEntry);
+EnemyOverride Enemizer_FindOverride(u8 scene, u8 layer, u8 room, u8 actorEntry);
 u8 Enemizer_OverrideActorEntry(ActorEntry* entry, s32 actorEntryIndex);
 void Enemizer_AfterActorSetup(void);
 EnemyOverride Enemizer_GetSpawnerOverride(void);

--- a/shared/s_actor_id.h
+++ b/shared/s_actor_id.h
@@ -37,6 +37,7 @@ enum ActorId {
     ACTOR_PG_HORSE           = 0x067,
     ACTOR_BUBBLE             = 0x069,
     ACTOR_FLYING_FLOOR_TILE  = 0x06B,
+    ACTOR_FOREST_BIG_STONE   = 0x086,
     ACTOR_BEAMOS             = 0x08A,
     ACTOR_DEMO_EFFECT        = 0x08B,
     ACTOR_FLOORMASTER        = 0x08E,

--- a/source/enemizer_list.cpp
+++ b/source/enemizer_list.cpp
@@ -367,6 +367,9 @@ void InitEnemyLocations(void) {
         enemyLocations[3][0][5][4]       = EnemyLocation(ENEMY_SKULLTULA,          LocType::ABOVE_GROUND);
         enemyLocations[3][0][6][0]       = EnemyLocation(ENEMY_STALFOS,            LocType::ABOVE_GROUND);
         enemyLocations[3][0][6][1]       = EnemyLocation(ENEMY_STALFOS,            LocType::ABOVE_GROUND);
+        enemyLocations[3][0][6][0xFD]    = EnemyLocation(ENEMY_STALFOS,            LocType::ABOVE_GROUND);
+        enemyLocations[3][0][6][0xFE]    = EnemyLocation(ENEMY_STALFOS,            LocType::ABOVE_GROUND);
+        enemyLocations[3][0][6][0xFF]    = EnemyLocation(ENEMY_STALFOS,            LocType::ABOVE_GROUND);
         enemyLocations[3][0][7][2]       = EnemyLocation(ENEMY_OCTOROK,            LocType::ABOVE_WATER);
         enemyLocations[3][0][7][3]       = EnemyLocation(ENEMY_SKULLWALLTULA,      LocType::ABOVE_GROUND);
         enemyLocations[3][0][7][4]       = EnemyLocation(ENEMY_DEKU_BABA_SMALL,    LocType::ABOVE_GROUND);

--- a/source/location_access/locacc_forest_temple.cpp
+++ b/source/location_access/locacc_forest_temple.cpp
@@ -429,7 +429,8 @@ void AreaTable_Init_ForestTemple() {
                  {
                      // Locations
                      LocationAccess(FOREST_TEMPLE_BOW_CHEST, { [] {
-                                        return CanDefeatEnemy(ENEMY_STALFOS) && Here(FOREST_TEMPLE_LOWER_STALFOS, [] {
+                                        return CanDefeatEnemies(3, 0, 6, { 0xFD, 0xFE, 0xFF }) &&
+                                               Here(FOREST_TEMPLE_LOWER_STALFOS, [] {
                                                    return CanDefeatEnemies(3, 0, 6, { 0, 1 });
                                                });
                                     } }),
@@ -437,13 +438,15 @@ void AreaTable_Init_ForestTemple() {
                  {
                      // Exits
                      Entrance(FOREST_TEMPLE_RED_POE_ROOM, { [] {
-                                  return CanDefeatEnemy(ENEMY_STALFOS) && Here(FOREST_TEMPLE_LOWER_STALFOS, [] {
+                                  return CanDefeatEnemies(3, 0, 6, { 0xFD, 0xFE, 0xFF }) &&
+                                         Here(FOREST_TEMPLE_LOWER_STALFOS, [] {
                                              return CanDefeatEnemies(3, 0, 6, { 0, 1 });
                                          });
                                   ;
                               } }),
                      Entrance(FOREST_TEMPLE_BLUE_POE_ROOM, { [] {
-                                  return CanDefeatEnemy(ENEMY_STALFOS) && Here(FOREST_TEMPLE_LOWER_STALFOS, [] {
+                                  return CanDefeatEnemies(3, 0, 6, { 0xFD, 0xFE, 0xFF }) &&
+                                         Here(FOREST_TEMPLE_LOWER_STALFOS, [] {
                                              return CanDefeatEnemies(3, 0, 6, { 0, 1 });
                                          });
                                   ;


### PR DESCRIPTION
This adds the 3 Stalfos guarding the Bow chest to the randomized enemy locations.
The main reason they weren't previously included is that the first Stalfos can walk in mid-air on the central hole. Now I solved this issue by moving the dynapoly for the platform when enemy update functions are called, so they will act like the floor is already covering the hole.

I've also included a fix for a bug that prevented some Stalfos from properly appearing in the falling ceiling room.